### PR TITLE
jobs: Fix various race conditions in job execution

### DIFF
--- a/libs/core/src/alloc_bump.c
+++ b/libs/core/src/alloc_bump.c
@@ -2,7 +2,7 @@
 
 #include "alloc_internal.h"
 
-#define freed_mem_tag 0xFF
+#define freed_mem_tag 0xFB
 
 struct AllocatorBump {
   Allocator api;

--- a/libs/core/src/alloc_heap.c
+++ b/libs/core/src/alloc_heap.c
@@ -4,7 +4,7 @@
 
 #include <stdlib.h>
 
-#define freed_mem_tag 0xFF
+#define freed_mem_tag 0xFA
 
 struct AllocatorHeap {
   Allocator api;

--- a/libs/core/src/alloc_scratch.c
+++ b/libs/core/src/alloc_scratch.c
@@ -7,7 +7,7 @@
 #define alloc_scratch_max_alloc_size (usize_kibibyte * 64)
 #define alloc_scratch_guard_size (usize_kibibyte * 128)
 
-#define freed_mem_tag 0xFF
+#define freed_mem_tag 0xFC
 #define guard_mem_tag 0xAA
 
 struct AllocatorScratch {

--- a/libs/core/src/rng.c
+++ b/libs/core/src/rng.c
@@ -69,7 +69,8 @@ THREAD_LOCAL struct RngXorWow g_rng_xorwow = {.api = {.next = rng_xorwow_next}};
 THREAD_LOCAL Rng* g_rng;
 
 void rng_init_thread() {
-  rng_xorwow_init(&g_rng_xorwow, time_real_clock());
+  const TimeReal clock = time_real_clock();
+  rng_xorwow_init(&g_rng_xorwow, clock ? clock : 42);
   g_rng = (Rng*)&g_rng_xorwow;
 }
 

--- a/libs/core/test/test_thread.c
+++ b/libs/core/test/test_thread.c
@@ -218,7 +218,9 @@ spec(thread) {
       thread_yield();
     }
 
+    thread_mutex_lock(data.mutex);
     thread_cond_broadcast(data.cond);
+    thread_mutex_unlock(data.mutex);
 
     for (usize i = 0; i != array_elems(threads); ++i) {
       thread_join(threads[i]);

--- a/libs/jobs/src/executor.c
+++ b/libs/jobs/src/executor.c
@@ -10,6 +10,7 @@
 #include "work_queue_internal.h"
 
 // Amounts of cores reserved for OS and other applications on the system.
+// Note: the main-thread is also a worker, so worker count of 1 won't start any additional threads.
 #define worker_reserved_core_count 1
 #define worker_min_count 1
 #define worker_max_count 64

--- a/libs/jobs/src/scheduler.c
+++ b/libs/jobs/src/scheduler.c
@@ -48,7 +48,10 @@ JobId jobs_scheduler_run(JobGraph* graph) {
   *dynarray_push_t(&g_runningJobs, Job*) = job;
   thread_mutex_unlock(g_jobMutex);
 
+  // Note: We cannot touch the 'job' memory anymore after 'executor_run' returns, reason is the job
+  // could actually finish while we are still inside this function.
   executor_run(job);
+
   return id;
 }
 


### PR DESCRIPTION
Fixes various race-conditions in job execution. Mainly use-after-free's where a dependency already finished (and cleaned-up) the entire job while other functions where still using that job memory.