### PR TITLE
check: Add mocha json test-result output

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,7 +85,6 @@ jobs:
       if: success() || failure()
       with:
         name: archive-${{matrix.config.name}}
-        if-no-files-found: error
         path: |
           build/**/logs/*.log
           build/**/logs/*.mocha
@@ -95,5 +94,6 @@ jobs:
       if: success() || failure()
       with:
         name: test-results-${{matrix.config.name}}
+        fail-on-error: false
         path: build/**/logs/*.mocha
         reporter: mocha-json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,6 +94,6 @@ jobs:
       uses: dorny/test-reporter@v1
       if: success() || failure()
       with:
-        name: tests-${{matrix.config.name}}
+        name: test-results-${{matrix.config.name}}
         path: build/**/logs/*.mocha
         reporter: mocha-json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,11 +80,20 @@ jobs:
         cd build                            &&
         mingw32-make -k test
 
-    - name: archive-logs
+    - name: archive
       uses: actions/upload-artifact@v2
       if: success() || failure()
       with:
-        name: logs-${{matrix.config.name}}
-        path: build/**/logs/*.log
+        name: archive-${{matrix.config.name}}
         if-no-files-found: error
+        path: |
+          build/**/logs/*.log
+          build/**/logs/*.mocha
 
+    - name: report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        name: tests-${{matrix.config.name}}
+        path: build/**/logs/*.mocha
+        reporter: mocha-json

--- a/libs/check/CMakeLists.txt
+++ b/libs/check/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(volo_check STATIC
   src/def.c
   src/output.c
   src/output_log.c
+  src/output_mocha.c
   src/output_pretty.c
   src/result.c
   src/runner.c
@@ -16,6 +17,7 @@ target_include_directories(volo_check PUBLIC include)
 target_link_libraries(volo_check PUBLIC volo_core)
 target_link_libraries(volo_check PUBLIC volo_jobs)
 target_link_libraries(volo_check PUBLIC volo_log)
+target_link_libraries(volo_check PUBLIC volo_json)
 
 add_executable(volo_check_test
   test/main.c

--- a/libs/check/src/output.h
+++ b/libs/check/src/output.h
@@ -8,8 +8,9 @@ typedef struct sCheckOutput CheckOutput;
 struct sCheckOutput {
   void (*runStarted)(CheckOutput*);
 
-  void (*testsDiscovered)(CheckOutput*, usize count, TimeDuration);
+  void (*testsDiscovered)(CheckOutput*, usize specCount, usize testCount, TimeDuration);
 
+  // NOTE: Will be called in parallel.
   void (*testFinished)(
       CheckOutput*, const CheckSpec*, const CheckTest*, CheckResultType, CheckResult*);
 

--- a/libs/check/src/output.h
+++ b/libs/check/src/output.h
@@ -10,6 +10,8 @@ struct sCheckOutput {
 
   void (*testsDiscovered)(CheckOutput*, usize specCount, usize testCount, TimeDuration);
 
+  void (*testSkipped)(CheckOutput*, const CheckSpec*, const CheckTest*);
+
   // NOTE: Will be called in parallel.
   void (*testFinished)(
       CheckOutput*, const CheckSpec*, const CheckTest*, CheckResultType, CheckResult*);

--- a/libs/check/src/output_log.c
+++ b/libs/check/src/output_log.c
@@ -24,13 +24,15 @@ static void output_run_started(CheckOutput* out) {
       log_param("executable", fmt_path(g_path_executable)));
 }
 
-static void output_tests_discovered(CheckOutput* out, const usize count, const TimeDuration dur) {
+static void output_tests_discovered(
+    CheckOutput* out, const usize specCount, const usize testCount, const TimeDuration dur) {
   CheckOutputLog* logOut = (CheckOutputLog*)out;
 
   log(logOut->logger,
       LogLevel_Debug,
       "Test discovery complete",
-      log_param("count", fmt_int(count)),
+      log_param("spec-count", fmt_int(specCount)),
+      log_param("test-count", fmt_int(testCount)),
       log_param("duration", fmt_duration(dur)));
 }
 

--- a/libs/check/src/output_log.c
+++ b/libs/check/src/output_log.c
@@ -36,6 +36,16 @@ static void output_tests_discovered(
       log_param("duration", fmt_duration(dur)));
 }
 
+static void output_test_skipped(CheckOutput* out, const CheckSpec* spec, const CheckTest* test) {
+  CheckOutputLog* logOut = (CheckOutputLog*)out;
+
+  log(logOut->logger,
+      LogLevel_Info,
+      "Test skipped",
+      log_param("spec", fmt_text(spec->def->name)),
+      log_param("test", fmt_text(test->description)));
+}
+
 static void output_test_finished(
     CheckOutput*          out,
     const CheckSpec*      spec,
@@ -95,6 +105,7 @@ CheckOutput* check_output_log(Allocator* alloc, Logger* logger) {
           {
               .runStarted      = output_run_started,
               .testsDiscovered = output_tests_discovered,
+              .testSkipped     = output_test_skipped,
               .testFinished    = output_test_finished,
               .runFinished     = output_run_finished,
               .destroy         = output_destroy,

--- a/libs/check/src/output_log.c
+++ b/libs/check/src/output_log.c
@@ -86,7 +86,7 @@ static void output_destroy(CheckOutput* out) {
   alloc_free_t(logOut->alloc, logOut);
 }
 
-CheckOutput* check_output_log_create(Allocator* alloc, Logger* logger) {
+CheckOutput* check_output_log(Allocator* alloc, Logger* logger) {
   CheckOutputLog* logOut = alloc_alloc_t(alloc, CheckOutputLog);
   *logOut                = (CheckOutputLog){
       .api =

--- a/libs/check/src/output_log.h
+++ b/libs/check/src/output_log.h
@@ -6,4 +6,4 @@
  * Create a CheckOutput that writes log messages to the given logger.
  * Destroy using 'check_output_destroy()'.
  */
