### PR TITLE
asset: Add asset unload delay

### DIFF
--- a/apps/pedestal.c
+++ b/apps/pedestal.c
@@ -256,7 +256,8 @@ static int app_run(const String assetPath) {
   EcsWorld*  world  = ecs_world_create(g_alloc_heap, def);
   EcsRunner* runner = ecs_runner_create(g_alloc_heap, world, EcsRunnerFlags_DumpGraphDot);
 
-  asset_manager_create_fs(world, AssetManagerFlags_TrackChanges, assetPath);
+  asset_manager_create_fs(
+      world, AssetManagerFlags_TrackChanges | AssetManagerFlags_DelayUnload, assetPath);
 
   gap_window_create(world, GapWindowFlags_Default, g_windowSize);
   ecs_world_add_t(

--- a/libs/asset/include/asset_manager.h
+++ b/libs/asset/include/asset_manager.h
@@ -10,6 +10,7 @@ typedef struct {
 typedef enum {
   AssetManagerFlags_None         = 0,
   AssetManagerFlags_TrackChanges = 1 << 0,
+  AssetManagerFlags_DelayUnload  = 1 << 1,
 } AssetManagerFlags;
 
 /**

--- a/libs/asset/src/manager.c
+++ b/libs/asset/src/manager.c
@@ -258,7 +258,8 @@ ecs_system_define(AssetUpdateDirtySys) {
       goto AssetUpdateDone;
     }
 
-    const bool unload = !assetComp->refCount && assetComp->unloadTicks++ >= asset_unload_delay;
+    const u32 unloadDelay = manager->flags & AssetManagerFlags_DelayUnload ? asset_unload_delay : 0;
+    const bool unload     = !assetComp->refCount && assetComp->unloadTicks++ >= unloadDelay;
     if (unload && assetComp->flags & AssetFlags_Loaded) {
       /**
        * Asset should be unloaded.


### PR DESCRIPTION
This prevents loading the same asset multiple times if different systems request and release the asset in quick succession.