### PR TITLE
scene: Text memory reduction

### DIFF
--- a/assets/shaders/ui/text.vert
+++ b/assets/shaders/ui/text.vert
@@ -23,7 +23,7 @@ const f32_vec2 c_unitTexCoords[c_verticesPerGlyph] = {
     f32_vec2(0, 0),
 };
 
-bind_spec(0) const u32 s_maxGlyphs = 2048;
+bind_spec(0) const u32 s_maxGlyphs = 4096;
 
 /**
  * Packed data for 2 glyphs.

--- a/assets/shaders/ui/text.vert
+++ b/assets/shaders/ui/text.vert
@@ -35,7 +35,7 @@ struct GlyphPackedData {
 };
 
 struct FontData {
-  f32      glyphPerAtlas; // glyphsPerDim * glyphsPerDim
+  f32      glyphsInFont; // glyphsPerDim * glyphsPerDim
   f32      glyphsPerDim;
   f32      invGlyphsPerDim; // 1,0 / glyphsPerDim
   f32_vec4 color;
@@ -68,7 +68,7 @@ void main() {
   const f32_vec4 glyphData  = glyph_data(glyphIndex);
   const f32_vec2 glyphPos   = glyphData.xy;
   const f32      glyphSize  = glyphData.z;
-  const f32      atlasIndex = glyphData.w * u_font.glyphPerAtlas;
+  const f32      atlasIndex = glyphData.w * u_font.glyphsInFont;
 
   /**
    * Compute the ui positions of the vertices.

--- a/assets/shaders/ui/text.vert
+++ b/assets/shaders/ui/text.vert
@@ -26,12 +26,13 @@ const f32_vec2 c_unitTexCoords[c_verticesPerGlyph] = {
 bind_spec(0) const u32 s_maxGlyphs = 2048;
 
 struct GlyphData {
-  f32_vec4 raw; // x, y = position, z = size, w = glyphIndex.
+  f32_vec4 raw; // x, y = position, z = size, w = glyphIndex / glyphPerAtlas.
 };
 
 struct FontData {
+  f32      glyphPerAtlas; // glyphsPerDim * glyphsPerDim
   f32      glyphsPerDim;
-  f32      invGlyphsPerDim;
+  f32      invGlyphsPerDim; // 1,0 / glyphsPerDim
   f32_vec4 color;
 };
 
@@ -49,7 +50,7 @@ void main() {
   const u32      vertIndex  = in_vertexIndex % c_verticesPerGlyph;
   const f32_vec2 glyphPos   = u_glyphs[glyphIndex].raw.xy;
   const f32      glyphSize  = u_glyphs[glyphIndex].raw.z;
-  const f32      atlasIndex = u_glyphs[glyphIndex].raw.w;
+  const f32      atlasIndex = u_glyphs[glyphIndex].raw.w * u_font.glyphPerAtlas;
 
   /**
    * Compute the ui positions of the vertices.

--- a/assets/shaders/ui/text.vert
+++ b/assets/shaders/ui/text.vert
@@ -25,8 +25,13 @@ const f32_vec2 c_unitTexCoords[c_verticesPerGlyph] = {
 
 bind_spec(0) const u32 s_maxGlyphs = 2048;
 
-struct GlyphData {
-  f32_vec4 raw; // x, y = position, z = size, w = glyphIndex / glyphPerAtlas.
+/**
+ * Packed data for 2 glyphs.
+ * To fit as much data as possible in the fast uniform storage we fit two glyphs into a single 16
+ * byte struct (to meet the 16 byte alignment requirement).
+ */
+struct GlyphPackedData {
+  f16_vec4 a, b; // x, y = position, z = size, w = glyphIndex / glyphPerAtlas.
 };
 
 struct FontData {
@@ -38,19 +43,32 @@ struct FontData {
 
 bind_global_data(0) readonly uniform Global { GlobalData u_global; };
 bind_instance_data(0) readonly uniform Instance {
-  FontData  u_font;
-  GlyphData u_glyphs[s_maxGlyphs];
+  FontData        u_font;
+  GlyphPackedData u_packedGlyphs[s_maxGlyphs / 2];
 };
 
 bind_internal(0) out f32_vec2 out_texcoord;
 bind_internal(1) out flat f32_vec4 out_color;
 
+/**
+ * Retrieve the glyph-data for the given glyph-index.
+ */
+f32_vec4 glyph_data(const u32 glyphIndex) {
+  /**
+   * Find the glyph-tuple (as they are stored in sets of 2) and then retrieve the correct entry.
+   */
+  const u32  packedIndex = glyphIndex / 2;
+  const bool useA        = glyphIndex % 2 == 0;
+  return useA ? f32_vec4(u_packedGlyphs[packedIndex].a) : f32_vec4(u_packedGlyphs[packedIndex].b);
+}
+
 void main() {
   const u32      glyphIndex = in_vertexIndex / c_verticesPerGlyph;
   const u32      vertIndex  = in_vertexIndex % c_verticesPerGlyph;
-  const f32_vec2 glyphPos   = u_glyphs[glyphIndex].raw.xy;
-  const f32      glyphSize  = u_glyphs[glyphIndex].raw.z;
-  const f32      atlasIndex = u_glyphs[glyphIndex].raw.w * u_font.glyphPerAtlas;
+  const f32_vec4 glyphData  = glyph_data(glyphIndex);
+  const f32_vec2 glyphPos   = glyphData.xy;
+  const f32      glyphSize  = glyphData.z;
+  const f32      atlasIndex = glyphData.w * u_font.glyphPerAtlas;
 
   /**
    * Compute the ui positions of the vertices.

--- a/libs/scene/src/renderable.c
+++ b/libs/scene/src/renderable.c
@@ -1,4 +1,5 @@
 #include "core_alloc.h"
+#include "core_bits.h"
 #include "core_math.h"
 #include "scene_renderable.h"
 
@@ -26,7 +27,7 @@ Mem scene_renderable_unique_data(SceneRenderableUniqueComp* renderable, const us
   if (LIKELY(renderable->instDataMem.ptr)) {
     alloc_free(g_alloc_heap, renderable->instDataMem);
   }
-  renderable->instDataMem  = alloc_alloc(g_alloc_heap, math_max(size, 16), 16);
+  renderable->instDataMem  = alloc_alloc(g_alloc_heap, bits_align(size, 16), 16);
   renderable->instDataSize = size;
   return renderable->instDataMem;
 }

--- a/libs/scene/src/text.c
+++ b/libs/scene/src/text.c
@@ -30,13 +30,13 @@ typedef struct {
 ASSERT(sizeof(ShaderFontData) == 32, "Size needs to match the size defined in glsl");
 
 typedef struct {
-  ALIGNAS(16)
-  f32 position[2];
-  f32 size;
-  f32 indexFrac;
+  ALIGNAS(8)
+  f16 position[2];
+  f16 size;
+  f16 indexFrac;
 } ShaderGlyphData;
 
-ASSERT(sizeof(ShaderGlyphData) == 16, "Size needs to match the size defined in glsl");
+ASSERT(sizeof(ShaderGlyphData) == 8, "Size needs to match the size defined in glsl");
 
 typedef struct {
   const AssetFtxComp*        font;
@@ -89,13 +89,13 @@ static void scene_text_build_char(SceneTextBuilder* builder, const Unicode cp) {
      */
     const f32 glyphsPerAtlas = builder->font->glyphsPerDim * builder->font->glyphsPerDim;
     builder->outputGlyphData[builder->outputGlyphCount++] = (ShaderGlyphData){
-        .indexFrac = ch->glyphIndex / (f32)glyphsPerAtlas,
+        .indexFrac = bits_f32_to_f16(ch->glyphIndex / (f32)glyphsPerAtlas),
         .position =
             {
-                ch->offsetX * builder->glyphSize + builder->cursor[0],
-                ch->offsetY * builder->glyphSize + builder->cursor[1],
+                bits_f32_to_f16(ch->offsetX * builder->glyphSize + builder->cursor[0]),
+                bits_f32_to_f16(ch->offsetY * builder->glyphSize + builder->cursor[1]),
             },
-        .size = ch->size * builder->glyphSize,
+        .size = bits_f32_to_f16(ch->size * builder->glyphSize),
     };
   }
   builder->cursor[0] += ch->advance * builder->glyphSize;

--- a/libs/scene/src/text.c
+++ b/libs/scene/src/text.c
@@ -13,7 +13,7 @@
 #include "scene_renderable.h"
 #include "scene_text.h"
 
-#define scene_text_max_glyphs 2048
+#define scene_text_max_glyphs 4096
 #define scene_text_tab_size 4
 
 static const String g_textGraphic = string_static("graphics/ui/text.gra");


### PR DESCRIPTION
Reduce the amount of memory needed per glyph from 16 to 8 bytes and thus doubling our maximum amount of characters per text component.

The following text is using 1 text component with 1 draw:
![image](https://user-images.githubusercontent.com/14230060/150687879-c7b1a14f-d7e4-475e-89a3-c709b120e93f.png)
