### PR TITLE
core: String glob match

### DIFF
--- a/libs/check/test/main.c
+++ b/libs/check/test/main.c
@@ -30,12 +30,12 @@ int main(const int argc, const char** argv) {
   CliApp* app =
       cli_app_create(g_alloc_heap, string_lit("Test harness for the volo check library."));
 
-  const CliId helpFlag = cli_register_flag(app, 'h', string_lit("help"), CliOptionFlags_None);
-  cli_register_desc(app, helpFlag, string_lit("Display this help page."));
-
   const CliId outputPassingTestsFlag =
       cli_register_flag(app, 'o', string_lit("output-passing"), CliOptionFlags_None);
   cli_register_desc(app, outputPassingTestsFlag, string_lit("Display passing tests."));
+
+  const CliId helpFlag = cli_register_flag(app, 'h', string_lit("help"), CliOptionFlags_None);
+  cli_register_desc(app, helpFlag, string_lit("Display this help page."));
 
   CliInvocation* invoc = cli_parse(app, argc - 1, argv + 1);
   if (cli_parse_result(invoc) == CliParseResult_Fail) {

--- a/libs/cli/include/cli_read.h
+++ b/libs/cli/include/cli_read.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "core_string.h"
 #include "core_types.h"
 
 // Forward declare from 'cli_parse.h'.
@@ -6,6 +7,12 @@ typedef struct sCliInvocation CliInvocation;
 
 // Forward declare from 'cli_app.h'.
 typedef u16 CliId;
+
+/**
+ * Read a string that was provided to the given option.
+ * If the option was not provided then 'defaultVal' is returned.
+ */
+String cli_read_string(CliInvocation*, CliId, String defaultVal);
 
 /**
  * Read a i64 integer that was provided to the given option.

--- a/libs/cli/src/read.c
+++ b/libs/cli/src/read.c
@@ -3,7 +3,12 @@
 #include "cli_parse.h"
 #include "cli_read.h"
 
-i64 cli_read_i64(CliInvocation* invoc, const CliId id, i64 defaultVal) {
+String cli_read_string(CliInvocation* invoc, const CliId id, const String defaultVal) {
+  CliParseValues values = cli_parse_values(invoc, id);
+  return values.count ? *values.head : defaultVal;
+}
+
+i64 cli_read_i64(CliInvocation* invoc, const CliId id, const i64 defaultVal) {
   CliParseValues values = cli_parse_values(invoc, id);
   if (!values.count) {
     return defaultVal;
@@ -14,7 +19,7 @@ i64 cli_read_i64(CliInvocation* invoc, const CliId id, i64 defaultVal) {
   return result;
 }
 
-u64 cli_read_u64(CliInvocation* invoc, const CliId id, u64 defaultVal) {
+u64 cli_read_u64(CliInvocation* invoc, const CliId id, const u64 defaultVal) {
   CliParseValues values = cli_parse_values(invoc, id);
   if (!values.count) {
     return defaultVal;
@@ -25,7 +30,7 @@ u64 cli_read_u64(CliInvocation* invoc, const CliId id, u64 defaultVal) {
   return result;
 }
 
-f64 cli_read_f64(CliInvocation* invoc, const CliId id, f64 defaultVal) {
+f64 cli_read_f64(CliInvocation* invoc, const CliId id, const f64 defaultVal) {
   CliParseValues values = cli_parse_values(invoc, id);
   if (!values.count) {
     return defaultVal;

--- a/libs/cli/test/main.c
+++ b/libs/cli/test/main.c
@@ -33,12 +33,12 @@ int main(const int argc, const char** argv) {
 
   CliApp* app = cli_app_create(g_alloc_heap, string_lit("Test harness for the volo cli library."));
 
-  const CliId helpFlag = cli_register_flag(app, 'h', string_lit("help"), CliOptionFlags_None);
-  cli_register_desc(app, helpFlag, string_lit("Display this help page."));
-
   const CliId outputPassingTestsFlag =
       cli_register_flag(app, 'o', string_lit("output-passing"), CliOptionFlags_None);
   cli_register_desc(app, outputPassingTestsFlag, string_lit("Display passing tests."));
+
+  const CliId helpFlag = cli_register_flag(app, 'h', string_lit("help"), CliOptionFlags_None);
+  cli_register_desc(app, helpFlag, string_lit("Display this help page."));
 
   CliInvocation* invoc = cli_parse(app, argc - 1, argv + 1);
   if (cli_parse_result(invoc) == CliParseResult_Fail) {

--- a/libs/cli/test/test_read.c
+++ b/libs/cli/test/test_read.c
@@ -6,6 +6,30 @@
 
 spec(read) {
 
+  it("returns the provided string") {
+    CliApp*     app  = cli_app_create(g_alloc_heap, string_lit("My test app"));
+    const CliId flag = cli_register_flag(app, 's', string_lit("string"), CliOptionFlags_Value);
+
+    CliInvocation* invoc = cli_parse(app, 2, (const char*[]){"-s", "Hello World"});
+
+    check_eq_string(cli_read_string(invoc, flag, string_lit("Backup")), string_lit("Hello World"));
+
+    cli_parse_destroy(invoc);
+    cli_app_destroy(app);
+  }
+
+  it("returns the default when not providing a string") {
+    CliApp*     app  = cli_app_create(g_alloc_heap, string_lit("My test app"));
+    const CliId flag = cli_register_flag(app, 's', string_lit("string"), CliOptionFlags_Value);
+
+    CliInvocation* invoc = cli_parse(app, 0, null);
+
+    check_eq_string(cli_read_string(invoc, flag, string_lit("Goodbye")), string_lit("Goodbye"));
+
+    cli_parse_destroy(invoc);
+    cli_app_destroy(app);
+  }
+
   it("returns the provided i64") {
     CliApp*     app  = cli_app_create(g_alloc_heap, string_lit("My test app"));
     const CliId flag = cli_register_flag(app, 'i', string_lit("int"), CliOptionFlags_Value);

--- a/libs/core/include/core_string.h
+++ b/libs/core/include/core_string.h
@@ -11,6 +11,11 @@ typedef struct sAllocator Allocator;
  */
 typedef Mem String;
 
+typedef enum {
+  StringMatchFlags_None       = 0,
+  StringMatchFlags_IgnoreCase = 1 << 0,
+} StringMatchFlags;
+
 /**
  * Create an empty (0 characters) string.
  */
@@ -128,3 +133,12 @@ usize string_find_last(String, String subStr);
  * Note: Returns 'sentinel_usize' if none of the characters could be found.
  */
 usize string_find_last_any(String, String chars);
+
+/**
+ * Match the given string to a glob pattern.
+ *
+ * Supported pattern syntax:
+ * '?' matches any single character.
+ * '*' matches any number of any characters including none.
+ */
+bool string_match_glob(String, String pattern, StringMatchFlags);

--- a/libs/core/src/string.c
+++ b/libs/core/src/string.c
@@ -1,3 +1,4 @@
+#include "core_ascii.h"
 #include "core_diag.h"
 #include "core_math.h"
 #include "core_sentinel.h"
@@ -72,4 +73,51 @@ usize string_find_last_any(String str, String chars) {
     }
   }
   return sentinel_usize;
+}
+
+bool string_match_glob(String str, String pattern, const StringMatchFlags flags) {
+  /**
+   * Basic glob matching algorithm.
+   * More information on the implementation: https://research.swtch.com/glob.
+   */
+  usize patternIdx     = 0;
+  usize strIdx         = 0;
+  usize nextPatternIdx = 0;
+  usize nextStrIdx     = 0;
+  while (patternIdx < pattern.size || strIdx < str.size) {
+    if (patternIdx < pattern.size) {
+      const u8 patternChar = *string_at(pattern, patternIdx);
+      switch (patternChar) {
+      case '?':
+        if (strIdx < str.size) {
+          ++patternIdx;
+          ++strIdx;
+          continue;
+        }
+        break;
+      case '*':
+        nextPatternIdx = patternIdx++;
+        nextStrIdx     = strIdx + 1;
+        continue;
+      default:
+        if (strIdx < str.size && flags & StringMatchFlags_IgnoreCase
+                ? ascii_to_lower(*string_at(str, strIdx)) == ascii_to_lower(patternChar)
+                : *string_at(str, strIdx) == patternChar) {
+          ++patternIdx;
+          ++strIdx;
+          continue;
+        }
+        break;
+      }
+    }
+    // End of pattern segment; resume the previous segment if any, otherwise fail.
+    if (nextStrIdx && nextStrIdx <= str.size) {
+      patternIdx = nextPatternIdx;
+      strIdx     = nextStrIdx;
+      continue;
+    }
+    return false;
+  }
+  // Entire pattern matched.
+  return true;
 }

