### PR TITLE
cmake: Add test targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ message(STATUS "* Generator: ${CMAKE_GENERATOR}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
+# Setup test target.
+include(cmake/test.cmake)
+configure_test_target()
+
 # Setup global platform specific defines.
 include(cmake/platform.cmake)
 detect_platform()

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -1,0 +1,26 @@
+# --------------------------------------------------------------------------------------------------
+# CMake test utilities.
+# --------------------------------------------------------------------------------------------------
+
+# Configure a 'test' target.
+# Any test that is registered using 'configure_test()' will be added as a dependency of this target.
+# This allows running all tests by invoking the 'test' target.
+#
+function(configure_test_target)
+  message(STATUS "Configuring test target")
+  add_custom_target(test)
+endfunction(configure_test_target)
+
+# Configure a 'test.[shortName]' target that will execute the given test executable when invoked.
+#
+function(configure_test target shortName)
+  message(STATUS "Configuring ${shortName} test")
+
+  set(testTargetName "test.${shortName}")
+  add_custom_target(${testTargetName} COMMAND ${target} VERBATIM USES_TERMINAL)
+  add_dependencies(${testTargetName} ${target})
+
+  if(TARGET test)
+    add_dependencies(test ${testTargetName})
+  endif()
+endfunction(configure_test)

--- a/libs/check/CMakeLists.txt
+++ b/libs/check/CMakeLists.txt
@@ -21,3 +21,5 @@ add_executable(volo_check_test
   test/test_fizzbuzz.c)
 target_link_libraries(volo_check_test PRIVATE volo_check)
 target_link_libraries(volo_check_test PRIVATE volo_cli)
+
+configure_test(volo_check_test check)

--- a/libs/cli/CMakeLists.txt
+++ b/libs/cli/CMakeLists.txt
@@ -24,3 +24,5 @@ add_executable(volo_cli_test
   test/test_validate.c)
 target_link_libraries(volo_cli_test PRIVATE volo_cli)
 target_link_libraries(volo_cli_test PRIVATE volo_check)
+
+configure_test(volo_cli_test cli)

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -79,3 +79,5 @@ add_executable(volo_core_test
 target_link_libraries(volo_core_test PRIVATE volo_check)
 target_link_libraries(volo_core_test PRIVATE volo_cli)
 target_link_libraries(volo_core_test PRIVATE volo_core)
+
+configure_test(volo_core_test core)

--- a/libs/jobs/CMakeLists.txt
+++ b/libs/jobs/CMakeLists.txt
@@ -24,3 +24,5 @@ add_executable(volo_jobs_test
 target_link_libraries(volo_jobs_test PRIVATE volo_check)
 target_link_libraries(volo_jobs_test PRIVATE volo_cli)
 target_link_libraries(volo_jobs_test PRIVATE volo_jobs)
+
+configure_test(volo_jobs_test jobs)


### PR DESCRIPTION
Add cmake targets to invoke the unit tests using your build-system.

List the registered test targets in ninja:
![image](https://user-images.githubusercontent.com/14230060/130665863-534eac13-8452-427a-846b-58053541a9db.png)

Execute all the tests in ninja:
![image](https://user-images.githubusercontent.com/14230060/130666013-676b7736-6d42-49ae-b3e2-ac35770cb656.png)

Execute a single test using make:
![image](https://user-images.githubusercontent.com/14230060/130666362-141058c4-a6c0-43a7-8d08-35e9a1820682.png)
