### PR TITLE
cmake: Track shader dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,7 @@
   "emeraldwalk.runonsave": {
     "commands": [
       {
-        "match": "\\.(?:vert|frag)$",
+        "match": "\\.(?:vert|frag|glsl)$",
         "cmd": "cmake --build build --target volo_shaders"
       }
     ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 cmake_minimum_required(VERSION 3.19)
 
+cmake_policy(SET CMP0116 NEW) # Support Ninja dep-files in subdirectories.
+
 project(Volo VERSION 0.1.0 LANGUAGES C)
 
 # Custom options.

--- a/cmake/shader.cmake
+++ b/cmake/shader.cmake
@@ -12,16 +12,18 @@ function(configure_shaders target)
   message(STATUS ">> Vulkan glslc: ${Vulkan_GLSLC_EXECUTABLE}")
 
   foreach(shaderPath IN LISTS ARGN)
-
     # Create a custom command to compile the shader to spir-v using glslc.
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${shaderPath}.spv
       DEPENDS ${shaderPath}
-      COMMAND ${Vulkan_GLSLC_EXECUTABLE}
-      -x glsl --target-env=vulkan1.1 --target-spv=spv1.3 -Werror -O
-      -o ${CMAKE_CURRENT_SOURCE_DIR}/${shaderPath}.spv
-      ${CMAKE_CURRENT_SOURCE_DIR}/${shaderPath})
-
+      DEPFILE ${shaderPath}.d
+      COMMAND
+        ${Vulkan_GLSLC_EXECUTABLE}
+        -MD -MF ${shaderPath}.d
+        -x glsl --target-env=vulkan1.1 --target-spv=spv1.3 -Werror -O
+        -o ${CMAKE_CURRENT_SOURCE_DIR}/${shaderPath}.spv
+        ${CMAKE_CURRENT_SOURCE_DIR}/${shaderPath}
+      )
     list(APPEND artifacts ${CMAKE_CURRENT_SOURCE_DIR}/${shaderPath}.spv)
   endforeach()
 


### PR DESCRIPTION
Tells glslc to generate dep (.d) files containing the list of includes so the buildsystem can rebuild the shader when an include changes.