### PR TITLE
rend: Use hardware srgb decoding

### DIFF
--- a/assets/shaders/demo/terrain.frag
+++ b/assets/shaders/demo/terrain.frag
@@ -35,7 +35,7 @@ f32v3 heightmap_normal(const f32v2 uv, const f32 scale) {
 }
 
 void main() {
-  const f32v4 diffuse      = texture_sample_srgb(u_texDiffuse, in_texcoord);
+  const f32v4 diffuse      = texture(u_texDiffuse, in_texcoord);
   const f32v3 worldViewDir = quat_rotate(u_global.camRotation, f32v3(0, 0, 1));
 
   const f32v3 localNormal = heightmap_normal(in_texcoord, s_heightMapScale);

--- a/assets/shaders/include/texture.glsl
+++ b/assets/shaders/include/texture.glsl
@@ -5,27 +5,11 @@
 #include "types.glsl"
 
 /**
- * Sample a linear encoded texture.
+ * Sample a cubemap.
  */
-f32v4 texture_sample_linear(const sampler2D tex, const f32v2 texcoord) {
-  return texture(tex, texcoord);
-}
-
-/**
- * Sample a srgb encoded texture.
- */
-f32v4 texture_sample_srgb(const sampler2D tex, const f32v2 texcoord) {
-  const f32v4 raw = texture_sample_linear(tex, texcoord);
-  return f32v4(color_decode_srgb(raw.rgb), raw.a);
-}
-
-/**
- * Sample a srgb encoded cubemap.
- */
-f32v4 texture_cube_srgb(const samplerCube tex, const f32v3 direction) {
+f32v4 texture_cube(const samplerCube tex, const f32v3 direction) {
   // NOTE: Flip the Y component as we are using the bottom as the texture origin.
-  const f32v4 raw = texture(tex, f32v3(direction.x, -direction.y, direction.z));
-  return f32v4(color_decode_srgb(raw.rgb), raw.a);
+  return texture(tex, f32v3(direction.x, -direction.y, direction.z));
 }
 
 /**
@@ -33,7 +17,7 @@ f32v4 texture_cube_srgb(const samplerCube tex, const f32v3 direction) {
  * normal and tangent references, 'w' component of the tangent indicates the handedness.
  * NOTE: normalRef and tangentRef are not required to be unit vectors.
  */
-f32v3 texture_sample_normal(
+f32v3 texture_normal(
     const sampler2D normalSampler,
     const f32v2     texcoord,
     const f32v3     normalRef,

--- a/assets/shaders/scene/sky_cubemap.frag
+++ b/assets/shaders/scene/sky_cubemap.frag
@@ -10,4 +10,4 @@ bind_internal(0) in f32v3 in_worldViewDir; // NOTE: non-normalized
 
 bind_internal(0) out f32v4 out_color;
 
-void main() { out_color = texture_cube_srgb(u_texCubeMap, in_worldViewDir); }
+void main() { out_color = texture_cube(u_texCubeMap, in_worldViewDir); }

--- a/assets/shaders/standard.frag
+++ b/assets/shaders/standard.frag
@@ -27,7 +27,7 @@ bind_internal(0) out f32v4 out_color;
 
 f32v3 surface_normal() {
   if (s_normalMap) {
-    return texture_sample_normal(u_texNormal, in_texcoord, in_worldNormal, in_worldTangent);
+    return texture_normal(u_texNormal, in_texcoord, in_worldNormal, in_worldTangent);
   }
   return normalize(in_worldNormal);
 }
@@ -35,13 +35,13 @@ f32v3 surface_normal() {
 f32v4 compute_reflection(const f32v4 diffuse, const f32v3 normal, const f32v3 viewDir) {
   if (s_reflectSkybox) {
     const f32v3 dir = reflect(viewDir, normal);
-    return mix(diffuse, texture_cube_srgb(u_cubeSkybox, dir), s_reflectFrac);
+    return mix(diffuse, texture_cube(u_cubeSkybox, dir), s_reflectFrac);
   }
   return diffuse;
 }
 
 void main() {
-  const f32v4   diffuse = texture_sample_srgb(u_texDiffuse, in_texcoord);
+  const f32v4   diffuse = texture(u_texDiffuse, in_texcoord);
   const f32v3   normal  = surface_normal();
   const f32v3   viewDir = normalize(in_worldPosition - u_global.camPosition.xyz);
   const Shading shading = s_shade ? light_shade_blingphong(normal, viewDir) : light_shade_flat();

--- a/assets/shaders/ui/text.frag
+++ b/assets/shaders/ui/text.frag
@@ -34,7 +34,7 @@ f32 get_color_frac(const f32 dist) {
 }
 
 void main() {
-  const f32   dist  = texture_sample_linear(u_fontTexture, in_texcoord).r;
+  const f32   dist  = texture(u_fontTexture, in_texcoord).r;
   const f32v3 color = mix(c_outlineColor.rgb, in_color.rgb, get_color_frac(dist));
   out_color         = f32v4(color, in_color.a * get_glyph_alpha(dist));
 }

--- a/assets/shaders/ui/texture.frag
+++ b/assets/shaders/ui/texture.frag
@@ -10,4 +10,4 @@ bind_internal(0) in f32v2 in_texcoord;
 
 bind_internal(0) out f32v4 out_color;
 
-void main() { out_color = texture_sample_srgb(u_tex, in_texcoord); }
+void main() { out_color = texture(u_tex, in_texcoord); }

--- a/libs/asset/include/asset_texture.h
+++ b/libs/asset/include/asset_texture.h
@@ -28,8 +28,9 @@ typedef enum {
 } AssetTextureChannels;
 
 typedef enum {
-  AssetTextureFlags_MipMaps = 1 << 0,
-  AssetTextureFlags_CubeMap = 1 << 1,
+  AssetTextureFlags_Srgb    = 1 << 0,
+  AssetTextureFlags_MipMaps = 1 << 1,
+  AssetTextureFlags_CubeMap = 1 << 2,
 } AssetTextureFlags;
 
 ecs_comp_extern_public(AssetTextureComp) {

--- a/libs/asset/include/asset_texture.h
+++ b/libs/asset/include/asset_texture.h
@@ -28,9 +28,10 @@ typedef enum {
 } AssetTextureChannels;
 
 typedef enum {
-  AssetTextureFlags_Srgb    = 1 << 0,
-  AssetTextureFlags_MipMaps = 1 << 1,
-  AssetTextureFlags_CubeMap = 1 << 2,
+  AssetTextureFlags_Srgb      = 1 << 0,
+  AssetTextureFlags_MipMaps   = 1 << 1,
+  AssetTextureFlags_CubeMap   = 1 << 2,
+  AssetTextureFlags_NormalMap = 1 << 3,
 } AssetTextureFlags;
 
 ecs_comp_extern_public(AssetTextureComp) {

--- a/libs/asset/src/loader.c
+++ b/libs/asset/src/loader.c
@@ -6,7 +6,7 @@
 
 AssetLoader asset_loader(const AssetFormat format) {
 #define RET_LOADER(_NAME_)                                                                         \
-  void asset_loader_name(_NAME_)(EcsWorld*, EcsEntityId, AssetSource*);                            \
+  void asset_loader_name(_NAME_)(EcsWorld*, String, EcsEntityId, AssetSource*);                    \
   return &asset_loader_name(_NAME_)
 
   switch (format) {

--- a/libs/asset/src/loader_font_ttf.c
+++ b/libs/asset/src/loader_font_ttf.c
@@ -1049,7 +1049,9 @@ static void ttf_load_fail(EcsWorld* world, const EcsEntityId entity, const TtfEr
   ecs_world_add_empty_t(world, entity, AssetFailedComp);
 }
 
-void asset_load_ttf(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_ttf(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
+
   TtfError            err                = TtfError_None;
   DynArray            characters         = dynarray_create_t(g_alloc_heap, AssetFontChar, 128);
   DynArray            points             = dynarray_create_t(g_alloc_heap, AssetFontPoint, 1024);

--- a/libs/asset/src/loader_ftx.c
+++ b/libs/asset/src/loader_ftx.c
@@ -212,12 +212,12 @@ static void ftx_generate(
      */
     const f32 border = def->border / (f32)def->glyphSize;
     chars[i]         = (AssetFtxChar){
-        .cp         = inputChars[i].cp,
-        .glyphIndex = inputChars[i].glyph->segmentCount ? nextGlyphIndex : sentinel_u32,
-        .size       = inputChars[i].glyph->size + border * 2.0f,
-        .offsetX    = inputChars[i].glyph->offsetX - border,
-        .offsetY    = inputChars[i].glyph->offsetY - border,
-        .advance    = inputChars[i].glyph->advance,
+                .cp         = inputChars[i].cp,
+                .glyphIndex = inputChars[i].glyph->segmentCount ? nextGlyphIndex : sentinel_u32,
+                .size       = inputChars[i].glyph->size + border * 2.0f,
+                .offsetX    = inputChars[i].glyph->offsetX - border,
+                .offsetY    = inputChars[i].glyph->offsetY - border,
+                .advance    = inputChars[i].glyph->advance,
     };
     if (inputChars[i].glyph->segmentCount) {
       if (UNLIKELY(nextGlyphIndex >= maxGlyphs)) {
@@ -351,7 +351,9 @@ ecs_module_init(asset_ftx_module) {
   ecs_register_system(FtxUnloadAssetSys, ecs_view_id(FtxUnloadView));
 }
 
-void asset_load_ftx(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_ftx(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
+
   String         errMsg;
   FtxDef         def;
   DataReadResult result;

--- a/libs/asset/src/loader_graphic.c
+++ b/libs/asset/src/loader_graphic.c
@@ -209,6 +209,7 @@ ecs_module_init(asset_graphic_module) {
   ecs_register_system(UnloadGraphicAssetSys, ecs_view_id(UnloadView));
 }
 
-void asset_load_gra(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_gra(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
   ecs_world_add_t(world, entity, AssetGraphicLoadComp, .src = src);
 }

--- a/libs/asset/src/loader_internal.h
+++ b/libs/asset/src/loader_internal.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "repo_internal.h"
 
-typedef void (*AssetLoader)(EcsWorld*, EcsEntityId assetEntity, AssetSource*);
+typedef void (*AssetLoader)(EcsWorld*, String id, EcsEntityId assetEntity, AssetSource*);
 
 AssetLoader asset_loader(AssetFormat);

--- a/libs/asset/src/loader_mesh_obj.c
+++ b/libs/asset/src/loader_mesh_obj.c
@@ -357,10 +357,13 @@ static void obj_load_fail(EcsWorld* world, const EcsEntityId entity, const ObjEr
   ecs_world_add_empty_t(world, entity, AssetFailedComp);
 }
 
-void asset_load_obj(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_obj(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
+
   ObjError          err     = ObjError_None;
   AssetMeshBuilder* builder = null;
-  ObjData           data    = {
+
+  ObjData data = {
       .positions = dynarray_create_t(g_alloc_heap, GeoVector, 64),
       .texcoords = dynarray_create_t(g_alloc_heap, GeoVector, 64),
       .normals   = dynarray_create_t(g_alloc_heap, GeoVector, 64),

--- a/libs/asset/src/loader_mesh_pme.c
+++ b/libs/asset/src/loader_mesh_pme.c
@@ -383,7 +383,8 @@ static String pme_error_str(const PmeError err) {
   return g_msgs[err];
 }
 
-void asset_load_pme(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_pme(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
   pme_datareg_init();
 
   String            errMsg;

--- a/libs/asset/src/loader_raw.c
+++ b/libs/asset/src/loader_raw.c
@@ -39,7 +39,9 @@ ecs_module_init(asset_raw_module) {
   ecs_register_system(UnloadRawAssetSys, ecs_view_id(UnloadView));
 }
 
-void asset_load_raw(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_raw(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
+
   ecs_world_add_t(world, entity, AssetRawComp, .data = src->data);
   ecs_world_add_t(world, entity, AssetRawSourceComp, .src = src);
   ecs_world_add_empty_t(world, entity, AssetLoadedComp);

--- a/libs/asset/src/loader_shader_spv.c
+++ b/libs/asset/src/loader_shader_spv.c
@@ -548,7 +548,9 @@ static void spv_load_fail(EcsWorld* world, const EcsEntityId entity, const SpvEr
   ecs_world_add_empty_t(world, entity, AssetFailedComp);
 }
 
-void asset_load_spv(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_spv(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
+
   /**
    * SpirV consists of 32 bit words so we interpret the file as a set of 32 bit words.
    * TODO: Convert to big-endian in case we're running on a big-endian system.

--- a/libs/asset/src/loader_texture.c
+++ b/libs/asset/src/loader_texture.c
@@ -1,7 +1,9 @@
 #include "asset_texture.h"
 #include "core_alloc.h"
+#include "core_array.h"
 #include "core_diag.h"
 #include "core_math.h"
+#include "core_string.h"
 #include "ecs_world.h"
 
 #include "repo_internal.h"
@@ -52,4 +54,17 @@ Mem asset_texture_data(const AssetTextureComp* texture) {
   const usize layerCount = math_max(1, texture->layers);
   const usize dataSize   = asset_texture_pixel_size(texture) * pixelCount * layerCount;
   return mem_create(texture->pixelsRaw, dataSize);
+}
+
+bool asset_texture_is_normalmap(const String id) {
+  const static String g_patterns[] = {
+      string_static("*_nrm.*"),
+      string_static("*_normal.*"),
+  };
+  array_for_t(g_patterns, String, pattern) {
+    if (string_match_glob(id, *pattern, StringMatchFlags_IgnoreCase)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/libs/asset/src/loader_texture.c
+++ b/libs/asset/src/loader_texture.c
@@ -57,7 +57,7 @@ Mem asset_texture_data(const AssetTextureComp* texture) {
 }
 
 bool asset_texture_is_normalmap(const String id) {
-  const static String g_patterns[] = {
+  static const String g_patterns[] = {
       string_static("*_nrm.*"),
       string_static("*_normal.*"),
   };

--- a/libs/asset/src/loader_texture_atx.c
+++ b/libs/asset/src/loader_texture_atx.c
@@ -277,7 +277,9 @@ ecs_module_init(asset_atx_module) {
       AtxLoadAssetSys, ecs_view_id(ManagerView), ecs_view_id(LoadView), ecs_view_id(TextureView));
 }
 
-void asset_load_atx(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_atx(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
+
   String         errMsg;
   AtxDef         def;
   DataReadResult result;

--- a/libs/asset/src/loader_texture_atx.c
+++ b/libs/asset/src/loader_texture_atx.c
@@ -144,7 +144,7 @@ static void atx_generate(
       *err = AtxError_MismatchChannels;
       return;
     }
-    if (UNLIKELY(srgb != (textures[i]->flags & AssetTextureFlags_Srgb) != 0)) {
+    if (UNLIKELY(srgb != ((textures[i]->flags & AssetTextureFlags_Srgb) != 0))) {
       *err = AtxError_MismatchEncoding;
       return;
     }

--- a/libs/asset/src/loader_texture_internal.h
+++ b/libs/asset/src/loader_texture_internal.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "core_string.h"
+
+/**
+ * Check if the given asset-id is a normalmap.
+ * NOTE: This uses a naming convention based detection (ending with nrm or normal).
+ */
+bool asset_texture_is_normalmap(String id);

--- a/libs/asset/src/loader_texture_ppm.c
+++ b/libs/asset/src/loader_texture_ppm.c
@@ -211,7 +211,7 @@ void asset_load_ppm(EcsWorld* world, const EcsEntityId entity, AssetSource* src)
       AssetTextureComp,
       .type     = AssetTextureType_Byte,
       .channels = AssetTextureChannels_Four,
-      .flags    = AssetTextureFlags_MipMaps,
+      .flags    = AssetTextureFlags_Srgb | AssetTextureFlags_MipMaps,
       .width    = width,
       .height   = height,
       .pixelsB4 = pixels);

--- a/libs/asset/src/loader_texture_ppm.c
+++ b/libs/asset/src/loader_texture_ppm.c
@@ -5,6 +5,7 @@
 #include "ecs_world.h"
 #include "log_logger.h"
 
+#include "loader_texture_internal.h"
 #include "repo_internal.h"
 
 /**
@@ -171,8 +172,18 @@ static void ppm_load_fail(EcsWorld* world, const EcsEntityId entity, const Pixma
   ecs_world_add_empty_t(world, entity, AssetFailedComp);
 }
 
+static AssetTextureFlags ppm_texture_flags(const bool isNormalmap) {
+  AssetTextureFlags flags = AssetTextureFlags_MipMaps;
+  if (isNormalmap) {
+    flags |= AssetTextureFlags_NormalMap;
+  } else {
+    flags |= AssetTextureFlags_Srgb;
+  }
+  return flags;
+}
+
 void asset_load_ppm(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
-  (void)id;
+  const bool isNormalmap = asset_texture_is_normalmap(id);
 
   String      input = src->data;
   PixmapError res   = PixmapError_None;
@@ -213,7 +224,7 @@ void asset_load_ppm(EcsWorld* world, const String id, const EcsEntityId entity, 
       AssetTextureComp,
       .type     = AssetTextureType_Byte,
       .channels = AssetTextureChannels_Four,
-      .flags    = AssetTextureFlags_Srgb | AssetTextureFlags_MipMaps,
+      .flags    = ppm_texture_flags(isNormalmap),
       .width    = width,
       .height   = height,
       .pixelsB4 = pixels);

--- a/libs/asset/src/loader_texture_ppm.c
+++ b/libs/asset/src/loader_texture_ppm.c
@@ -171,7 +171,9 @@ static void ppm_load_fail(EcsWorld* world, const EcsEntityId entity, const Pixma
   ecs_world_add_empty_t(world, entity, AssetFailedComp);
 }
 
-void asset_load_ppm(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_ppm(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
+
   String      input = src->data;
   PixmapError res   = PixmapError_None;
 

--- a/libs/asset/src/loader_texture_ptx.c
+++ b/libs/asset/src/loader_texture_ptx.c
@@ -212,7 +212,8 @@ static void ptx_generate(const PtxDef* def, AssetTextureComp* outTexture) {
   };
 }
 
-void asset_load_ptx(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_ptx(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
   ptx_datareg_init();
 
   String         errMsg;

--- a/libs/asset/src/loader_texture_r32.c
+++ b/libs/asset/src/loader_texture_r32.c
@@ -37,7 +37,9 @@ static void raw32_load_fail(EcsWorld* world, const EcsEntityId entity, const Raw
   ecs_world_add_empty_t(world, entity, AssetFailedComp);
 }
 
-void asset_load_r32(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_r32(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
+
   if (src->data.size % sizeof(f32)) {
     raw32_load_fail(world, entity, Raw32Error_Corrupt);
     goto Error;

--- a/libs/asset/src/loader_texture_tga.c
+++ b/libs/asset/src/loader_texture_tga.c
@@ -259,7 +259,9 @@ static void tga_load_fail(EcsWorld* world, const EcsEntityId entity, const TgaEr
   ecs_world_add_empty_t(world, entity, AssetFailedComp);
 }
 
-void asset_load_tga(EcsWorld* world, const EcsEntityId entity, AssetSource* src) {
+void asset_load_tga(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
+  (void)id;
+
   Mem      data  = src->data;
   TgaError res   = TgaError_None;
   TgaFlags flags = 0;

--- a/libs/asset/src/loader_texture_tga.c
+++ b/libs/asset/src/loader_texture_tga.c
@@ -332,7 +332,7 @@ void asset_load_tga(EcsWorld* world, const EcsEntityId entity, AssetSource* src)
       AssetTextureComp,
       .type     = AssetTextureType_Byte,
       .channels = AssetTextureChannels_Four,
-      .flags    = AssetTextureFlags_MipMaps,
+      .flags    = AssetTextureFlags_Srgb | AssetTextureFlags_MipMaps,
       .width    = width,
       .height   = height,
       .pixelsB4 = pixels);

--- a/libs/asset/src/loader_texture_tga.c
+++ b/libs/asset/src/loader_texture_tga.c
@@ -5,6 +5,7 @@
 #include "ecs_world.h"
 #include "log_logger.h"
 
+#include "loader_texture_internal.h"
 #include "repo_internal.h"
 
 /**
@@ -259,8 +260,18 @@ static void tga_load_fail(EcsWorld* world, const EcsEntityId entity, const TgaEr
   ecs_world_add_empty_t(world, entity, AssetFailedComp);
 }
 
+static AssetTextureFlags tga_texture_flags(const bool isNormalmap) {
+  AssetTextureFlags flags = AssetTextureFlags_MipMaps;
+  if (isNormalmap) {
+    flags |= AssetTextureFlags_NormalMap;
+  } else {
+    flags |= AssetTextureFlags_Srgb;
+  }
+  return flags;
+}
+
 void asset_load_tga(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
-  (void)id;
+  const bool isNormalmap = asset_texture_is_normalmap(id);
 
   Mem      data  = src->data;
   TgaError res   = TgaError_None;
@@ -334,7 +345,7 @@ void asset_load_tga(EcsWorld* world, const String id, const EcsEntityId entity, 
       AssetTextureComp,
       .type     = AssetTextureType_Byte,
       .channels = AssetTextureChannels_Four,
-      .flags    = AssetTextureFlags_Srgb | AssetTextureFlags_MipMaps,
+      .flags    = tga_texture_flags(isNormalmap),
       .width    = width,
       .height   = height,
       .pixelsB4 = pixels);

--- a/libs/asset/src/manager.c
+++ b/libs/asset/src/manager.c
@@ -105,7 +105,7 @@ static bool asset_manager_load(
       log_param("size", fmt_size(source->data.size)));
 
   AssetLoader loader = asset_loader(source->format);
-  loader(world, assetEntity, source);
+  loader(world, asset->id, assetEntity, source);
   return true;
 }
 


### PR DESCRIPTION
Instead of treating all textures as linear (and doing the srgb decode in the shaders) we now use hardware srgb formats where applicable. This does mean we need to detect normal maps (at the moment they are detected based on a naming convention).