### PR TITLE
core: Win32 file monitor fixes

### DIFF
--- a/libs/core/src/file_pal_linux.c
+++ b/libs/core/src/file_pal_linux.c
@@ -248,6 +248,7 @@ FileResult file_delete_dir_sync(String path) {
 
 FileResult file_map(File* file, String* output) {
   diag_assert_msg(!file->mapping, "File is already mapped");
+  diag_assert_msg(file->access != 0, "File handle does not have read or write access");
 
   const usize size = file_stat_sync(file).size;
 

--- a/libs/core/src/file_pal_win32.c
+++ b/libs/core/src/file_pal_win32.c
@@ -82,7 +82,7 @@ file_create(Allocator* alloc, String path, FileMode mode, FileAccessFlags access
   winutils_to_widestr(pathBufferMem, path);
 
   DWORD shareMode =
-      FILE_SHARE_READ | FILE_SHARE_WRITE; // Consider a flag for specifying no concurrent writes?
+      access == 0 ? (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE) : FILE_SHARE_READ;
   DWORD desiredAccess       = 0;
   DWORD creationDisposition = 0;
   DWORD flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_POSIX_SEMANTICS;

--- a/libs/core/src/file_pal_win32.c
+++ b/libs/core/src/file_pal_win32.c
@@ -285,6 +285,7 @@ FileResult file_delete_dir_sync(String path) {
 
 FileResult file_map(File* file, String* output) {
   diag_assert_msg(!file->mapping, "File is already mapped");
+  diag_assert_msg(file->access != 0, "File handle does not have read or write access");
 
   LARGE_INTEGER size;
   size.QuadPart = file_stat_sync(file).size;

--- a/libs/core/test/test_file_monitor.c
+++ b/libs/core/test/test_file_monitor.c
@@ -4,8 +4,6 @@
 #include "core_file_monitor.h"
 #include "core_path.h"
 #include "core_rng.h"
-#include "core_thread.h"
-#include "core_time.h"
 
 static String test_random_path() {
   return path_build_scratch(
@@ -60,8 +58,6 @@ spec(file_monitor) {
 
     check_eq_int(file_monitor_watch(monitor, path, 42), FileMonitorResult_Success);
 
-    thread_sleep(time_milliseconds(1));
-
     file_write_to_path_sync(path, string_lit("Hello World"));
 
     FileMonitorEvent event;
@@ -84,8 +80,6 @@ spec(file_monitor) {
 
     check_eq_int(file_monitor_watch(monitor, pathA, 1), FileMonitorResult_Success);
     check_eq_int(file_monitor_watch(monitor, pathB, 2), FileMonitorResult_Success);
-
-    thread_sleep(time_milliseconds(1));
 
     file_write_to_path_sync(pathA, string_lit("A-Modified"));
     file_write_to_path_sync(pathB, string_lit("B-Modified"));

--- a/libs/core/test/test_file_monitor.c
+++ b/libs/core/test/test_file_monitor.c
@@ -4,6 +4,8 @@
 #include "core_file_monitor.h"
 #include "core_path.h"
 #include "core_rng.h"
+#include "core_thread.h"
+#include "core_time.h"
 
 static String test_random_path() {
   return path_build_scratch(
@@ -58,10 +60,12 @@ spec(file_monitor) {
 
     check_eq_int(file_monitor_watch(monitor, path, 42), FileMonitorResult_Success);
 
+    thread_sleep(time_millisecond);
+
     file_write_to_path_sync(path, string_lit("Hello World"));
 
     FileMonitorEvent event;
-    check(file_monitor_poll(monitor, &event));
+    check_require(file_monitor_poll(monitor, &event));
 
     check_eq_string(event.path, path);
     check_eq_int(event.userData, 42);
@@ -81,13 +85,15 @@ spec(file_monitor) {
     check_eq_int(file_monitor_watch(monitor, pathA, 1), FileMonitorResult_Success);
     check_eq_int(file_monitor_watch(monitor, pathB, 2), FileMonitorResult_Success);
 
+    thread_sleep(time_millisecond);
+
     file_write_to_path_sync(pathA, string_lit("A-Modified"));
     file_write_to_path_sync(pathB, string_lit("B-Modified"));
 
     FileMonitorEvent event1;
-    check(file_monitor_poll(monitor, &event1));
+    check_require(file_monitor_poll(monitor, &event1));
     FileMonitorEvent event2;
-    check(file_monitor_poll(monitor, &event2));
+    check_require(file_monitor_poll(monitor, &event2));
 
     check(event1.userData != event2.userData);
     check(event1.userData == 1 || event1.userData == 2);


### PR DESCRIPTION
Wait with reporting the change event until the file is readable again, gives semantics closer to the linux inotify 'CLOSE_WRITE' event.