### PR TITLE
data: Support non-empty value flag

### DIFF
--- a/assets/graphics/scene/grid.gra
+++ b/assets/graphics/scene/grid.gra
@@ -8,7 +8,6 @@
     }
   ],
   "samplers": [],
-  "vertexCount": 0,
   "renderOrder": 20,
   "topology": "Lines",
   "lineWidth": 2,

--- a/assets/graphics/ui/lines.gra
+++ b/assets/graphics/ui/lines.gra
@@ -14,7 +14,6 @@
       "shaderId": "shaders/ui/color.frag.spv"
     }
   ],
-  "vertexCount": 0,
   "renderOrder": 100,
   "topology": "Lines",
   "lineWidth": 4,

--- a/assets/graphics/ui/points.gra
+++ b/assets/graphics/ui/points.gra
@@ -19,7 +19,6 @@
       "shaderId": "shaders/ui/color.frag.spv"
     }
   ],
-  "vertexCount": 0,
   "renderOrder": 101,
   "topology": "Points",
   "rasterizer": "Points",

--- a/assets/graphics/ui/text.gra
+++ b/assets/graphics/ui/text.gra
@@ -14,7 +14,6 @@
       "filter": "Linear"
     }
   ],
-  "vertexCount": 0,
   "renderOrder": 100,
   "topology": "Triangles",
   "rasterizer": "Fill",

