### PR TITLE
rend: Transfer optimize

### DIFF
--- a/libs/rend/demos/pedestal.c
+++ b/libs/rend/demos/pedestal.c
@@ -150,7 +150,7 @@ ecs_system_define(DemoUpdateSys) {
     gap_window_title_set(
         window,
         fmt_write_scratch(
-            "{>4} hz | {>8} gpu | {>6} verts | {>6} tris | {>8} ram | {>8} vram | {>8} rend-ram",
+            "{>4} hz | {>8} gpu | {>6} verts | {>6} tris | {>8} ram | {>8} vram | {>7} rend-ram",
             fmt_float(demo->updateFreq, .maxDecDigits = 0),
             fmt_duration(demo->renderTime),
             fmt_int(rendStats ? rendStats->vertices : 0),

--- a/libs/rend/src/rvk/uniform.c
+++ b/libs/rend/src/rvk/uniform.c
@@ -18,7 +18,7 @@
 /**
  * Size of the backing buffers to allocate.
  */
-#define rvk_uniform_buffer_size (32 * usize_mebibyte)
+#define rvk_uniform_buffer_size (16 * usize_mebibyte)
 
 typedef struct {
   RvkBuffer  buffer;


### PR DESCRIPTION
Support dynamically sized transfer buffers and prefer the smallest buffer that fits (to reserve the big buffers for big transfers).