--- a/libs/core/test/main.c
+++ b/libs/core/test/main.c
@@ -53,12 +53,12 @@ int main(const int argc, const char** argv) {
 
   CliApp* app = cli_app_create(g_alloc_heap, string_lit("Test harness for the volo core library."));
 
-  const CliId helpFlag = cli_register_flag(app, 'h', string_lit("help"), CliOptionFlags_None);
-  cli_register_desc(app, helpFlag, string_lit("Display this help page."));
-
   const CliId outputPassingTestsFlag =
       cli_register_flag(app, 'o', string_lit("output-passing"), CliOptionFlags_None);
   cli_register_desc(app, outputPassingTestsFlag, string_lit("Display passing tests."));
+
+  const CliId helpFlag = cli_register_flag(app, 'h', string_lit("help"), CliOptionFlags_None);
+  cli_register_desc(app, helpFlag, string_lit("Display this help page."));
 
   CliInvocation* invoc = cli_parse(app, argc - 1, argv + 1);
   if (cli_parse_result(invoc) == CliParseResult_Fail) {

--- a/libs/core/test/test_string.c
+++ b/libs/core/test/test_string.c
@@ -147,6 +147,48 @@ spec(string) {
     dynarray_destroy(&array);
   }
 
+  it("can match glob patterns") {
+    const StringMatchFlags f = StringMatchFlags_None;
+    check(string_match_glob(string_lit("hello"), string_lit("*"), f));
+    check(string_match_glob(string_lit("world"), string_lit("*world"), f));
+    check(string_match_glob(string_lit(" world"), string_lit("*world"), f));
+    check(string_match_glob(string_lit("helloworld"), string_lit("*world"), f));
+    check(string_match_glob(string_lit("helloworld"), string_lit("hello*world"), f));
+    check(string_match_glob(string_lit("hello world"), string_lit("hello*world"), f));
+    check(string_match_glob(string_lit("hellostuffworld"), string_lit("hello*world"), f));
+    check(string_match_glob(
+        string_lit("hellostuffworldsomemore"), string_lit("hello*world*more"), f));
+    check(string_match_glob(string_lit("hellostuffworldmore"), string_lit("hello*world*more"), f));
+    check(string_match_glob(string_lit("world"), string_lit("*world*"), f));
+    check(string_match_glob(string_lit("helloworldmore"), string_lit("*world*"), f));
+    check(string_match_glob(string_lit("world"), string_lit("**"), f));
+    check(string_match_glob(string_lit(""), string_lit("*"), f));
+    check(string_match_glob(string_lit(""), string_lit(""), f));
+    check(string_match_glob(string_lit("a"), string_lit("?"), f));
+    check(string_match_glob(string_lit(" "), string_lit("?"), f));
+    check(string_match_glob(string_lit("hello world"), string_lit("h??lo?w?rld"), f));
+    check(string_match_glob(string_lit("hello"), string_lit("hello"), f));
+
+    check(!string_match_glob(string_lit("hello"), string_lit("*world"), f));
+    check(!string_match_glob(string_lit("worldhello"), string_lit("*world"), f));
+    check(!string_match_glob(string_lit(""), string_lit("hello"), f));
+    check(!string_match_glob(string_lit("world"), string_lit("hello"), f));
+    check(!string_match_glob(string_lit("helloworld"), string_lit("hello"), f));
+    check(!string_match_glob(string_lit("worldhello"), string_lit("hello"), f));
+    check(!string_match_glob(string_lit("hello"), string_lit(""), f));
+    check(!string_match_glob(string_lit("hellostuffworl"), string_lit("hello*world"), f));
+    check(!string_match_glob(string_lit("hellstuffworl"), string_lit("hello*world"), f));
+    check(!string_match_glob(string_lit("hellostuffworld"), string_lit("hello*world*more"), f));
+    check(!string_match_glob(string_lit(""), string_lit("?"), f));
+    check(!string_match_glob(string_lit("ello world"), string_lit("h??lo?w?rld?"), f));
+    check(!string_match_glob(string_lit("helloworld"), string_lit("h??lo?w?rld?"), f));
+    check(!string_match_glob(string_lit("hello world"), string_lit("h??lo?w?rld?"), f));
+
+    check(string_match_glob(string_lit("HeLlO"), string_lit("hello"), StringMatchFlags_IgnoreCase));
+    check(
+        !string_match_glob(string_lit("HeLlOZ"), string_lit("hello"), StringMatchFlags_IgnoreCase));
+  }
+
   it("can be sorted") {
     Allocator* alloc = alloc_bump_create_stack(1024);
     DynArray   array = dynarray_create_t(alloc, String, 4);

--- a/libs/jobs/test/main.c
+++ b/libs/jobs/test/main.c
@@ -31,12 +31,12 @@ int main(const int argc, const char** argv) {
 
   CliApp* app = cli_app_create(g_alloc_heap, string_lit("Test harness for the volo jobs library."));
 
-  const CliId helpFlag = cli_register_flag(app, 'h', string_lit("help"), CliOptionFlags_None);
-  cli_register_desc(app, helpFlag, string_lit("Display this help page."));
-
   const CliId outputPassingTestsFlag =
       cli_register_flag(app, 'o', string_lit("output-passing"), CliOptionFlags_None);
   cli_register_desc(app, outputPassingTestsFlag, string_lit("Display passing tests."));
+
+  const CliId helpFlag = cli_register_flag(app, 'h', string_lit("help"), CliOptionFlags_None);
+  cli_register_desc(app, helpFlag, string_lit("Display this help page."));
 
   CliInvocation* invoc = cli_parse(app, argc - 1, argv + 1);
   if (cli_parse_result(invoc) == CliParseResult_Fail) {


### PR DESCRIPTION
Adds utility for matching strings against glob patterns:
```
String input = string_lit("helloworld");
String pattern = string_lit("*world");
bool match = string_match_glob(input, pattern, StringMatchFlags_IgnoreCase);
```