--- a/libs/asset/src/loader_graphic.c
+++ b/libs/asset/src/loader_graphic.c
@@ -68,12 +68,14 @@ static void graphic_datareg_init() {
     data_reg_const_t(g_dataReg, AssetGraphicCull, Front);
 
     data_reg_struct_t(g_dataReg, AssetGraphicOverride);
-    data_reg_field_t(g_dataReg, AssetGraphicOverride, name, data_prim_t(String));
+    data_reg_field_t(
+        g_dataReg, AssetGraphicOverride, name, data_prim_t(String), .flags = DataFlags_NotEmpty);
     data_reg_field_t(g_dataReg, AssetGraphicOverride, binding, data_prim_t(u32));
     data_reg_field_t(g_dataReg, AssetGraphicOverride, value, data_prim_t(f64));
 
     data_reg_struct_t(g_dataReg, AssetGraphicShader);
-    data_reg_field_t(g_dataReg, AssetGraphicShader, shaderId, data_prim_t(String));
+    data_reg_field_t(
+        g_dataReg, AssetGraphicShader, shaderId, data_prim_t(String), .flags = DataFlags_NotEmpty);
     data_reg_field_t(
         g_dataReg,
         AssetGraphicShader,
@@ -83,7 +85,12 @@ static void graphic_datareg_init() {
         .flags     = DataFlags_Opt);
 
     data_reg_struct_t(g_dataReg, AssetGraphicSampler);
-    data_reg_field_t(g_dataReg, AssetGraphicSampler, textureId, data_prim_t(String));
+    data_reg_field_t(
+        g_dataReg,
+        AssetGraphicSampler,
+        textureId,
+        data_prim_t(String),
+        .flags = DataFlags_NotEmpty);
     data_reg_field_t(
         g_dataReg, AssetGraphicSampler, wrap, t_AssetGraphicWrap, .flags = DataFlags_Opt);
     data_reg_field_t(
@@ -97,7 +104,8 @@ static void graphic_datareg_init() {
         AssetGraphicComp,
         shaders,
         t_AssetGraphicShader,
-        .container = DataContainer_Array);
+        .container = DataContainer_Array,
+        .flags     = DataFlags_NotEmpty);
     data_reg_field_t(
         g_dataReg,
         AssetGraphicComp,
@@ -106,9 +114,17 @@ static void graphic_datareg_init() {
         .container = DataContainer_Array,
         .flags     = DataFlags_Opt);
     data_reg_field_t(
-        g_dataReg, AssetGraphicComp, meshId, data_prim_t(String), .flags = DataFlags_Opt);
+        g_dataReg,
+        AssetGraphicComp,
+        meshId,
+        data_prim_t(String),
+        .flags = DataFlags_Opt | DataFlags_NotEmpty);
     data_reg_field_t(
-        g_dataReg, AssetGraphicComp, vertexCount, data_prim_t(u32), .flags = DataFlags_Opt);
+        g_dataReg,
+        AssetGraphicComp,
+        vertexCount,
+        data_prim_t(u32),
+        .flags = DataFlags_Opt | DataFlags_NotEmpty);
     data_reg_field_t(
         g_dataReg, AssetGraphicComp, renderOrder, data_prim_t(i32), .flags = DataFlags_Opt);
     data_reg_field_t(
@@ -116,7 +132,11 @@ static void graphic_datareg_init() {
     data_reg_field_t(
         g_dataReg, AssetGraphicComp, rasterizer, t_AssetGraphicRasterizer, .flags = DataFlags_Opt);
     data_reg_field_t(
-        g_dataReg, AssetGraphicComp, lineWidth, data_prim_t(u32), .flags = DataFlags_Opt);
+        g_dataReg,
+        AssetGraphicComp,
+        lineWidth,
+        data_prim_t(u32),
+        .flags = DataFlags_Opt | DataFlags_NotEmpty);
     data_reg_field_t(
         g_dataReg, AssetGraphicComp, blend, t_AssetGraphicBlend, .flags = DataFlags_Opt);
     data_reg_field_t(
@@ -183,19 +203,11 @@ ecs_system_define(LoadGraphicAssetSys) {
 
     // Resolve shader references.
     array_ptr_for_t(graphicComp->shaders, AssetGraphicShader, ptr) {
-      if (string_is_empty(ptr->shaderId)) {
-        graphic_load_fail(world, entity, string_lit("Missing shader asset"));
-        goto Error;
-      }
       ptr->shader = asset_lookup(world, manager, ptr->shaderId);
     }
 
     // Resolve texture references.
     array_ptr_for_t(graphicComp->samplers, AssetGraphicSampler, ptr) {
-      if (string_is_empty(ptr->textureId)) {
-        graphic_load_fail(world, entity, string_lit("Missing texture asset"));
-        goto Error;
-      }
       ptr->texture = asset_lookup(world, manager, ptr->textureId);
     }
 

--- a/libs/core/include/core_memory.h
+++ b/libs/core/include/core_memory.h
@@ -182,6 +182,11 @@ bool mem_eq(Mem a, Mem b);
 bool mem_contains(Mem, u8 byte);
 
 /**
+ * Check if all bytes in the memory region are equal to a specific byte.
+ */
+bool mem_all(Mem, u8 byte);
+
+/**
  * Swap the memory contents.
  * Pre-condition: a.size == b.size
  * Pre-condition: a.size <= 1024.

--- a/libs/core/src/memory.c
+++ b/libs/core/src/memory.c
@@ -137,6 +137,15 @@ bool mem_contains(const Mem mem, const u8 byte) {
   return false;
 }
 
+bool mem_all(Mem mem, const u8 byte) {
+  mem_for_u8(mem, itr) {
+    if (*itr != byte) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void mem_swap(const Mem a, const Mem b) {
   diag_assert(mem_valid(a));
   diag_assert(mem_valid(b));

--- a/libs/core/test/test_memory.c
+++ b/libs/core/test/test_memory.c
@@ -184,6 +184,26 @@ spec(memory) {
     check(!mem_contains(mem, 0));
   }
 
+  it("can check if all bytes are equal to specific byte") {
+    Mem memA = array_mem(((u8[]){
+        1,
+        1,
+        1,
+    }));
+
+    check(!mem_all(memA, 0));
+    check(mem_all(memA, 1));
+
+    Mem memB = array_mem(((u8[]){
+        1,
+        2,
+        3,
+    }));
+    check(!mem_all(memB, 1));
+    check(!mem_all(memB, 2));
+    check(!mem_all(memB, 3));
+  }
+
   it("can create a dynamicly sized allocation on the stack") {
     Rng* rng = rng_create_xorwow(g_alloc_scratch, 42);
 

--- a/libs/data/include/data_read.h
+++ b/libs/data/include/data_read.h
@@ -10,6 +10,7 @@ typedef enum {
   DataReadError_InvalidField,
   DataReadError_NumberOutOfBounds,
   DataReadError_ZeroIsInvalid,
+  DataReadError_EmptyStringIsInvalid,
 } DataReadError;
 
 /**

--- a/libs/data/include/data_read.h
+++ b/libs/data/include/data_read.h
@@ -11,6 +11,7 @@ typedef enum {
   DataReadError_NumberOutOfBounds,
   DataReadError_ZeroIsInvalid,
   DataReadError_EmptyStringIsInvalid,
+  DataReadError_EmptyArrayIsInvalid,
 } DataReadError;
 
 /**

--- a/libs/data/include/data_read.h
+++ b/libs/data/include/data_read.h
@@ -9,6 +9,7 @@ typedef enum {
   DataReadError_FieldNotFound,
   DataReadError_InvalidField,
   DataReadError_NumberOutOfBounds,
+  DataReadError_ZeroIsInvalid,
 } DataReadError;
 
 /**

--- a/libs/data/include/data_read.h
+++ b/libs/data/include/data_read.h
@@ -11,6 +11,7 @@ typedef enum {
   DataReadError_NumberOutOfBounds,
   DataReadError_ZeroIsInvalid,
   DataReadError_EmptyStringIsInvalid,
+  DataReadError_NullIsInvalid,
   DataReadError_EmptyArrayIsInvalid,
 } DataReadError;
 

--- a/libs/data/include/data_registry.h
+++ b/libs/data/include/data_registry.h
@@ -13,8 +13,9 @@ typedef enum {
 } DataContainer;
 
 typedef enum {
-  DataFlags_None = 0,
-  DataFlags_Opt  = 1 << 0,
+  DataFlags_None     = 0,
+  DataFlags_Opt      = 1 << 0,
+  DataFlags_NotEmpty = 1 << 1,
 } DataFlags;
 
 /**

--- a/libs/data/src/read_json.c
+++ b/libs/data/src/read_json.c
@@ -289,8 +289,12 @@ static void data_read_json_val_array(const ReadCtx* ctx, DataReadResult* res) {
   const DataDecl* decl  = data_decl(ctx->reg, ctx->meta.type);
   const usize     count = json_elem_count(ctx->doc, ctx->val);
   if (!count) {
-    *mem_as_t(ctx->data, DataArray) = (DataArray){0};
-    *res                            = result_success();
+    if (UNLIKELY(ctx->meta.flags & DataFlags_NotEmpty)) {
+      *res = result_fail(DataReadError_EmptyArrayIsInvalid, "Value cannot be an empty array");
+    } else {
+      *mem_as_t(ctx->data, DataArray) = (DataArray){0};
+      *res                            = result_success();
+    }
     return;
   }
 

--- a/libs/data/src/read_json.c
+++ b/libs/data/src/read_json.c
@@ -260,8 +260,12 @@ static void data_read_json_val_single(const ReadCtx* ctx, DataReadResult* res) {
 
 static void data_read_json_val_pointer(const ReadCtx* ctx, DataReadResult* res) {
   if (json_type(ctx->doc, ctx->val) == JsonType_Null) {
-    *mem_as_t(ctx->data, void*) = null;
-    *res                        = result_success();
+    if (UNLIKELY(ctx->meta.flags & DataFlags_NotEmpty)) {
+      *res = result_fail(DataReadError_NullIsInvalid, "Value cannot be null");
+    } else {
+      *mem_as_t(ctx->data, void*) = null;
+      *res                        = result_success();
+    }
     return;
   }
 

--- a/libs/data/test/test_read_json.c
+++ b/libs/data/test/test_read_json.c
@@ -150,6 +150,13 @@ spec(read_json) {
     test_read_fail(_testCtx, reg, string_lit("true"), meta, DataReadError_MismatchedType);
   }
 
+  it("fails when a pointer value cannot be empty") {
+    const DataMeta meta = data_meta_t(
+        data_prim_t(u32), .container = DataContainer_Pointer, .flags = DataFlags_NotEmpty);
+
+    test_read_fail(_testCtx, reg, string_lit("null"), meta, DataReadError_NullIsInvalid);
+  }
+
   it("can read an array") {
     const DataMeta meta = data_meta_t(data_prim_t(u32), .container = DataContainer_Array);
 

--- a/libs/data/test/test_read_json.c
+++ b/libs/data/test/test_read_json.c
@@ -176,6 +176,13 @@ spec(read_json) {
     test_read_fail(_testCtx, reg, string_lit("null"), meta, DataReadError_MismatchedType);
   }
 
+  it("fails when an array value cannot be empty") {
+    const DataMeta meta = data_meta_t(
+        data_prim_t(u32), .container = DataContainer_Array, .flags = DataFlags_NotEmpty);
+
+    test_read_fail(_testCtx, reg, string_lit("[]"), meta, DataReadError_EmptyArrayIsInvalid);
+  }
+
   it("can read an enum") {
     typedef enum {
       ReadJsonTestEnum_A = -42,

--- a/libs/data/test/test_read_json.c
+++ b/libs/data/test/test_read_json.c
@@ -96,7 +96,7 @@ spec(read_json) {
     }
   }
 
-  it("fails when a value cannot be empty but the number is zero") {
+  it("fails when a number value cannot be empty") {
     static const struct {
       String   input;
       DataKind prim;
@@ -128,6 +128,12 @@ spec(read_json) {
     check_eq_string(val, string_empty);
 
     test_read_fail(_testCtx, reg, string_lit("null"), meta, DataReadError_MismatchedType);
+  }
+
+  it("fails when a string value cannot be empty") {
+    const DataMeta meta = data_meta_t(data_prim_t(String), .flags = DataFlags_NotEmpty);
+
+    test_read_fail(_testCtx, reg, string_lit("\"\""), meta, DataReadError_EmptyStringIsInvalid);
   }
 
   it("can read a pointer") {


### PR DESCRIPTION
Adds the feature of annotating fields to disallow empty values. Supported for: number, string, pointer, array.