### PR TITLE
asset: Fix delaying the unload of assets where the dependencies failed to load

### DIFF
--- a/libs/rend/src/resource.c
+++ b/libs/rend/src/resource.c
@@ -47,6 +47,7 @@ typedef enum {
 typedef enum {
   RendResUnloadState_UnloadDependents,
   RendResUnloadState_UnregisterDependencies,
+  RendResUnloadState_WaitAssetUnload,
   RendResUnloadState_Destroy,
   RendResUnloadState_Done,
 } RendResUnloadState;
@@ -579,6 +580,11 @@ ecs_system_define(RendResUnloadUpdateSys) {
         }
       }
       ++unloadComp->state;
+    } break;
+    case RendResUnloadState_WaitAssetUnload: {
+      if (!ecs_world_has_t(world, entity, AssetLoadedComp)) {
+        ++unloadComp->state;
+      }
     } break;
     case RendResUnloadState_Destroy: {
       ecs_world_remove_t(world, entity, RendResComp);


### PR DESCRIPTION
This causes a reload loop until the delay was done.