### PR TITLE
scene: Add scale component

### DIFF
--- a/assets/graphics/demo/bunny.gra
+++ b/assets/graphics/demo/bunny.gra
@@ -1,19 +1,7 @@
 {
   "shaders": [
     {
-      "shaderId": "shaders/standard.vert.spv",
-      "overrides": [
-        {
-          "name": "scale",
-          "binding": 0,
-          "value": 0.75
-        },
-        {
-          "name": "offsetY",
-          "binding": 2,
-          "value": -0.55
-        }
-      ]
+      "shaderId": "shaders/standard.vert.spv"
     },
     {
       "shaderId": "shaders/standard.frag.spv"

--- a/assets/graphics/demo/cayo.gra
+++ b/assets/graphics/demo/cayo.gra
@@ -1,19 +1,7 @@
 {
   "shaders": [
     {
-      "shaderId": "shaders/standard.vert.spv",
-      "overrides": [
-        {
-          "name": "scale",
-          "binding": 0,
-          "value": 0.8
-        },
-        {
-          "name": "offsetY",
-          "binding": 2,
-          "value": -0.52
-        }
-      ]
+      "shaderId": "shaders/standard.vert.spv"
     },
     {
       "shaderId": "shaders/standard.frag.spv",

--- a/assets/graphics/demo/corset.gra
+++ b/assets/graphics/demo/corset.gra
@@ -1,19 +1,7 @@
 {
   "shaders": [
     {
-      "shaderId": "shaders/standard.vert.spv",
-      "overrides": [
-        {
-          "name": "scale",
-          "binding": 0,
-          "value": 0.6
-        },
-        {
-          "name": "offsetY",
-          "binding": 2,
-          "value": -0.52
-        }
-      ]
+      "shaderId": "shaders/standard.vert.spv"
     },
     {
       "shaderId": "shaders/standard.frag.spv",

--- a/assets/graphics/demo/head.gra
+++ b/assets/graphics/demo/head.gra
@@ -1,19 +1,7 @@
 {
   "shaders": [
     {
-      "shaderId": "shaders/standard.vert.spv",
-      "overrides": [
-        {
-          "name": "scale",
-          "binding": 0,
-          "value": 3
-        },
-        {
-          "name": "offsetY",
-          "binding": 2,
-          "value": 0.3
-        }
-      ]
+      "shaderId": "shaders/standard.vert.spv"
     },
     {
       "shaderId": "shaders/standard.frag.spv",

--- a/assets/graphics/demo/head_wire.gra
+++ b/assets/graphics/demo/head_wire.gra
@@ -1,19 +1,7 @@
 {
   "shaders": [
     {
-      "shaderId": "shaders/standard.vert.spv",
-      "overrides": [
-        {
-          "name": "scale",
-          "binding": 0,
-          "value": 3.0
-        },
-        {
-          "name": "offsetY",
-          "binding": 2,
-          "value": 0.3
-        }
-      ]
+      "shaderId": "shaders/standard.vert.spv"
     },
     {
       "shaderId": "shaders/standard.frag.spv",

--- a/assets/graphics/demo/pedestal.gra
+++ b/assets/graphics/demo/pedestal.gra
@@ -1,19 +1,7 @@
 {
   "shaders": [
     {
-      "shaderId": "shaders/standard.vert.spv",
-      "overrides": [
-        {
-          "name": "scale",
-          "binding": 0,
-          "value": 0.4
-        },
-        {
-          "name": "offsetY",
-          "binding": 2,
-          "value": -0.8
-        }
-      ]
+      "shaderId": "shaders/standard.vert.spv"
     },
     {
       "shaderId": "shaders/standard.frag.spv",

--- a/assets/graphics/sphere.gra
+++ b/assets/graphics/sphere.gra
@@ -1,14 +1,7 @@
 {
   "shaders": [
     {
-      "shaderId": "shaders/standard.vert.spv",
-      "overrides": [
-        {
-          "name": "scale",
-          "binding": 0,
-          "value": 0.5
-        }
-      ]
+      "shaderId": "shaders/standard.vert.spv"
     },
     {
       "shaderId": "shaders/standard.frag.spv"

--- a/assets/shaders/include/instance.glsl
+++ b/assets/shaders/include/instance.glsl
@@ -6,8 +6,8 @@
 const u32 c_maxInstances = 2048;
 
 struct InstanceData {
-  f32v4 position; // x, y, z position
-  f32v4 rotation; // x, y, z, w rotation quaternion
+  f32v4 posAndScale; // x, y, z position, w scale
+  f32v4 rot;         // x, y, z, w rotation quaternion
 };
 
 #endif // INCLUDE_INSTANCE

--- a/assets/shaders/standard.vert
+++ b/assets/shaders/standard.vert
@@ -7,11 +7,6 @@
 #include "quat.glsl"
 #include "vertex.glsl"
 
-bind_spec(0) const f32 s_scale   = 1.0;
-bind_spec(1) const f32 s_offsetX = 0.0;
-bind_spec(2) const f32 s_offsetY = 0.0;
-bind_spec(3) const f32 s_offsetZ = 0.0;
-
 bind_global_data(0) readonly uniform Global { GlobalData u_global; };
 bind_graphic_data(0) readonly buffer Mesh { VertexPacked[] u_vertices; };
 bind_instance_data(0) readonly uniform Instance { InstanceData[c_maxInstances] u_instances; };
@@ -23,13 +18,11 @@ bind_internal(2) out f32v2 out_texcoord;
 void main() {
   const Vertex vert = vert_unpack(u_vertices[in_vertexIndex]);
 
-  const f32v3 offset  = f32v3(s_offsetX, s_offsetY, s_offsetZ);
-  const f32v3 meshPos = vert.position * s_scale + offset;
+  const f32v3 instancePos   = u_instances[in_instanceIndex].posAndScale.xyz;
+  const f32   instanceScale = u_instances[in_instanceIndex].posAndScale.w;
+  const f32v4 instanceQuat  = u_instances[in_instanceIndex].rot;
 
-  const f32v3 instancePos  = u_instances[in_instanceIndex].position.xyz;
-  const f32v4 instanceQuat = u_instances[in_instanceIndex].rotation;
-
-  const f32v3 worldPos = quat_rotate(instanceQuat, meshPos) + instancePos;
+  const f32v3 worldPos = quat_rotate(instanceQuat, vert.position * instanceScale) + instancePos;
 
   out_vertexPosition = u_global.viewProj * f32v4(worldPos, 1);
   out_normal         = quat_rotate(instanceQuat, vert.normal);

--- a/libs/scene/include/scene_transform.h
+++ b/libs/scene/include/scene_transform.h
@@ -9,5 +9,7 @@ ecs_comp_extern_public(SceneTransformComp) {
   GeoQuat   rotation;
 };
 
+ecs_comp_extern_public(SceneScaleComp) { f32 scale; };
+
 GeoMatrix scene_transform_matrix(const SceneTransformComp*);
 GeoMatrix scene_transform_matrix_inv(const SceneTransformComp*);

--- a/libs/scene/src/transform.c
+++ b/libs/scene/src/transform.c
@@ -2,7 +2,12 @@
 
 ecs_comp_define_public(SceneTransformComp);
 
-ecs_module_init(scene_transform_module) { ecs_register_comp(SceneTransformComp); }
+ecs_comp_define_public(SceneScaleComp);
+
+ecs_module_init(scene_transform_module) {
+  ecs_register_comp(SceneTransformComp);
+  ecs_register_comp(SceneScaleComp);
+}
 
 GeoMatrix scene_transform_matrix(const SceneTransformComp* trans) {
   const GeoMatrix pos = geo_matrix_translate(trans->position);


### PR DESCRIPTION
Instead of the hacky scale overrides in the vertex shader there now is a `SceneScaleComp` component for specifying instance scale. This will become important when we want to calculate object bounds.