### PR TITLE
jobs: Thread affinity tasks

### DIFF
--- a/libs/check/src/runner.c
+++ b/libs/check/src/runner.c
@@ -87,7 +87,8 @@ CheckResultType check_run(CheckDef* check, const CheckRunFlags flags) {
           graph,
           fmt_write_scratch("{}-{}", fmt_text(spec->def->name), fmt_int(test->id)),
           check_test_task,
-          mem_struct(CheckTaskData, .spec = spec, .test = test, .ctx = &ctx));
+          mem_struct(CheckTaskData, .spec = spec, .test = test, .ctx = &ctx),
+          JobTaskFlags_None);
     });
   });
 

--- a/libs/core/include/core_sentinel.h
+++ b/libs/core/include/core_sentinel.h
@@ -27,14 +27,14 @@
  * Pre-condition: '_VAL_' is a primitive integer / floating-point type.
  */
 #define sentinel_check(_VAL_) _Generic((_VAL_),                                                    \
-    i8:   (_VAL_) == sentinel_i8,                                                                  \
-    i16:  (_VAL_) == sentinel_i16,                                                                 \
-    i32:  (_VAL_) == sentinel_i32,                                                                 \
-    i64:  (_VAL_) == sentinel_i64,                                                                  \
-    u8:   (_VAL_) == sentinel_u8,                                                                  \
-    u16:  (_VAL_) == sentinel_u16,                                                                 \
-    u32:  (_VAL_) == sentinel_u32,                                                                 \
-    u64:  (_VAL_) == sentinel_u64,                                                                 \
+    i8:   (i8)(_VAL_)   == sentinel_i8,                                                            \
+    i16:  (i16)(_VAL_)  == sentinel_i16,                                                           \
+    i32:  (i32)(_VAL_)  == sentinel_i32,                                                           \
+    i64:  (i64)(_VAL_)  == sentinel_i64,                                                           \
+    u8:   (u8)(_VAL_)   == sentinel_u8,                                                            \
+    u16:  (u16)(_VAL_)  == sentinel_u16,                                                           \
+    u32:  (u32)(_VAL_)  == sentinel_u32,                                                           \
+    u64:  (u64)(_VAL_)  == sentinel_u64,                                                           \
     f32:  float_isnan(_VAL_),                                                                      \
     f64:  float_isnan(_VAL_)                                                                       \
   )

--- a/libs/core/include/core_sentinel.h
+++ b/libs/core/include/core_sentinel.h
@@ -30,7 +30,7 @@
     i8:   (_VAL_) == sentinel_i8,                                                                  \
     i16:  (_VAL_) == sentinel_i16,                                                                 \
     i32:  (_VAL_) == sentinel_i32,                                                                 \
-    i64:  (_VAL_) == sentinel_i8,                                                                  \
+    i64:  (_VAL_) == sentinel_i64,                                                                  \
     u8:   (_VAL_) == sentinel_u8,                                                                  \
     u16:  (_VAL_) == sentinel_u16,                                                                 \
     u32:  (_VAL_) == sentinel_u32,                                                                 \

--- a/libs/ecs/src/runner.c
+++ b/libs/ecs/src/runner.c
@@ -69,7 +69,8 @@ static JobTaskId graph_insert_finalize(EcsRunner* runner) {
       runner->graph,
       string_lit("finalize"),
       graph_runner_finalize_task,
-      mem_struct(MetaTaskData, .runner = runner));
+      mem_struct(MetaTaskData, .runner = runner),
+      JobTaskFlags_None);
 }
 
 static JobTaskId
