### PR TITLE
core: Add list arg support in format lib

### DIFF
--- a/libs/core/src/format.c
+++ b/libs/core/src/format.c
@@ -142,6 +142,16 @@ void format_write_arg(DynString* str, const FormatArg* arg) {
   case FormatArgType_End:
   case FormatArgType_Nop:
     break;
+  case FormatArgType_List:
+    dynstring_append(str, ((const FormatOptsList*)arg->settings)->prefix);
+    for (const FormatArg* child = arg->value_list; child->type != FormatArgType_End; ++child) {
+      if (child != arg->value_list) {
+        dynstring_append(str, ((const FormatOptsList*)arg->settings)->seperator);
+      }
+      format_write_arg(str, child);
+    }
+    dynstring_append(str, ((const FormatOptsList*)arg->settings)->suffix);
+    break;
   case FormatArgType_i64:
     format_write_i64(str, arg->value_i64, arg->settings);
     break;
@@ -154,28 +164,28 @@ void format_write_arg(DynString* str, const FormatArg* arg) {
   case FormatArgType_bool:
     format_write_bool(str, arg->value_bool);
     break;
-  case FormatArgType_bitset:
+  case FormatArgType_BitSet:
     format_write_bitset(str, arg->value_bitset);
     break;
-  case FormatArgType_mem:
+  case FormatArgType_Mem:
     format_write_mem(str, arg->value_mem);
     break;
-  case FormatArgType_duration:
+  case FormatArgType_Duration:
     format_write_time_duration_pretty(str, arg->value_duration);
     break;
-  case FormatArgType_time:
+  case FormatArgType_Time:
     format_write_time_iso8601(str, arg->value_time, arg->settings);
     break;
-  case FormatArgType_size:
+  case FormatArgType_Size:
     format_write_size_pretty(str, arg->value_size);
     break;
-  case FormatArgType_text:
+  case FormatArgType_Text:
     format_write_text(str, arg->value_text, arg->settings);
     break;
-  case FormatArgType_path:
+  case FormatArgType_Path:
     path_canonize(str, arg->value_path);
     break;
-  case FormatArgType_ttystyle:
+  case FormatArgType_TtyStyle:
     tty_write_style_sequence(str, arg->value_ttystyle);
     break;
   }

--- a/libs/core/test/test_format.c
+++ b/libs/core/test/test_format.c
@@ -165,6 +165,13 @@ void test_format() {
       string_lit("{ >4 }|{ >4}|{:4}|{:4}|"),
       fmt_args(fmt_int(1), fmt_int(20), fmt_int(1), fmt_int(42)),
       string_lit("   1|  20| 1  | 42 |"));
+  test_format_write_formatted(
+      string_lit("{}"),
+      fmt_args(fmt_list_lit(fmt_int(1), fmt_int(2), fmt_int(3))),
+      string_lit("1, 2, 3"));
+  test_format_write_formatted(string_lit("{}"), fmt_args(fmt_list_lit()), string_lit(""));
+  test_format_write_formatted(
+      string_lit("{}"), fmt_args(fmt_list_lit(fmt_int(1))), string_lit("1"));
 
   test_format_write_u64(0, format_opts_int(), string_lit("0"));
   test_format_write_u64(0, format_opts_int(.minDigits = 4), string_lit("0000"));


### PR DESCRIPTION
Add support for lists of arguments as a formatting argument.

Example:
```c
diag_print("Test: {}\n", fmt_list_lit(fmt_int(42), fmt_bool(true), fmt_text_lit("Hello")));
```
Output:
![image](https://user-images.githubusercontent.com/14230060/121943621-734b5680-cd5a-11eb-9c39-7be0a1499b8f.png)

Example:
```c
diag_print(
      "Test: {}\n",
      fmt_list(
          fmt_args(fmt_int(42), fmt_bool(true), fmt_text_lit("Hello")),
          .prefix    = string_lit("["),
          .suffix    = string_lit("]"),
          .seperator = string_lit(" ")));
```
Output:
![image](https://user-images.githubusercontent.com/14230060/121943710-865e2680-cd5a-11eb-9fef-5c9f18f73b6b.png)

Example:
```c
i32 dynamicSize = 6;

FormatArg integers[10] = {0};
for (i32 i = 0; i != dynamicSize; ++i) {
  integers[i] = fmt_int(i);
}
diag_print("SomeIntegers: {}\n", fmt_list(integers));
```
Output:
![image](https://user-images.githubusercontent.com/14230060/121943781-9aa22380-cd5a-11eb-9e5a-12aaf2e5020c.png)
