### PR TITLE
scene: Use integers for glyph instance data

### DIFF
--- a/assets/shaders/include/types.glsl
+++ b/assets/shaders/include/types.glsl
@@ -3,6 +3,16 @@
 
 #extension GL_EXT_shader_16bit_storage : enable
 
+#define i16 int16_t
+#define i16_vec2 i16vec2
+#define i16_vec3 i16vec3
+#define i16_vec4 i16vec4
+
+#define u16 uint16_t
+#define u16_vec2 u16vec2
+#define u16_vec3 u16vec3
+#define u16_vec4 u16vec4
+
 #define i32 int
 #define i32_vec2 ivec2
 #define i32_vec3 ivec3

--- a/assets/shaders/ui/text.vert
+++ b/assets/shaders/ui/text.vert
@@ -31,11 +31,10 @@ bind_spec(0) const u32 s_maxGlyphs = 4096;
  * byte struct (to meet the 16 byte alignment requirement).
  */
 struct GlyphPackedData {
-  f16_vec4 a, b; // x, y = position, z = size, w = glyphIndex / glyphPerAtlas.
+  u16_vec4 a, b; // x, y = position, z = size, w = glyphIndex.
 };
 
 struct FontData {
-  f32      glyphsInFont; // glyphsPerDim * glyphsPerDim
   f32      glyphsPerDim;
   f32      invGlyphsPerDim; // 1,0 / glyphsPerDim
   f32_vec4 color;
@@ -53,22 +52,22 @@ bind_internal(1) out flat f32_vec4 out_color;
 /**
  * Retrieve the glyph-data for the given glyph-index.
  */
-f32_vec4 glyph_data(const u32 glyphIndex) {
+u32_vec4 glyph_data(const u32 glyphIndex) {
   /**
    * Find the glyph-tuple (as they are stored in sets of 2) and then retrieve the correct entry.
    */
   const u32  packedIndex = glyphIndex / 2;
   const bool useA        = glyphIndex % 2 == 0;
-  return useA ? f32_vec4(u_packedGlyphs[packedIndex].a) : f32_vec4(u_packedGlyphs[packedIndex].b);
+  return useA ? u32_vec4(u_packedGlyphs[packedIndex].a) : u32_vec4(u_packedGlyphs[packedIndex].b);
 }
 
 void main() {
   const u32      glyphIndex = in_vertexIndex / c_verticesPerGlyph;
   const u32      vertIndex  = in_vertexIndex % c_verticesPerGlyph;
-  const f32_vec4 glyphData  = glyph_data(glyphIndex);
-  const f32_vec2 glyphPos   = glyphData.xy;
-  const f32      glyphSize  = glyphData.z;
-  const f32      atlasIndex = glyphData.w * u_font.glyphsInFont;
+  const u32_vec4 glyphData  = glyph_data(glyphIndex);
+  const u32_vec2 glyphPos   = glyphData.xy;
+  const u32      glyphSize  = glyphData.z;
+  const u32      atlasIndex = glyphData.w;
 
   /**
    * Compute the ui positions of the vertices.

--- a/assets/shaders/ui/text.vert
+++ b/assets/shaders/ui/text.vert
@@ -31,7 +31,7 @@ bind_spec(0) const u32 s_maxGlyphs = 4096;
  * byte struct (to meet the 16 byte alignment requirement).
  */
 struct GlyphPackedData {
-  u16_vec4 a, b; // x, y = position, z = size, w = glyphIndex.
+  i16_vec4 a, b; // x, y = position, z = size, w = glyphIndex.
 };
 
 struct FontData {
@@ -52,22 +52,22 @@ bind_internal(1) out flat f32_vec4 out_color;
 /**
  * Retrieve the glyph-data for the given glyph-index.
  */
-u32_vec4 glyph_data(const u32 glyphIndex) {
+i32_vec4 glyph_data(const u32 glyphIndex) {
   /**
    * Find the glyph-tuple (as they are stored in sets of 2) and then retrieve the correct entry.
    */
   const u32  packedIndex = glyphIndex / 2;
   const bool useA        = glyphIndex % 2 == 0;
-  return useA ? u32_vec4(u_packedGlyphs[packedIndex].a) : u32_vec4(u_packedGlyphs[packedIndex].b);
+  return useA ? i32_vec4(u_packedGlyphs[packedIndex].a) : i32_vec4(u_packedGlyphs[packedIndex].b);
 }
 
 void main() {
   const u32      glyphIndex = in_vertexIndex / c_verticesPerGlyph;
   const u32      vertIndex  = in_vertexIndex % c_verticesPerGlyph;
-  const u32_vec4 glyphData  = glyph_data(glyphIndex);
-  const u32_vec2 glyphPos   = glyphData.xy;
-  const u32      glyphSize  = glyphData.z;
-  const u32      atlasIndex = glyphData.w;
+  const i32_vec4 glyphData  = glyph_data(glyphIndex);
+  const i32_vec2 glyphPos   = glyphData.xy;
+  const i32      glyphSize  = glyphData.z;
+  const i32      atlasIndex = glyphData.w;
 
   /**
    * Compute the ui positions of the vertices.

--- a/libs/scene/src/text.c
+++ b/libs/scene/src/text.c
@@ -31,9 +31,9 @@ ASSERT(sizeof(ShaderFontData) == 32, "Size needs to match the size defined in gl
 
 typedef struct {
   ALIGNAS(8)
-  u16 position[2];
-  u16 size;
-  u16 index;
+  i16 position[2];
+  i16 size;
+  i16 index;
 } ShaderGlyphData;
 
 ASSERT(sizeof(ShaderGlyphData) == 8, "Size needs to match the size defined in glsl");
@@ -90,11 +90,11 @@ static void scene_text_build_char(SceneTextBuilder* builder, const Unicode cp) {
     builder->outputGlyphData[builder->outputGlyphCount++] = (ShaderGlyphData){
         .position =
             {
-                (u16)(ch->offsetX * builder->glyphSize + builder->cursor[0]),
-                (u16)(ch->offsetY * builder->glyphSize + builder->cursor[1]),
+                (i16)(ch->offsetX * builder->glyphSize + builder->cursor[0]),
+                (i16)(ch->offsetY * builder->glyphSize + builder->cursor[1]),
             },
-        .size  = (u16)(ch->size * builder->glyphSize),
-        .index = ch->glyphIndex,
+        .size  = (i16)(ch->size * builder->glyphSize),
+        .index = (i16)ch->glyphIndex,
     };
   }
   builder->cursor[0] += ch->advance * builder->glyphSize;

--- a/libs/scene/src/text.c
+++ b/libs/scene/src/text.c
@@ -14,7 +14,6 @@
 #include "scene_text.h"
 
 #define scene_text_max_glyphs_to_render 4096
-#define scene_text_max_glyphs_in_font 1024
 #define scene_text_tab_size 4
 
 static const String g_textGraphic = string_static("graphics/ui/text.gra");
@@ -22,9 +21,9 @@ static const String g_textFont    = string_static("fonts/mono.ftx");
 
 typedef struct {
   ALIGNAS(16)
-  f32      glyphsInFont;
-  f32      glyphsPerDim, invGlyphsPerDim;
-  f32      padding[1];
+  f32      glyphsPerDim;
+  f32      invGlyphsPerDim;
+  f32      padding[2];
   GeoColor color;
 } ShaderFontData;
 
@@ -32,9 +31,9 @@ ASSERT(sizeof(ShaderFontData) == 32, "Size needs to match the size defined in gl
 
 typedef struct {
   ALIGNAS(8)
-  f16 position[2];
-  f16 size;
-  f16 indexFrac;
+  u16 position[2];
+  u16 size;
+  u16 index;
 } ShaderGlyphData;
 
 ASSERT(sizeof(ShaderGlyphData) == 8, "Size needs to match the size defined in glsl");
@@ -88,15 +87,14 @@ static void scene_text_build_char(SceneTextBuilder* builder, const Unicode cp) {
     /**
      * This character has a glyph, output it to the shader.
      */
-    const f32 glyphsPerAtlas = builder->font->glyphsPerDim * builder->font->glyphsPerDim;
     builder->outputGlyphData[builder->outputGlyphCount++] = (ShaderGlyphData){
-        .indexFrac = bits_f32_to_f16(ch->glyphIndex / (f32)glyphsPerAtlas),
         .position =
             {
-                bits_f32_to_f16(ch->offsetX * builder->glyphSize + builder->cursor[0]),
-                bits_f32_to_f16(ch->offsetY * builder->glyphSize + builder->cursor[1]),
+                (u16)(ch->offsetX * builder->glyphSize + builder->cursor[0]),
+                (u16)(ch->offsetY * builder->glyphSize + builder->cursor[1]),
             },
-        .size = bits_f32_to_f16(ch->size * builder->glyphSize),
+        .size  = (u16)(ch->size * builder->glyphSize),
+        .index = ch->glyphIndex,
     };
   }
   builder->cursor[0] += ch->advance * builder->glyphSize;
@@ -115,16 +113,6 @@ static void scene_text_build(SceneTextBuilder* builder) {
         log_param("maximum", fmt_int(scene_text_max_glyphs_to_render)));
     return;
   }
-  const u32 glyphsInFont = builder->font->glyphsPerDim * builder->font->glyphsPerDim;
-  if (UNLIKELY(glyphsInFont > scene_text_max_glyphs_in_font)) {
-    /**
-     * Sanity check here because we encode the glyph-index as a 16 bit floating point fraction we
-     * might get into trouble with fonts containing many glyphs.
-     */
-    log_w("Font contains more glyphs then are supported");
-    return;
-  }
-
   const usize maxDataSize = sizeof(ShaderFontData) + sizeof(ShaderGlyphData) * codePointsCount;
   Mem         data        = scene_renderable_unique_data_set(builder->renderable, maxDataSize);
 
@@ -132,7 +120,6 @@ static void scene_text_build(SceneTextBuilder* builder) {
    * Setup per-font data (shared between all glyphs in this text).
    */
   *mem_as_t(data, ShaderFontData) = (ShaderFontData){
-      .glyphsInFont    = glyphsInFont,
       .glyphsPerDim    = builder->font->glyphsPerDim,
       .invGlyphsPerDim = 1.0f / (f32)builder->font->glyphsPerDim,
       .color           = builder->color,


### PR DESCRIPTION
Lifts the limitation on the maximum amount of glyphs in a ftx font and allows us to more easily pack additional data in there in the future.