-CheckOutput* check_output_log_create(Allocator*, Logger*);
+CheckOutput* check_output_log(Allocator*, Logger*);

--- a/libs/check/src/output_mocha.c
+++ b/libs/check/src/output_mocha.c
@@ -90,7 +90,7 @@ static void output_test_skipped(CheckOutput* out, const CheckSpec* spec, const C
   const JsonVal testObj = mocha_add_test_obj(doc, spec, test);
   json_add_elem(doc, mochaOut->pendingArr, testObj);
 
-  // Note: Add an empty 'err' object as a few consumers depend on this existing.
+  // Note: Add an empty 'err' object as some consumers depend on this existing.
   const JsonVal errObj = json_add_object(doc);
   json_add_field_str(doc, testObj, string_lit("err"), errObj);
 }

--- a/libs/check/src/output_mocha.c
+++ b/libs/check/src/output_mocha.c
@@ -78,9 +78,14 @@ static void output_tests_discovered(
 
 static void output_test_skipped(CheckOutput* out, const CheckSpec* spec, const CheckTest* test) {
   CheckOutputMocha* mochaOut = (CheckOutputMocha*)out;
+  JsonDoc*          doc      = mochaOut->doc;
 
-  const JsonVal testObj = mocha_add_test_obj(mochaOut->doc, spec, test);
-  json_add_elem(mochaOut->doc, mochaOut->pendingArr, testObj);
+  const JsonVal testObj = mocha_add_test_obj(doc, spec, test);
+  json_add_elem(doc, mochaOut->pendingArr, testObj);
+
+  // Note: Add an empty 'err' object as a few consumers depend on this existing.
+  const JsonVal errObj = json_add_object(doc);
+  json_add_field_str(doc, testObj, string_lit("err"), errObj);
 }
 
 static void output_test_finished(

--- a/libs/check/src/output_mocha.c
+++ b/libs/check/src/output_mocha.c
@@ -1,0 +1,208 @@
+#include "core_diag.h"
+#include "core_format.h"
+#include "core_path.h"
+#include "core_thread.h"
+#include "core_time.h"
+
+#include "json.h"
+
+#include "output_mocha.h"
+
+typedef struct {
+  CheckOutput api;
+  Allocator*  alloc;
+  ThreadMutex mutex;
+  JsonDoc*    doc;
+  JsonVal     rootObj;
+  JsonVal     statsObj;
+  JsonVal     passesArr;
+  JsonVal     failuresArr;
+  File*       file;
+} CheckOutputMocha;
+
+static void mocha_write_json(JsonDoc* doc, JsonVal rootObj, File* file) {
+  DynString dynString = dynstring_create(g_alloc_heap, 64 * usize_kibibyte);
+
+  json_write(&dynString, doc, rootObj, &json_write_opts());
+
+  const FileResult writeRes = file_write_sync(file, dynstring_view(&dynString));
+  if (writeRes != FileResult_Success) {
+    diag_crash_msg(
+        "Failed to write mocha test-results to file: {}", fmt_text(file_result_str(writeRes)));
+  }
+
+  dynstring_destroy(&dynString);
+}
+
+static void output_run_started(CheckOutput* out) {
+  CheckOutputMocha* mochaOut = (CheckOutputMocha*)out;
+  JsonDoc*          doc      = mochaOut->doc;
+
+  const TimeReal startTime = time_real_clock();
+  json_add_field_str(
+      doc,
+      mochaOut->statsObj,
+      string_lit("start"),
+      json_add_string(doc, format_write_arg_scratch(&fmt_time(startTime))));
+}
+
+static void output_tests_discovered(
+    CheckOutput* out, const usize specCount, const usize testCount, const TimeDuration dur) {
+  CheckOutputMocha* mochaOut = (CheckOutputMocha*)out;
+  JsonDoc*          doc      = mochaOut->doc;
+
+  (void)dur;
+
+  json_add_field_str(
+      doc, mochaOut->statsObj, string_lit("suites"), json_add_number(doc, specCount));
+
+  json_add_field_str(doc, mochaOut->statsObj, string_lit("tests"), json_add_number(doc, testCount));
+}
+
+static void output_test_finished(
+    CheckOutput*          out,
+    const CheckSpec*      spec,
+    const CheckTest*      test,
+    const CheckResultType type,
+    CheckResult*          result) {
+  CheckOutputMocha* mochaOut = (CheckOutputMocha*)out;
+  JsonDoc*          doc      = mochaOut->doc;
+
+  thread_mutex_lock(mochaOut->mutex);
+
+  const JsonVal testObj = json_add_object(doc);
+  json_add_field_str(doc, testObj, string_lit("title"), json_add_string(doc, test->description));
+
+  json_add_field_str(
+      doc,
+      testObj,
+      string_lit("fullTitle"),
+      json_add_string(
+          doc, fmt_write_scratch("{} {}", fmt_text(spec->def->name), fmt_text(test->description))));
+
+  json_add_field_str(doc, testObj, string_lit("file"), json_add_string(doc, test->source.file));
+
+  json_add_field_str(
+      doc,
+      testObj,
+      string_lit("duration"),
+      json_add_number(doc, result->duration / (f64)time_millisecond));
+
+  if (result->errors.size) {
+    const CheckError* err = dynarray_at_t(&result->errors, 0, CheckError);
+
+    const JsonVal errObj = json_add_object(doc);
+    json_add_field_str(doc, errObj, string_lit("message"), json_add_string(doc, err->msg));
+    json_add_field_str(doc, testObj, string_lit("err"), errObj);
+  }
+
+  switch (type) {
+  case CheckResultType_Pass:
+    json_add_elem(mochaOut->doc, mochaOut->passesArr, testObj);
+    break;
+  case CheckResultType_Fail:
+    json_add_elem(mochaOut->doc, mochaOut->failuresArr, testObj);
+    break;
+  }
+
+  thread_mutex_unlock(mochaOut->mutex);
+}
+
+static void output_run_finished(
+    CheckOutput*          out,
+    const CheckResultType type,
+    const TimeDuration    dur,
+    const usize           numPassed,
+    const usize           numFailed,
+    const usize           numSkipped) {
+  CheckOutputMocha* mochaOut = (CheckOutputMocha*)out;
+  JsonDoc*          doc      = mochaOut->doc;
+
+  (void)type;
+  (void)numSkipped;
+
+  json_add_field_str(
+      doc, mochaOut->statsObj, string_lit("passes"), json_add_number(doc, numPassed));
+
+  json_add_field_str(
+      doc, mochaOut->statsObj, string_lit("failures"), json_add_number(doc, numFailed));
+
+  const TimeReal endTime = time_real_clock();
+  json_add_field_str(
+      doc,
+      mochaOut->statsObj,
+      string_lit("end"),
+      json_add_string(doc, format_write_arg_scratch(&fmt_time(endTime))));
+
+  json_add_field_str(
+      doc,
+      mochaOut->statsObj,
+      string_lit("duration"),
+      json_add_number(doc, dur / (f64)time_millisecond));
+}
+
+static void output_destroy(CheckOutput* out) {
+  CheckOutputMocha* mochaOut = (CheckOutputMocha*)out;
+
+  mocha_write_json(mochaOut->doc, mochaOut->rootObj, mochaOut->file);
+
+  thread_mutex_destroy(mochaOut->mutex);
+  file_destroy(mochaOut->file);
+  json_destroy(mochaOut->doc);
+
+  alloc_free_t(mochaOut->alloc, mochaOut);
+}
+
+CheckOutput* check_output_mocha(Allocator* alloc, File* file) {
+  JsonDoc*      doc         = json_create(alloc, 512);
+  const JsonVal rootObj     = json_add_object(doc);
+  const JsonVal statsObj    = json_add_object(doc);
+  const JsonVal passesArr   = json_add_array(doc);
+  const JsonVal failuresArr = json_add_array(doc);
+
+  json_add_field_str(doc, rootObj, string_lit("stats"), statsObj);
+  json_add_field_str(doc, rootObj, string_lit("passes"), passesArr);
+  json_add_field_str(doc, rootObj, string_lit("failures"), failuresArr);
+
+  CheckOutputMocha* mochaOut = alloc_alloc_t(alloc, CheckOutputMocha);
+  *mochaOut                  = (CheckOutputMocha){
+      .api =
+          {
+              .runStarted      = output_run_started,
+              .testsDiscovered = output_tests_discovered,
+              .testFinished    = output_test_finished,
+              .runFinished     = output_run_finished,
+              .destroy         = output_destroy,
+          },
+      .alloc       = alloc,
+      .mutex       = thread_mutex_create(alloc),
+      .doc         = doc,
+      .rootObj     = rootObj,
+      .statsObj    = statsObj,
+      .passesArr   = passesArr,
+      .failuresArr = failuresArr,
+      .file        = file,
+  };
+  return (CheckOutput*)mochaOut;
+}
+
+CheckOutput* check_output_mocha_to_path(Allocator* alloc, String path) {
+  File*      file;
+  FileResult res;
+  if ((res = file_create_dir_sync(path_parent(path))) != FileResult_Success) {
+    diag_crash_msg("Failed to create parent directory: {}", fmt_text(file_result_str(res)));
+  }
+  if ((res = file_create(alloc, path, FileMode_Create, FileAccess_Write, &file)) !=
+      FileResult_Success) {
+    diag_crash_msg("Failed to create mocha test-result file: {}", fmt_text(file_result_str(res)));
+  }
+  return check_output_mocha(alloc, file);
+}
+
+CheckOutput* check_output_mocha_default(Allocator* alloc) {
+  const String resultPath = path_build_scratch(
+      path_parent(g_path_executable),
+      string_lit("logs"),
+      path_name_timestamp_scratch(path_stem(g_path_executable), string_lit("mocha")));
+  return check_output_mocha_to_path(alloc, resultPath);
+}

--- a/libs/check/src/output_mocha.c
+++ b/libs/check/src/output_mocha.c
@@ -88,12 +88,12 @@ static void output_test_finished(
       string_lit("duration"),
       json_add_number(doc, result->duration / (f64)time_millisecond));
 
+  const JsonVal errObj = json_add_object(doc);
+  json_add_field_str(doc, testObj, string_lit("err"), errObj);
+
   if (result->errors.size) {
     const CheckError* err = dynarray_at_t(&result->errors, 0, CheckError);
-
-    const JsonVal errObj = json_add_object(doc);
     json_add_field_str(doc, errObj, string_lit("message"), json_add_string(doc, err->msg));
-    json_add_field_str(doc, testObj, string_lit("err"), errObj);
   }
 
   switch (type) {

--- a/libs/check/src/output_mocha.h
+++ b/libs/check/src/output_mocha.h
@@ -3,19 +3,55 @@
 #include "output.h"
 
 /**
- * TODO:
- * Create a CheckOutput that writes pretty formatted text to the given file.
- * Note: the given file is automatically destroyed when the output is destroyed.
- * Destroy using 'check_output_destroy()'.
+ * Mocha json reporter output.
+ *
+ * Mocha is a popular JavaScript unit testing library (https://github.com/mochajs/mocha) and the
+ * json reporter format is supported by various tools.
+ *
+ * Example output:
+ * ```
+ * {
+ *   "stats": {
+ *     "start": "2021-09-09T14:36:45.947Z",
+ *     "end": "2021-09-09T14:36:45.951Z",
+ *     "duration": 4
+ *     "tests": 1,
+ *     "passes": 1,
+ *     "failures": 0,
+ *     "pending": 0,
+ *   },
+ *   "passing": {
+ *       "title": "returns FizzBuzz for multiples of 3 and 5",
+ *       "fullTitle": "fizzbuzz returns FizzBuzz for multiples of 3 and 5",
+ *       "file": "libs/check/test/test_fizzbuzz.c",
+ *       "duration": 1,
+ *       "err": {}
+ *     }
+ *   ],
+ *   "failures": [],
+ *   "pending": []
+ * }
+ * ```
+ * Note: Durations are in whole milliseconds.
+ * Note: Skipped tests are categorized as 'pending' in the Mocha json format.
+ *
+ * Aims for compatiblity with the Mocha json reporter from v7.2.0 or higher.
+ */
+
+/**
+ * Create a mocha json output that writes to the given file.
+ * Note: the given file handle is automatically destroyed when the output is destroyed.
+ * Note: Destroy using 'check_output_destroy()'.
  */
 CheckOutput* check_output_mocha(Allocator*, File*);
 
 /**
- * TODO:
+ * Create a mocha json output that writes a file at the given path.
  */
 CheckOutput* check_output_mocha_to_path(Allocator*, String path);
 
 /**
- * TODO:
+ * Create a mocha json output that writes a file called '[executable-name]_[timestamp].mocha' in a
+ * directory called 'logs' next to the executable.
  */
 CheckOutput* check_output_mocha_default(Allocator*);

--- a/libs/check/src/output_mocha.h
+++ b/libs/check/src/output_mocha.h
@@ -1,0 +1,21 @@
+#include "core_file.h"
+
+#include "output.h"
+
+/**
+ * TODO:
+ * Create a CheckOutput that writes pretty formatted text to the given file.
+ * Note: the given file is automatically destroyed when the output is destroyed.
+ * Destroy using 'check_output_destroy()'.
+ */
+CheckOutput* check_output_mocha(Allocator*, File*);
+
+/**
+ * TODO:
+ */
+CheckOutput* check_output_mocha_to_path(Allocator*, String path);
+
+/**
+ * TODO:
+ */
+CheckOutput* check_output_mocha_default(Allocator*);

--- a/libs/check/src/output_pretty.c
+++ b/libs/check/src/output_pretty.c
@@ -53,13 +53,15 @@ static void output_run_started(CheckOutput* out) {
   output_write(prettyOut, str);
 }
 
-static void output_tests_discovered(CheckOutput* out, const usize count, const TimeDuration dur) {
+static void output_tests_discovered(
+    CheckOutput* out, const usize specCount, const usize testCount, const TimeDuration dur) {
   CheckOutputPretty* prettyOut = (CheckOutputPretty*)out;
+  (void)specCount;
 
   const String str = fmt_write_scratch(
       "> Discovered {}{}{} tests. {}({}){}\n",
       arg_style_bold(prettyOut),
-      fmt_int(count),
+      fmt_int(testCount),
       arg_style_reset(prettyOut),
       arg_style_dim(prettyOut),
       fmt_duration(dur),

--- a/libs/check/src/output_pretty.c
+++ b/libs/check/src/output_pretty.c
@@ -70,6 +70,12 @@ static void output_tests_discovered(
   output_write(prettyOut, str);
 }
 
+static void output_test_skipped(CheckOutput* out, const CheckSpec* spec, const CheckTest* test) {
+  (void)out;
+  (void)spec;
+  (void)test;
+}
+
 static void output_test_finished(
     CheckOutput*          out,
     const CheckSpec*      spec,
@@ -154,6 +160,7 @@ CheckOutput* check_output_pretty(Allocator* alloc, File* file, const CheckRunFla
           {
               .runStarted      = output_run_started,
               .testsDiscovered = output_tests_discovered,
+              .testSkipped     = output_test_skipped,
               .testFinished    = output_test_finished,
               .runFinished     = output_run_finished,
               .destroy         = output_destroy,

--- a/libs/check/src/output_pretty.c
+++ b/libs/check/src/output_pretty.c
@@ -145,8 +145,7 @@ static void output_destroy(CheckOutput* out) {
   alloc_free_t(prettyOut->alloc, prettyOut);
 }
 
-CheckOutput*
-check_output_pretty_create(Allocator* alloc, File* file, const CheckRunFlags runFlags) {
+CheckOutput* check_output_pretty(Allocator* alloc, File* file, const CheckRunFlags runFlags) {
   CheckOutputPretty* prettyOut = alloc_alloc_t(alloc, CheckOutputPretty);
   *prettyOut                   = (CheckOutputPretty){
       .api =

--- a/libs/check/src/output_pretty.h
+++ b/libs/check/src/output_pretty.h
@@ -6,4 +6,4 @@
  * Create a CheckOutput that writes pretty formatted text to the given file.
  * Destroy using 'check_output_destroy()'.
  */
-CheckOutput* check_output_pretty_create(Allocator*, File*, CheckRunFlags);
+CheckOutput* check_output_pretty(Allocator*, File*, CheckRunFlags);

--- a/libs/check/src/runner.c
+++ b/libs/check/src/runner.c
@@ -50,8 +50,8 @@ CheckResultType check_run(CheckDef* check, const CheckRunFlags flags) {
 
   // Setup outputs.
   CheckOutput* outputs[] = {
-      check_output_pretty_create(g_alloc_heap, g_file_stdout, flags),
-      check_output_log_create(g_alloc_heap, g_logger),
+      check_output_pretty(g_alloc_heap, g_file_stdout, flags),
+      check_output_log(g_alloc_heap, g_logger),
   };
   CheckRunContext ctx = {.outputs = outputs, .outputsCount = array_elems(outputs)};
 

--- a/libs/check/src/runner.c
+++ b/libs/check/src/runner.c
@@ -11,6 +11,7 @@
 #include "check_runner.h"
 
 #include "output_log.h"
+#include "output_mocha.h"
 #include "output_pretty.h"
 #include "spec_internal.h"
 
@@ -51,6 +52,7 @@ CheckResultType check_run(CheckDef* check, const CheckRunFlags flags) {
   // Setup outputs.
   CheckOutput* outputs[] = {
       check_output_pretty(g_alloc_heap, g_file_stdout, flags),
+      check_output_mocha_default(g_alloc_heap),
       check_output_log(g_alloc_heap, g_logger),
   };
   CheckRunContext ctx = {.outputs = outputs, .outputsCount = array_elems(outputs)};
@@ -69,8 +71,9 @@ CheckResultType check_run(CheckDef* check, const CheckRunFlags flags) {
   });
 
   const TimeDuration discoveryTime = time_steady_duration(startTime, time_steady_clock());
-  array_for_t(
-      outputs, CheckOutput*, out, { (*out)->testsDiscovered(*out, numTests, discoveryTime); });
+  array_for_t(outputs, CheckOutput*, out, {
+    (*out)->testsDiscovered(*out, specs.size, numTests, discoveryTime);
+  });
 
   // Create a job graph with tasks to execute all tests.
   JobGraph* graph      = jobs_graph_create(g_alloc_heap, string_lit("tests"), numTests);

--- a/libs/check/src/runner.c
+++ b/libs/check/src/runner.c
@@ -83,6 +83,7 @@ CheckResultType check_run(CheckDef* check, const CheckRunFlags flags) {
     dynarray_for_t(&spec->tests, CheckTest, test, {
       if (test->flags & CheckTestFlags_Skip || (focus && !(test->flags & CheckTestFlags_Focus))) {
         ++numSkipped;
+        array_for_t(outputs, CheckOutput*, out, { (*out)->testSkipped(*out, spec, test); });
         continue;
       }
       jobs_graph_add_task(

--- a/libs/core/include/core_math.h
+++ b/libs/core/include/core_math.h
@@ -54,3 +54,25 @@ f32 math_sin_f32(f32);
  * Computes the cosine of the given value (in radians).
  */
 f32 math_cos_f32(f32);
+
+/**
+ * Compute the integer part of the given value (removes the fractional part).
+ */
+f64 math_trunc_f64(f64);
+
+/**
+ * Compute the floor (round-down) of the given value.
+ */
+f64 math_floor_f64(f64);
+
+/**
+ * Compute the ceiling (round-up) of the given value.
+ */
+f64 math_ceil_f64(f64);
+
+/**
+ * Compute the rounded version of the given value.
+ * Note: Uses round-to-even for values exactly half-way between two values (also known as 'Bankers
+ * rounding').
+ */
+f64 math_round_f64(f64);

--- a/libs/core/src/math.c
+++ b/libs/core/src/math.c
@@ -38,3 +38,32 @@ INLINE_HINT f32 math_log_f32(const f32 val) { return logf(val); }
 INLINE_HINT f32 math_sin_f32(const f32 val) { return sinf(val); }
 
 INLINE_HINT f32 math_cos_f32(const f32 val) { return cosf(val); }
+
+INLINE_HINT f64 math_trunc_f64(const f64 val) { return (i64)val; }
+
+INLINE_HINT f64 math_floor_f64(const f64 val) {
+  const f64 trunc = math_trunc_f64(val);
+  return trunc > val ? (trunc - 1) : trunc;
+}
+
+INLINE_HINT f64 math_ceil_f64(const f64 val) {
+  const f64 trunc = math_trunc_f64(val);
+  return trunc < val ? (trunc + 1) : trunc;
+}
+
+f64 math_round_f64(const f64 val) {
+  const f64 trunc = math_trunc_f64(val);
+  const f64 frac  = math_abs(val - trunc);
+  if (frac < 0.5) {
+    return trunc;
+  }
+  if (UNLIKELY(frac == 0.5)) {
+    /**
+     * Round-to-even (aka bankers rounding).
+     * Given a number exactly halfway between two values, round to the even value (zero is
+     * considered even here).
+     */
+    return ((i64)trunc % 2) ? (trunc + math_sign(val)) : trunc;
+  }
+  return trunc + math_sign(val);
+}

--- a/libs/core/test/test_math.c
+++ b/libs/core/test/test_math.c
@@ -41,4 +41,55 @@ spec(math) {
     check_eq_float(math_abs(-1.25), 1.25, 1e-6);
     check_eq_float(math_abs(0.0), 0.0, 1e-6);
   }
+
+  it("can truncate the fractional part of floats") {
+    check_eq_float(math_trunc_f64(1.42), 1.0, 1e-24);
+    check_eq_float(math_trunc_f64(42.1337), 42.0, 1e-24);
+    check_eq_float(math_trunc_f64(-1.42), -1.0, 1e-24);
+    check_eq_float(math_trunc_f64(-42.1337), -42.0, 1e-24);
+    check_eq_float(math_trunc_f64(-.34), 0.0, 1e-24);
+  }
+
+  it("can floor (round-down) floats") {
+    check_eq_float(math_floor_f64(.1), 0.0, 1e-24);
+    check_eq_float(math_floor_f64(1.1), 1.0, 1e-24);
+    check_eq_float(math_floor_f64(1.99), 1.0, 1e-24);
+    check_eq_float(math_floor_f64(-42.1337), -43.0, 1e-24);
+    check_eq_float(math_floor_f64(-2.3), -3.0, 1e-24);
+    check_eq_float(math_floor_f64(-1.99), -2.0, 1e-24);
+  }
+
+  it("can ceil (round-up) floats") {
+    check_eq_float(math_ceil_f64(1.0), 1.0, 1e-24);
+    check_eq_float(math_ceil_f64(0.0), 0.0, 1e-24);
+    check_eq_float(math_ceil_f64(1.2), 2.0, 1e-24);
+    check_eq_float(math_ceil_f64(-1.0), -1.0, 1e-24);
+    check_eq_float(math_ceil_f64(-1.2), -1.0, 1e-24);
+    check_eq_float(math_ceil_f64(-42.1337), -42.0, 1e-24);
+    check_eq_float(math_ceil_f64(-1.99), -1.0, 1e-24);
+    check_eq_float(math_ceil_f64(-1.01), -1.0, 1e-24);
+  }
+
+  it("can round (round to even) floats") {
+    check_eq_float(math_round_f64(1.0), 1.0, 1e-24);
+    check_eq_float(math_round_f64(.0), 0.0, 1e-24);
+    check_eq_float(math_round_f64(.6), 1.0, 1e-24);
+    check_eq_float(math_round_f64(.5), 0.0, 1e-24);
+    check_eq_float(math_round_f64(.499), 0.0, 1e-24);
+    check_eq_float(math_round_f64(.51), 1.0, 1e-24);
+    check_eq_float(math_round_f64(1.4), 1.0, 1e-24);
+    check_eq_float(math_round_f64(1.5), 2.0, 1e-24);
+    check_eq_float(math_round_f64(1.6), 2.0, 1e-24);
+    check_eq_float(math_round_f64(2.5), 2.0, 1e-24);
+    check_eq_float(math_round_f64(2.6), 3.0, 1e-24);
+    check_eq_float(math_round_f64(3.5), 4.0, 1e-24);
+    check_eq_float(math_round_f64(-.1), 0.0, 1e-24);
+    check_eq_float(math_round_f64(-.4), 0.0, 1e-24);
+    check_eq_float(math_round_f64(-.5), 0.0, 1e-24);
+    check_eq_float(math_round_f64(-1.5), -2.0, 1e-24);
+    check_eq_float(math_round_f64(-1.6), -2.0, 1e-24);
+    check_eq_float(math_round_f64(-2.5), -2.0, 1e-24);
+    check_eq_float(math_round_f64(-2.6), -3.0, 1e-24);
+    check_eq_float(math_round_f64(-3.5), -4.0, 1e-24);
+  }
 }

--- a/libs/log/include/log_sink_json.h
+++ b/libs/log/include/log_sink_json.h
@@ -22,15 +22,17 @@ typedef enum {
  * Or follow a 'live' log:
  * $ tail --follow app.log | jq '.message'
  *
- * Output format (without the newlines):
- *
- * { "message": "Example",
+ * Example output (without the newlines and the spaces):
+ * ```
+ * {
+ *   "message": "Example",
  *   "level": "info",
  *   "timestamp": "2020-06-29T05:49:07.401231Z",
  *   "file": "/path/main.cpp",
  *   "line": 16,
  *   "extra": { "val": 42 }
  * }
+ * ```
  */
 
 /**
@@ -48,8 +50,8 @@ LogSink* log_sink_json(Allocator*, File*, LogMask, LogSinkJsonFlags);
 LogSink* log_sink_json_to_path(Allocator*, LogMask, String path);
 
 /**
- * Create a json log sink that writes a file called '[executable-name]_[timestamp]' in a directory
- * called 'logs' next to the executable.
+ * Create a json log sink that writes a file called '[executable-name]_[timestamp].log' in a
+ * directory called 'logs' next to the executable.
  *
  * Note: Should be added to a logger using 'log_add_sink()'.
  * Note: Is automatically cleaned up when its parent logger is destroyed.

--- a/libs/log/include/log_sink_pretty.h
+++ b/libs/log/include/log_sink_pretty.h
@@ -10,11 +10,12 @@ typedef enum {
  * PrettySink - sink that outputs as (styled) pretty printed text.
  * Especially usefull for logging to the console.
  *
- * Output format (including newlines):
- *
+ * Example output::
+ * ```
  * 2020-06-30T06:38:59.780823Z [info] Window openend
  *   width:  512
  *   height: 512
+ * ```
  */
 
 /**


### PR DESCRIPTION
Mocha json reporter output.

Mocha is a popular JavaScript unit testing library (https://github.com/mochajs/mocha) and the
json reporter format is supported by various tools.

Example output:
```
{
  "stats": {
    "start": "2021-09-09T14:36:45.947Z",
    "end": "2021-09-09T14:36:45.951Z",
    "duration": 4
    "tests": 1,
    "passes": 1,
    "failures": 0,
    "pending": 0,
  },
  "passing": {
      "title": "returns FizzBuzz for multiples of 3 and 5",
      "fullTitle": "fizzbuzz returns FizzBuzz for multiples of 3 and 5",
      "file": "libs/check/test/test_fizzbuzz.c",
     "duration": 1,
     "err": {}
    }
  ],
  "failures": [],
  "pending": []
}
```
Note: Durations are in whole milliseconds.
Note: Skipped tests are categorized as 'pending' in the Mocha json format.

Aims for compatibility with the Mocha json reporter from v7.2.0 or higher.

Also updates the Github Actions `test` pipeline to make use of this using the [Test Reporter](https://github.com/marketplace/actions/test-reporter) action by [dorny](https://github.com/dorny).