### PR TITLE
asset: Fix ftx glyph layout

### DIFF
--- a/apps/pedestal.c
+++ b/apps/pedestal.c
@@ -20,7 +20,7 @@
  */
 
 static const GapVector g_windowSize          = {1024, 768};
-static const f32       g_statsTextSize       = 30.0f;
+static const f32       g_statsTextSize       = 25.0f;
 static const u32       g_statsUpdateInterval = 4;
 static const f32       g_statSmoothFactor    = 0.05f;
 static const f32       g_pedestalRotateSpeed = 45.0f * math_deg_to_rad;

--- a/assets/fonts/mono.ftx
+++ b/assets/fonts/mono.ftx
@@ -1,7 +1,8 @@
 {
   "fontId": "fonts/hack_regular.ttf",
-  "size": 512,
-  "glyphSize": 32,
-  "border": 3,
+  "size": 256,
+  "glyphSize": 16,
+  "border": 2,
+  "lineSpacing": 0.2,
   "characters": "\u0020!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜø£Ø×ƒáíóúñÑªº¿®¬½¼¡«»░▒▓│┤ÁÂÀ©╣║╗╝¢¥┐└┴┬├─┼ãÃ╚╔╩╦╠═╬¤ðÐÊËÈıÍÎÏ┘┌█▄¦Ì▀ÓßÔÒõÕµþÞÚÛÙýÝ¯´≡±‗¾¶§÷¸°¨·¹³²■"
 }

--- a/assets/fonts/mono.ftx
+++ b/assets/fonts/mono.ftx
@@ -3,6 +3,5 @@
   "size": 512,
   "glyphSize": 32,
   "border": 3,
-  "advanceMultiplier": 0.85,
   "characters": "\u0020!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜø£Ø×ƒáíóúñÑªº¿®¬½¼¡«»░▒▓│┤ÁÂÀ©╣║╗╝¢¥┐└┴┬├─┼ãÃ╚╔╩╦╠═╬¤ðÐÊËÈıÍÎÏ┘┌█▄¦Ì▀ÓßÔÒõÕµþÞÚÛÙýÝ¯´≡±‗¾¶§÷¸°¨·¹³²■"
 }

--- a/libs/asset/src/loader_ftx.c
+++ b/libs/asset/src/loader_ftx.c
@@ -32,7 +32,6 @@ typedef struct {
   u32    size, glyphSize;
   u32    border;
   f32    lineSpacing;
-  f32    advanceMultiplier;
   String characters;
 } FtxDefinition;
 
@@ -52,8 +51,6 @@ static void ftx_datareg_init() {
     data_reg_field_t(g_dataReg, FtxDefinition, border, data_prim_t(u32));
     data_reg_field_t(
         g_dataReg, FtxDefinition, lineSpacing, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(
-        g_dataReg, FtxDefinition, advanceMultiplier, data_prim_t(f32), .flags = DataFlags_Opt);
     data_reg_field_t(g_dataReg, FtxDefinition, characters, data_prim_t(String));
 
     g_dataFtxDefMeta = data_meta_t(t_FtxDefinition);
@@ -203,7 +200,6 @@ static void ftx_generate(
     *err = FtxError_TooManyGlyphs;
     goto Error;
   }
-  const f32 advanceMult = def->advanceMultiplier < f32_epsilon ? 1.0f : def->advanceMultiplier;
 
   FtxDefinitionChar inputChars[ftx_max_chars];
   const u32         charCount = ftx_lookup_chars(font, def->characters, inputChars, err);
@@ -221,7 +217,7 @@ static void ftx_generate(
         .size       = inputChars[i].glyph->size,
         .offsetX    = inputChars[i].glyph->offsetX,
         .offsetY    = inputChars[i].glyph->offsetY,
-        .advance    = inputChars[i].glyph->advance * advanceMult,
+        .advance    = inputChars[i].glyph->advance,
     };
     if (inputChars[i].glyph->segmentCount) {
       if (UNLIKELY(nextGlyphIndex >= maxGlyphs)) {

--- a/libs/asset/src/loader_ftx.c
+++ b/libs/asset/src/loader_ftx.c
@@ -369,7 +369,7 @@ void asset_load_ftx(EcsWorld* world, const EcsEntityId entity, AssetSource* src)
     errMsg = ftx_error_str(FtxError_FontNotSpecified);
     goto Error;
   }
-  if (UNLIKELY(!def.size)) {
+  if (UNLIKELY(!def.size || !def.glyphSize)) {
     errMsg = ftx_error_str(FtxError_SizeZero);
     goto Error;
   }

--- a/libs/asset/src/loader_ftx.c
+++ b/libs/asset/src/loader_ftx.c
@@ -211,12 +211,17 @@ static void ftx_generate(
 
   u32 nextGlyphIndex = 0;
   for (u32 i = 0; i != charCount; ++i) {
+    /**
+     * Take the sdf border into account as the glyph will need to be rendered bigger to compensate.
+     */
+    const f32 relGlyphBorder = def->border / (f32)def->glyphSize * inputChars[i].glyph->size;
+
     chars[i] = (AssetFtxChar){
         .cp         = inputChars[i].cp,
         .glyphIndex = inputChars[i].glyph->segmentCount ? nextGlyphIndex : sentinel_u32,
-        .size       = inputChars[i].glyph->size,
-        .offsetX    = inputChars[i].glyph->offsetX,
-        .offsetY    = inputChars[i].glyph->offsetY,
+        .size       = inputChars[i].glyph->size + relGlyphBorder * 2.0f,
+        .offsetX    = inputChars[i].glyph->offsetX - relGlyphBorder,
+        .offsetY    = inputChars[i].glyph->offsetY - relGlyphBorder,
         .advance    = inputChars[i].glyph->advance,
     };
     if (inputChars[i].glyph->segmentCount) {


### PR DESCRIPTION
Now properly takes the sdf border into account.

For reference, on the left vscode and on the right our implementation:
![Screenshot from 2022-01-23 15-42-49](https://user-images.githubusercontent.com/14230060/150682113-2edf1b6c-0895-4661-9149-8056a9c0d168.png)