@@ -79,7 +80,8 @@ graph_insert_system(EcsRunner* runner, const EcsSystemId systemId, const EcsSyst
       systemDef->name,
       graph_system_task,
       mem_struct(
-          SystemTaskData, .world = runner->world, .id = systemId, .routine = systemDef->routine));
+          SystemTaskData, .world = runner->world, .id = systemId, .routine = systemDef->routine),
+      JobTaskFlags_None);
 };
 
 static bool graph_system_conflict(EcsWorld* world, const EcsSystemDef* a, const EcsSystemDef* b) {

--- a/libs/jobs/CMakeLists.txt
+++ b/libs/jobs/CMakeLists.txt
@@ -5,6 +5,7 @@
 message(STATUS "> library: jobs")
 
 add_library(volo_jobs STATIC
+  src/affinity_queue.c
   src/dot.c
   src/graph.c
   src/init.c

--- a/libs/jobs/include/jobs_graph.h
+++ b/libs/jobs/include/jobs_graph.h
@@ -12,6 +12,16 @@ typedef struct sAllocator Allocator;
  */
 typedef u32 JobTaskId;
 
+typedef enum {
+  JobTaskFlags_None = 0,
+
+  /**
+   * The task should always be run on the same thread.
+   * NOTE: Incurs an additional scheduling overhead.
+   */
+  JobTaskFlags_ThreadAffinity = 1 << 0,
+} JobTaskFlags;
+
 /**
  * Iterator for iterating task children.
  */
@@ -75,9 +85,9 @@ void jobs_graph_destroy(JobGraph*);
  * NOTE: 'ctx' is copied into the graph and has the same lifetime as the graph.
  *
  * Pre-condition: JobGraph is not running at the moment.
- * Pre-condition: ctx.size <= (64 - sizeof(void*) * 3).
+ * Pre-condition: ctx.size <= 32.
  */
-JobTaskId jobs_graph_add_task(JobGraph*, String name, JobTaskRoutine, Mem ctx);
+JobTaskId jobs_graph_add_task(JobGraph*, String name, JobTaskRoutine, Mem ctx, JobTaskFlags);
 
 /**
  * Register a dependency between two tasks. The child task will only be started after the parent

--- a/libs/jobs/src/affinity_queue.c
+++ b/libs/jobs/src/affinity_queue.c
@@ -1,0 +1,52 @@
+#include "core_annotation.h"
+#include "core_diag.h"
+#include "core_thread.h"
+
+#include "affinity_queue_internal.h"
+
+#define item_wrap(_IDX_) ((_IDX_) & (affqueue_max_items - 1))
+
+ASSERT((affqueue_max_items & (affqueue_max_items - 1u)) == 0, "Max size has to be a power-of-two")
+
+AffQueue affqueue_create(Allocator* alloc) {
+  return (AffQueue){
+      .bottom = 0,
+      .top    = 0,
+      .items = alloc_alloc(alloc, sizeof(AffQueueItem) * affqueue_max_items, alignof(WorkItem)).ptr,
+  };
+}
+
+void affqueue_destroy(Allocator* alloc, AffQueue* aq) {
+  alloc_free(alloc, mem_create(aq->items, sizeof(AffQueueItem) * affqueue_max_items));
+}
+
+usize affqueue_size(const AffQueue* aq) { return (usize)(aq->top - aq->bottom); }
+
+void affqueue_push(AffQueue* aq, Job* job, const JobTaskId task) {
+  diag_assert_msg(
+      affqueue_size(aq) < affqueue_max_items,
+      "Maximum number of affinity-queue items ({}) has been exceeded",
+      fmt_int(affqueue_max_items));
+
+  const i64     idx  = thread_atomic_add_i64(&aq->top, 1);
+  AffQueueItem* item = aq->items + item_wrap(idx);
+  item->work         = (WorkItem){
+      .job  = job,
+      .task = task,
+  };
+  thread_atomic_store_i64(&item->hasData, true);
+}
+
+WorkItem affqueue_pop(AffQueue* aq) {
+  const i64 bottom = aq->bottom; // No atomic load as its only written to from this thread.
+  const i64 top    = thread_atomic_load_i64(&aq->top);
+  for (i64 i = bottom; i != top; ++i) {
+    AffQueueItem* item            = aq->items + item_wrap(i);
+    i64           expectedHasData = true;
+    if (LIKELY(thread_atomic_compare_exchange_i64(&item->hasData, &expectedHasData, false))) {
+      ++aq->bottom;
+      return item->work;
+    }
+  }
+  return (WorkItem){0}; // Queue is empty.
+}

--- a/libs/jobs/src/affinity_queue_internal.h
+++ b/libs/jobs/src/affinity_queue_internal.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "core_alloc.h"
+
+#include "work_internal.h"
+
+/**
+ * Affinity Queue, queue for tasks that can only be run on a specific thread.
+ *
+ * It is a multi-producer single-consumer FIFO queue where all threads can push work but only the
+ * owning thread can pop.
+ */
+
+#define affqueue_max_items 256
+
+typedef struct {
+  i64      hasData;
+  WorkItem work;
+} AffQueueItem;
+
+typedef struct {
+  i64           top, bottom;
+  AffQueueItem* items;
+} AffQueue;
+
+AffQueue affqueue_create(Allocator*);
+void     affqueue_destroy(Allocator*, AffQueue*);
+
+/**
+ * Amount of items currently in the queue, only an indication as it can be raced by the mutating
+ * apis.
+ */
+usize affqueue_size(const AffQueue*);
+
+/**
+ * Push a new item to the queue.
+ * NOTE: Can be called by any thread.
+ */
+void affqueue_push(AffQueue*, Job*, JobTaskId);
+
+/**
+ * Pop an item from the queue in a FIFO manner.
+ * NOTE: Can only be called by the owning thread.
+ */
+WorkItem affqueue_pop(AffQueue*);

--- a/libs/jobs/src/graph.c
+++ b/libs/jobs/src/graph.c
@@ -289,14 +289,19 @@ void jobs_graph_destroy(JobGraph* graph) {
   alloc_free_t(graph->alloc, graph);
 }
 
-JobTaskId
-jobs_graph_add_task(JobGraph* graph, const String name, const JobTaskRoutine routine, Mem ctx) {
+JobTaskId jobs_graph_add_task(
+    JobGraph*            graph,
+    const String         name,
+    const JobTaskRoutine routine,
+    Mem                  ctx,
+    const JobTaskFlags   flags) {
   const JobTaskId id = (JobTaskId)graph->tasks.size;
 
   Mem taskStorage              = dynarray_push(&graph->tasks, 1);
   *((JobTask*)taskStorage.ptr) = (JobTask){
       .routine = routine,
       .name    = string_dup(graph->alloc, name),
+      .flags   = flags,
   };
   mem_cpy(mem_consume(taskStorage, sizeof(JobTask)), ctx);
 

--- a/libs/jobs/src/graph_internal.h
+++ b/libs/jobs/src/graph_internal.h
@@ -8,6 +8,7 @@ typedef u32 JobTaskLinkId;
 typedef struct {
   JobTaskRoutine routine;
   String         name;
+  JobTaskFlags   flags;
 } JobTask;
 
 typedef struct {

--- a/libs/jobs/src/work_internal.h
+++ b/libs/jobs/src/work_internal.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "job_internal.h"
+
+typedef struct {
+  Job*      job;
+  JobTaskId task;
+} WorkItem;
+
+#define workitem_valid(_WORKITEM_) ((_WORKITEM_).job != null)

--- a/libs/jobs/src/work_queue.c
+++ b/libs/jobs/src/work_queue.c
@@ -1,3 +1,4 @@
+#include "core_annotation.h"
 #include "core_diag.h"
 #include "core_thread.h"
 
@@ -11,6 +12,8 @@
  */
 
 #define item_wrap(_IDX_) ((_IDX_) & (workqueue_max_items - 1))
+
+ASSERT((workqueue_max_items & (workqueue_max_items - 1u)) == 0, "Max size has to be a power-of-two")
 
 WorkQueue workqueue_create(Allocator* alloc) {
   return (WorkQueue){
@@ -32,7 +35,7 @@ usize workqueue_size(const WorkQueue* wq) {
 
 void workqueue_push(WorkQueue* wq, Job* job, const JobTaskId task) {
   diag_assert_msg(
-      workqueue_size(wq) != workqueue_max_items,
+      workqueue_size(wq) < workqueue_max_items,
       "Maximum number of work-queue items ({}) has been exceeded",
       fmt_int(workqueue_max_items));
 

--- a/libs/jobs/src/work_queue_internal.h
+++ b/libs/jobs/src/work_queue_internal.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "core_alloc.h"
 
-#include "job_internal.h"
+#include "work_internal.h"
 
 /**
  * Lock free single-producer multiple-consumer queue.
@@ -14,19 +14,12 @@
  * - https://github.com/taskflow/work-stealing-queue
  */
 
-#define workqueue_max_items 8192
-
-typedef struct {
-  Job*      job;
-  JobTaskId task;
-} WorkItem;
+#define workqueue_max_items 2048
 
 typedef struct {
   i64       top, bottom;
   WorkItem* items;
 } WorkQueue;
-
-#define workitem_valid(_WORKITEM_) ((_WORKITEM_).job != null)
 
 WorkQueue workqueue_create(Allocator*);
 void      workqueue_destroy(Allocator*, WorkQueue*);

--- a/libs/jobs/test/test_dot.c
+++ b/libs/jobs/test/test_dot.c
@@ -2,19 +2,21 @@
 #include "core_alloc.h"
 #include "jobs_dot.h"
 
+#define task_flags JobTaskFlags_None
+
 spec(dot) {
   it("writes a Graph-Description-Language digraph based on a job-graph") {
 
     JobGraph* graph = jobs_graph_create(g_alloc_heap, string_lit("TestJob"), 2);
 
-    const JobTaskId a = jobs_graph_add_task(graph, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(graph, string_lit("B"), null, mem_empty);
-    const JobTaskId c = jobs_graph_add_task(graph, string_lit("C"), null, mem_empty);
-    const JobTaskId d = jobs_graph_add_task(graph, string_lit("D"), null, mem_empty);
-    const JobTaskId e = jobs_graph_add_task(graph, string_lit("E"), null, mem_empty);
-    const JobTaskId f = jobs_graph_add_task(graph, string_lit("F"), null, mem_empty);
-    const JobTaskId g = jobs_graph_add_task(graph, string_lit("G"), null, mem_empty);
-    jobs_graph_add_task(graph, string_lit("H"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(graph, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(graph, string_lit("B"), null, mem_empty, task_flags);
+    const JobTaskId c = jobs_graph_add_task(graph, string_lit("C"), null, mem_empty, task_flags);
+    const JobTaskId d = jobs_graph_add_task(graph, string_lit("D"), null, mem_empty, task_flags);
+    const JobTaskId e = jobs_graph_add_task(graph, string_lit("E"), null, mem_empty, task_flags);
+    const JobTaskId f = jobs_graph_add_task(graph, string_lit("F"), null, mem_empty, task_flags);
+    const JobTaskId g = jobs_graph_add_task(graph, string_lit("G"), null, mem_empty, task_flags);
+    jobs_graph_add_task(graph, string_lit("H"), null, mem_empty, task_flags);
 
     jobs_graph_task_depend(graph, a, b);
     jobs_graph_task_depend(graph, a, c);

--- a/libs/jobs/test/test_executor.c
+++ b/libs/jobs/test/test_executor.c
@@ -5,6 +5,8 @@
 #include "jobs_graph.h"
 #include "jobs_scheduler.h"
 
+#define task_flags JobTaskFlags_None
+
 typedef struct {
   i64* counter;
 } TestExecutorCounterData;
@@ -52,7 +54,8 @@ spec(executor) {
           jobGraph,
           string_lit("Increment"),
           test_task_increment_counter,
-          mem_struct(TestExecutorCounterData, .counter = &counter));
+          mem_struct(TestExecutorCounterData, .counter = &counter),
+          task_flags);
       if (i) {
         jobs_graph_task_depend(jobGraph, (JobTaskId)(i - 1), (JobTaskId)i);
       }
@@ -79,13 +82,15 @@ spec(executor) {
             jobGraph,
             string_lit("Decrement"),
             test_task_decrement_counter,
-            mem_struct(TestExecutorCounterData, .counter = &counter));
+            mem_struct(TestExecutorCounterData, .counter = &counter),
+            task_flags);
       } else {
         jobs_graph_add_task(
             jobGraph,
             string_lit("Increment"),
             test_task_increment_counter,
-            mem_struct(TestExecutorCounterData, .counter = &counter));
+            mem_struct(TestExecutorCounterData, .counter = &counter),
+            task_flags);
       }
       if (i) {
         jobs_graph_task_depend(jobGraph, (JobTaskId)i - 1, (JobTaskId)i);
@@ -112,7 +117,8 @@ spec(executor) {
           jobGraph,
           string_lit("Increment"),
           test_task_increment_counter_atomic,
-          mem_struct(TestExecutorCounterData, .counter = &counter));
+          mem_struct(TestExecutorCounterData, .counter = &counter),
+          task_flags);
     }
 
     jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
@@ -144,7 +150,8 @@ spec(executor) {
             graph,
             string_lit("Sum"),
             test_task_sum,
-            mem_struct(TestExecutorSumData, .values = data, .idxA = i, .idxB = halfSize + i));
+            mem_struct(TestExecutorSumData, .values = data, .idxA = i, .idxB = halfSize + i),
+            task_flags);
         if (!rootLayer) {
           jobs_graph_task_depend(graph, *dynarray_at_t(&dependencies, i, JobTaskId), id);
           jobs_graph_task_depend(graph, *dynarray_at_t(&dependencies, halfSize + i, JobTaskId), id);
@@ -172,14 +179,16 @@ spec(executor) {
         graph,
         string_lit("Init"),
         test_task_counter_to_42,
-        mem_struct(TestExecutorCounterData, .counter = &data[0]));
+        mem_struct(TestExecutorCounterData, .counter = &data[0]),
+        task_flags);
 
     for (usize i = 0; i != tasks; ++i) {
       const JobTaskId task = jobs_graph_add_task(
           graph,
           string_lit("SetVal"),
           test_task_sum,
-          mem_struct(TestExecutorSumData, .values = data, .idxA = i + 1, .idxB = 0));
+          mem_struct(TestExecutorSumData, .values = data, .idxA = i + 1, .idxB = 0),
+          task_flags);
       jobs_graph_task_depend(graph, initTask, task);
     }
 

--- a/libs/jobs/test/test_executor.c
+++ b/libs/jobs/test/test_executor.c
@@ -131,7 +131,7 @@ spec(executor) {
   }
 
   it("can compute a parallel sum of integers") {
-    i64   data[1024 * 8];
+    i64   data[1024 * 2];
     usize dataCount = array_elems(data);
     i64   sum       = 0;
     for (i64 i = 0; i != (i64)dataCount; ++i) {

--- a/libs/jobs/test/test_graph.c
+++ b/libs/jobs/test/test_graph.c
@@ -2,6 +2,8 @@
 #include "core_alloc.h"
 #include "jobs_graph.h"
 
+#define task_flags JobTaskFlags_None
+
 spec(graph) {
 
   JobGraph* job = null;
@@ -11,8 +13,10 @@ spec(graph) {
   it("stores a graph name") { check_eq_string(jobs_graph_name(job), string_lit("TestJob")); }
 
   it("stores task names") {
-    const JobTaskId taskA = jobs_graph_add_task(job, string_lit("TestTaskA"), null, mem_empty);
-    const JobTaskId taskB = jobs_graph_add_task(job, string_lit("TestTaskB"), null, mem_empty);
+    const JobTaskId taskA =
+        jobs_graph_add_task(job, string_lit("TestTaskA"), null, mem_empty, task_flags);
+    const JobTaskId taskB =
+        jobs_graph_add_task(job, string_lit("TestTaskB"), null, mem_empty, task_flags);
 
     check_eq_int(jobs_graph_task_count(job), 2);
     check_eq_string(jobs_graph_task_name(job, taskA), string_lit("TestTaskA"));
@@ -20,8 +24,8 @@ spec(graph) {
   }
 
   it("supports registering dependencies between tasks") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
 
     // Setup B to depend on A.
     jobs_graph_task_depend(job, a, b);
@@ -39,8 +43,8 @@ spec(graph) {
   }
 
   it("supports unregistering a dependency between tasks") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
 
     // Setup B to depend on A.
     jobs_graph_task_depend(job, a, b);
@@ -64,9 +68,9 @@ spec(graph) {
   }
 
   it("supports unregistering multiple dependencies") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
 
     // Setup B and C to depend on A.
     jobs_graph_task_depend(job, a, b);
@@ -89,18 +93,18 @@ spec(graph) {
   }
 
   it("cannot remove dependencies that do not exist") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
 
     check(!jobs_graph_task_undepend(job, a, b));
     check(!jobs_graph_task_undepend(job, b, a));
   }
 
   it("supports graphs with many-to-one dependencies") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
-    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
+    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty, task_flags);
 
     check_eq_int(jobs_graph_task_count(job), 4);
 
@@ -133,10 +137,10 @@ spec(graph) {
   }
 
   it("supports graphs with one-to-many dependencies") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
-    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
+    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty, task_flags);
 
     check_eq_int(jobs_graph_task_count(job), 4);
 
@@ -176,10 +180,10 @@ spec(graph) {
   }
 
   it("can reduce unnecessary dependencies in a linear graph") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
-    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
+    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty, task_flags);
 
     jobs_graph_task_depend(job, a, b);
     jobs_graph_task_depend(job, a, c);
@@ -210,11 +214,11 @@ spec(graph) {
   }
 
   it("can reduce unnecessary dependencies in a graph") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
-    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty);
-    const JobTaskId e = jobs_graph_add_task(job, string_lit("E"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
+    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty, task_flags);
+    const JobTaskId e = jobs_graph_add_task(job, string_lit("E"), null, mem_empty, task_flags);
 
     jobs_graph_task_depend(job, a, b);
     jobs_graph_task_depend(job, a, c);
@@ -233,13 +237,13 @@ spec(graph) {
   }
 
   it("cant reduce dependencies in a fully parallel graph") {
-    jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("D"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("E"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("F"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("G"), null, mem_empty);
+    jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("D"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("E"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("F"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("G"), null, mem_empty, task_flags);
 
     check_eq_int(jobs_graph_task_span(job), 1); // Span of this graph is 1.
 
@@ -250,8 +254,8 @@ spec(graph) {
   }
 
   it("can detect cycles") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
 
     // Setup cycle between A and B.
     jobs_graph_task_depend(job, a, b);
@@ -261,13 +265,13 @@ spec(graph) {
   }
 
   it("can detect indirect cycles") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
-    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty);
-    const JobTaskId e = jobs_graph_add_task(job, string_lit("E"), null, mem_empty);
-    const JobTaskId f = jobs_graph_add_task(job, string_lit("F"), null, mem_empty);
-    const JobTaskId g = jobs_graph_add_task(job, string_lit("G"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
+    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty, task_flags);
+    const JobTaskId e = jobs_graph_add_task(job, string_lit("E"), null, mem_empty, task_flags);
+    const JobTaskId f = jobs_graph_add_task(job, string_lit("F"), null, mem_empty, task_flags);
+    const JobTaskId g = jobs_graph_add_task(job, string_lit("G"), null, mem_empty, task_flags);
 
     jobs_graph_task_depend(job, a, b);
     jobs_graph_task_depend(job, a, c);
@@ -282,13 +286,13 @@ spec(graph) {
   }
 
   it("can compute the span of a serial graph") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
-    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty);
-    const JobTaskId e = jobs_graph_add_task(job, string_lit("E"), null, mem_empty);
-    const JobTaskId f = jobs_graph_add_task(job, string_lit("F"), null, mem_empty);
-    const JobTaskId g = jobs_graph_add_task(job, string_lit("G"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
+    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty, task_flags);
+    const JobTaskId e = jobs_graph_add_task(job, string_lit("E"), null, mem_empty, task_flags);
+    const JobTaskId f = jobs_graph_add_task(job, string_lit("F"), null, mem_empty, task_flags);
+    const JobTaskId g = jobs_graph_add_task(job, string_lit("G"), null, mem_empty, task_flags);
 
     jobs_graph_task_depend(job, a, b);
     jobs_graph_task_depend(job, b, c);
@@ -304,13 +308,13 @@ spec(graph) {
   }
 
   it("can compute the span of a parallel graph") {
-    jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("D"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("E"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("F"), null, mem_empty);
-    jobs_graph_add_task(job, string_lit("G"), null, mem_empty);
+    jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("D"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("E"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("F"), null, mem_empty, task_flags);
+    jobs_graph_add_task(job, string_lit("G"), null, mem_empty, task_flags);
 
     check(jobs_graph_validate(job));
     check_eq_int(jobs_graph_task_span(job), 1);
@@ -319,24 +323,24 @@ spec(graph) {
   }
 
   it("can compute the span of a complex graph") {
-    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty);
-    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty);
-    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty);
-    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty);
-    const JobTaskId e = jobs_graph_add_task(job, string_lit("E"), null, mem_empty);
-    const JobTaskId f = jobs_graph_add_task(job, string_lit("F"), null, mem_empty);
-    const JobTaskId g = jobs_graph_add_task(job, string_lit("G"), null, mem_empty);
-    const JobTaskId h = jobs_graph_add_task(job, string_lit("H"), null, mem_empty);
-    const JobTaskId i = jobs_graph_add_task(job, string_lit("I"), null, mem_empty);
-    const JobTaskId j = jobs_graph_add_task(job, string_lit("J"), null, mem_empty);
-    const JobTaskId k = jobs_graph_add_task(job, string_lit("K"), null, mem_empty);
-    const JobTaskId l = jobs_graph_add_task(job, string_lit("L"), null, mem_empty);
-    const JobTaskId m = jobs_graph_add_task(job, string_lit("M"), null, mem_empty);
-    const JobTaskId n = jobs_graph_add_task(job, string_lit("N"), null, mem_empty);
-    const JobTaskId o = jobs_graph_add_task(job, string_lit("O"), null, mem_empty);
-    const JobTaskId p = jobs_graph_add_task(job, string_lit("P"), null, mem_empty);
-    const JobTaskId q = jobs_graph_add_task(job, string_lit("Q"), null, mem_empty);
-    const JobTaskId r = jobs_graph_add_task(job, string_lit("R"), null, mem_empty);
+    const JobTaskId a = jobs_graph_add_task(job, string_lit("A"), null, mem_empty, task_flags);
+    const JobTaskId b = jobs_graph_add_task(job, string_lit("B"), null, mem_empty, task_flags);
+    const JobTaskId c = jobs_graph_add_task(job, string_lit("C"), null, mem_empty, task_flags);
+    const JobTaskId d = jobs_graph_add_task(job, string_lit("D"), null, mem_empty, task_flags);
+    const JobTaskId e = jobs_graph_add_task(job, string_lit("E"), null, mem_empty, task_flags);
+    const JobTaskId f = jobs_graph_add_task(job, string_lit("F"), null, mem_empty, task_flags);
+    const JobTaskId g = jobs_graph_add_task(job, string_lit("G"), null, mem_empty, task_flags);
+    const JobTaskId h = jobs_graph_add_task(job, string_lit("H"), null, mem_empty, task_flags);
+    const JobTaskId i = jobs_graph_add_task(job, string_lit("I"), null, mem_empty, task_flags);
+    const JobTaskId j = jobs_graph_add_task(job, string_lit("J"), null, mem_empty, task_flags);
+    const JobTaskId k = jobs_graph_add_task(job, string_lit("K"), null, mem_empty, task_flags);
+    const JobTaskId l = jobs_graph_add_task(job, string_lit("L"), null, mem_empty, task_flags);
+    const JobTaskId m = jobs_graph_add_task(job, string_lit("M"), null, mem_empty, task_flags);
+    const JobTaskId n = jobs_graph_add_task(job, string_lit("N"), null, mem_empty, task_flags);
+    const JobTaskId o = jobs_graph_add_task(job, string_lit("O"), null, mem_empty, task_flags);
+    const JobTaskId p = jobs_graph_add_task(job, string_lit("P"), null, mem_empty, task_flags);
+    const JobTaskId q = jobs_graph_add_task(job, string_lit("Q"), null, mem_empty, task_flags);
+    const JobTaskId r = jobs_graph_add_task(job, string_lit("R"), null, mem_empty, task_flags);
 
     jobs_graph_task_depend(job, a, b);
     jobs_graph_task_depend(job, b, c);

--- a/libs/jobs/test/test_scheduler.c
+++ b/libs/jobs/test/test_scheduler.c
@@ -2,13 +2,15 @@
 #include "core_alloc.h"
 #include "jobs_scheduler.h"
 
+#define task_flags JobTaskFlags_None
+
 static void test_task_nop(void* ctx) { (void)ctx; }
 
 spec(scheduler) {
 
   it("can run a single-task job-graph") {
     JobGraph* jobGraph = jobs_graph_create(g_alloc_scratch, string_lit("TestJob"), 1);
-    jobs_graph_add_task(jobGraph, string_lit("TestTask"), test_task_nop, mem_empty);
+    jobs_graph_add_task(jobGraph, string_lit("TestTask"), test_task_nop, mem_empty, task_flags);
 
     JobId id = jobs_scheduler_run(jobGraph);
     jobs_scheduler_wait_help(id);
@@ -21,7 +23,7 @@ spec(scheduler) {
     static const usize numRuns = 128;
 
     JobGraph* jobGraph = jobs_graph_create(g_alloc_scratch, string_lit("TestJob"), 1);
-    jobs_graph_add_task(jobGraph, string_lit("TestTask"), test_task_nop, mem_empty);
+    jobs_graph_add_task(jobGraph, string_lit("TestTask"), test_task_nop, mem_empty, task_flags);
 
     DynArray jobIds = dynarray_create_t(g_alloc_scratch, JobId, numRuns);
 


### PR DESCRIPTION
Add support for tasks that always need to be executed on the same thread.

The api doesn't let the caller choose the thread but the job-system will guarantee that the task will always be executed on the same thread throughout the whole application lifetime.