### PR TITLE
asset: Track upwards dependencies

### DIFF
--- a/libs/asset/src/loader_ftx.c
+++ b/libs/asset/src/loader_ftx.c
@@ -15,6 +15,7 @@
 #include "ecs_world.h"
 #include "log_logger.h"
 
+#include "manager_internal.h"
 #include "repo_internal.h"
 
 /**
@@ -212,12 +213,12 @@ static void ftx_generate(
      */
     const f32 border = def->border / (f32)def->glyphSize;
     chars[i]         = (AssetFtxChar){
-                .cp         = inputChars[i].cp,
-                .glyphIndex = inputChars[i].glyph->segmentCount ? nextGlyphIndex : sentinel_u32,
-                .size       = inputChars[i].glyph->size + border * 2.0f,
-                .offsetX    = inputChars[i].glyph->offsetX - border,
-                .offsetY    = inputChars[i].glyph->offsetY - border,
-                .advance    = inputChars[i].glyph->advance,
+        .cp         = inputChars[i].cp,
+        .glyphIndex = inputChars[i].glyph->segmentCount ? nextGlyphIndex : sentinel_u32,
+        .size       = inputChars[i].glyph->size + border * 2.0f,
+        .offsetX    = inputChars[i].glyph->offsetX - border,
+        .offsetY    = inputChars[i].glyph->offsetY - border,
+        .advance    = inputChars[i].glyph->advance,
     };
     if (inputChars[i].glyph->segmentCount) {
       if (UNLIKELY(nextGlyphIndex >= maxGlyphs)) {
@@ -280,6 +281,7 @@ ecs_system_define(FtxLoadAssetSys) {
     if (!load->font) {
       load->font = asset_lookup(world, manager, load->def.fontId);
       asset_acquire(world, load->font);
+      asset_register_dep(world, entity, load->font);
     }
     if (ecs_world_has_t(world, load->font, AssetFailedComp)) {
       err = FtxError_FontInvalid;

--- a/libs/asset/src/loader_graphic.c
+++ b/libs/asset/src/loader_graphic.c
@@ -8,6 +8,7 @@
 #include "ecs_world.h"
 #include "log_logger.h"
 
+#include "manager_internal.h"
 #include "repo_internal.h"
 
 static DataReg* g_dataReg;
@@ -158,11 +159,13 @@ ecs_system_define(LoadGraphicAssetSys) {
     // Resolve shader references.
     array_ptr_for_t(graphicComp->shaders, AssetGraphicShader, ptr) {
       ptr->shader = asset_lookup(world, manager, ptr->shaderId);
+      asset_register_dep(world, entity, ptr->shader);
     }
 
     // Resolve texture references.
     array_ptr_for_t(graphicComp->samplers, AssetGraphicSampler, ptr) {
       ptr->texture = asset_lookup(world, manager, ptr->textureId);
+      asset_register_dep(world, entity, ptr->texture);
     }
 
     // Resolve mesh reference.
@@ -172,6 +175,7 @@ ecs_system_define(LoadGraphicAssetSys) {
     }
     if (!string_is_empty(graphicComp->meshId)) {
       graphicComp->mesh = asset_lookup(world, manager, graphicComp->meshId);
+      asset_register_dep(world, entity, graphicComp->mesh);
     }
 
     ecs_world_remove_t(world, entity, AssetGraphicLoadComp);

--- a/libs/asset/src/loader_texture_atx.c
+++ b/libs/asset/src/loader_texture_atx.c
@@ -11,6 +11,7 @@
 #include "ecs_world.h"
 #include "log_logger.h"
 
+#include "manager_internal.h"
 #include "repo_internal.h"
 
 /**
@@ -218,6 +219,7 @@ ecs_system_define(AtxLoadAssetSys) {
         const EcsEntityId texAsset                     = asset_lookup(world, manager, *texName);
         *dynarray_push_t(&load->textures, EcsEntityId) = texAsset;
         asset_acquire(world, texAsset);
+        asset_register_dep(world, entity, texAsset);
       }
     }
 

--- a/libs/asset/src/manager_internal.h
+++ b/libs/asset/src/manager_internal.h
@@ -1,0 +1,8 @@
+#include "asset_manager.h"
+
+/**
+ * Register a dependency between the two assets.
+ * When 'dependency' is changed the 'asset' is also marked as changed.
+ * NOTE: At the moment is not possible to unregister a dependency.
+ */
+void asset_register_dep(EcsWorld* world, EcsEntityId asset, EcsEntityId dependency);


### PR DESCRIPTION
Track upwards dependencies so when a dependency changes we also mark the dependent assets as changed.