### PR TITLE
ui: Directly create render draws for canvas

### DIFF
--- a/apps/pedestal.c
+++ b/apps/pedestal.c
@@ -169,10 +169,6 @@ ecs_system_define(AppUpdateSys) {
     if (gap_window_key_pressed(window, GapKey_Backspace)) {
       app->flags ^= AppFlags_Rotate;
     }
-    if (gap_window_key_pressed(window, GapKey_Return)) {
-      const EcsEntityId newWindow = gap_window_create(world, GapWindowFlags_Default, g_windowSize);
-      debug_menu_create(world, newWindow);
-    }
     if (gap_window_key_pressed(window, GapKey_Alpha1)) {
       app->subjectCount = 1;
       app->flags |= AppFlags_Dirty;

--- a/apps/pedestal.c
+++ b/apps/pedestal.c
@@ -170,7 +170,8 @@ ecs_system_define(AppUpdateSys) {
       app->flags ^= AppFlags_Rotate;
     }
     if (gap_window_key_pressed(window, GapKey_Return)) {
-      gap_window_create(world, GapWindowFlags_Default, g_windowSize);
+      const EcsEntityId newWindow = gap_window_create(world, GapWindowFlags_Default, g_windowSize);
+      debug_menu_create(world, newWindow);
     }
     if (gap_window_key_pressed(window, GapKey_Alpha1)) {
       app->subjectCount = 1;

--- a/assets/fonts/ui.ftx
+++ b/assets/fonts/ui.ftx
@@ -11,7 +11,7 @@
     {
       "id": "fonts/materialicons_regular.ttf",
       "yOffset": -0.15,
-      "characters": "\uE9E4\uEF5B\uE3AE\uE1DB\uEA5F\uE069\uE338\uE4FC\uE80E\uE5CA\uE9BA\uE5D0\uE5D1\uE53B\uE53C"
+      "characters": "\uE9E4\uEF5B\uE3AE\uE1DB\uEA5F\uE069\uE338\uE4FC\uE80E\uE5CA\uE9BA\uE5D0\uE5D1\uE53B\uE53C\uE89E"
     },
     {
       "id": "fonts/shapes.ttf",

--- a/libs/debug/src/menu.c
+++ b/libs/debug/src/menu.c
@@ -1,4 +1,5 @@
 #include "core_alloc.h"
+#include "debug_menu.h"
 #include "ecs_world.h"
 #include "gap_window.h"
 #include "rend_stats.h"
@@ -70,13 +71,24 @@ static void debug_action_fullscreen(DebugMenuComp* menu, UiCanvasComp* canvas, G
   }
 }
 
+static void debug_action_new_window(EcsWorld* world, UiCanvasComp* canvas) {
+  static const GapVector newWindowSize = {1024, 768};
+
+  if (ui_button(canvas, .label = ui_shape_scratch(UiShape_OpenInNew))) {
+    const EcsEntityId newWindow = gap_window_create(world, GapWindowFlags_Default, newWindowSize);
+    debug_menu_create(world, newWindow);
+  }
+}
+
 static void debug_action_close(UiCanvasComp* canvas, GapWindowComp* win) {
   if (ui_button(canvas, .label = ui_shape_scratch(UiShape_Logout))) {
     gap_window_close(win);
   }
 }
 
-static void debug_action_bar_draw(DebugMenuComp* menu, UiCanvasComp* canvas, GapWindowComp* win) {
+static void debug_action_bar_draw(
+    EcsWorld* world, DebugMenuComp* menu, UiCanvasComp* canvas, GapWindowComp* win) {
+
   const UiVector offset = {g_debugActionBarButtonSize.x + g_debugActionBarSpacing, 0};
   ui_canvas_rect_move(canvas, offset, UiOrigin_WindowTopRight, UiUnits_Absolute, Ui_XY);
   ui_canvas_rect_resize(canvas, g_debugActionBarButtonSize, UiUnits_Absolute, Ui_XY);
@@ -86,6 +98,9 @@ static void debug_action_bar_draw(DebugMenuComp* menu, UiCanvasComp* canvas, Gap
 
   debug_action_bar_next(canvas);
   debug_action_fullscreen(menu, canvas, win);
+
+  debug_action_bar_next(canvas);
+  debug_action_new_window(world, canvas);
 
   debug_action_bar_next(canvas);
   debug_action_close(canvas, win);
@@ -183,7 +198,7 @@ ecs_system_define(DebugMenuUpdateSys) {
     if (menu->flags & DebugMenuFlags_ShowStats) {
       debug_stats_draw(canvas, &menu->stats, rendStats);
     }
-    debug_action_bar_draw(menu, canvas, window);
+    debug_action_bar_draw(world, menu, canvas, window);
   }
 }
 

--- a/libs/rend/include/rend_draw.h
+++ b/libs/rend/include/rend_draw.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "ecs_entity.h"
+#include "ecs_module.h"
+#include "geo_box.h"
+#include "scene_tag.h"
+
+/**
+ * Low level api for submitting draws.
+ * In most cases the scene apis should be preferred (SceneRenderable / SceneRenderableUnique).
+ */
+ecs_comp_extern(RendDrawComp);
+
+/**
+ * Add a new draw component to the given entity.
+ */
+RendDrawComp* rend_draw_create(EcsWorld*, EcsEntityId entity);
+
+/**
+ * Update the graphic asset used for the draw.
+ */
+void rend_draw_set_graphic(RendDrawComp*, EcsEntityId graphic);
+
+/**
+ * Override the vertex count for the draw.
+ * NOTE: Pass 0 to use the vertex-count as specified by the graphic.
+ */
+void rend_draw_set_vertex_count(RendDrawComp*, u32 vertexCount);
+
+/**
+ * Update the data size per instance for the given draw.
+ * NOTE: Clears all added instances.
+ */
+void rend_draw_set_data_size(RendDrawComp*, u32 size);
+
+/**
+ * Add a new instance to the given draw.
+ * NOTE: Tags and bounds are used to filter the draws per camera.
+ */
+Mem rend_draw_add_instance(RendDrawComp*, SceneTags, GeoBox aabb);

--- a/libs/rend/include/rend_draw.h
+++ b/libs/rend/include/rend_draw.h
@@ -4,6 +4,11 @@
 #include "geo_box.h"
 #include "scene_tag.h"
 
+typedef enum {
+  RendDrawFlags_None                = 0,
+  RendDrawFlags_NoInstanceFiltering = 1 << 0,
+} RendDrawFlags;
+
 /**
  * Low level api for submitting draws.
  * In most cases the scene apis should be preferred (SceneRenderable / SceneRenderableUnique).
@@ -13,7 +18,7 @@ ecs_comp_extern(RendDrawComp);
 /**
  * Add a new draw component to the given entity.
  */
-RendDrawComp* rend_draw_create(EcsWorld*, EcsEntityId entity);
+RendDrawComp* rend_draw_create(EcsWorld*, EcsEntityId entity, RendDrawFlags);
 
 /**
  * Update the graphic asset used for the draw.

--- a/libs/rend/include/rend_draw.h
+++ b/libs/rend/include/rend_draw.h
@@ -21,6 +21,11 @@ RendDrawComp* rend_draw_create(EcsWorld*, EcsEntityId entity);
 void rend_draw_set_graphic(RendDrawComp*, EcsEntityId graphic);
 
 /**
+ * Set a camera filter so only that specific camera will render this draw.
+ */
+void rend_draw_set_camera_filter(RendDrawComp*, EcsEntityId camera);
+
+/**
  * Override the vertex count for the draw.
  * NOTE: Pass 0 to use the vertex-count as specified by the graphic.
  */

--- a/libs/rend/include/rend_register.h
+++ b/libs/rend/include/rend_register.h
@@ -2,6 +2,7 @@
 #include "ecs_def.h"
 
 enum {
+  RendOrder_DrawClear   = -100,
   RendOrder_DrawCollect = 900,
   RendOrder_DrawExecute = 1000,
 };

--- a/libs/rend/src/draw.c
+++ b/libs/rend/src/draw.c
@@ -87,7 +87,7 @@ ecs_module_init(rend_draw_module) {
 
   ecs_register_system(RendClearDrawsSys, ecs_view_id(DrawView));
 
-  ecs_order(RendClearDrawsSys, RendOrder_DrawCollect - 1);
+  ecs_order(RendClearDrawsSys, RendOrder_DrawClear);
 }
 
 RendDrawComp* rend_draw_create(EcsWorld* world, const EcsEntityId entity) {

--- a/libs/rend/src/draw.c
+++ b/libs/rend/src/draw.c
@@ -12,6 +12,7 @@
 
 ecs_comp_define(RendDrawComp) {
   EcsEntityId graphic;
+  EcsEntityId cameraFilter;
   u32         vertexCountOverride;
   u32         instances;
   u32         outputInstances;
@@ -145,6 +146,10 @@ bool rend_draw_gather(RendDrawComp* draw, const RendView* view) {
    * pass the filter to separate output memory.
    */
 
+  if (draw->cameraFilter && view->camera != draw->cameraFilter) {
+    return false;
+  }
+
   rend_draw_ensure_storage(&draw->outputMem, draw->instances * draw->dataSize, rend_min_align);
 
   draw->outputInstances = 0;
@@ -171,6 +176,10 @@ RvkPassDraw rend_draw_output(const RendDrawComp* draw, RvkGraphic* graphic) {
 
 void rend_draw_set_graphic(RendDrawComp* comp, const EcsEntityId graphic) {
   comp->graphic = graphic;
+}
+
+void rend_draw_set_camera_filter(RendDrawComp* comp, const EcsEntityId camera) {
+  comp->cameraFilter = camera;
 }
 
 void rend_draw_set_vertex_count(RendDrawComp* comp, const u32 vertexCount) {

--- a/libs/rend/src/draw.c
+++ b/libs/rend/src/draw.c
@@ -212,10 +212,13 @@ void rend_draw_set_data_size(RendDrawComp* draw, const u32 size) {
 Mem rend_draw_add_instance(RendDrawComp* draw, const SceneTags tags, const GeoBox aabb) {
   ++draw->instances;
   rend_draw_ensure_storage(&draw->dataMem, draw->instances * draw->dataSize, rend_min_align);
-  rend_draw_ensure_storage(&draw->tagsMem, draw->instances * sizeof(SceneTags), 1);
-  rend_draw_ensure_storage(&draw->aabbMem, draw->instances * sizeof(GeoBox), alignof(GeoBox));
 
-  mem_as_t(draw->tagsMem, SceneTags)[draw->instances - 1] = tags;
-  mem_as_t(draw->aabbMem, GeoBox)[draw->instances - 1]    = aabb;
+  if (!(draw->flags & RendDrawFlags_NoInstanceFiltering)) {
+    rend_draw_ensure_storage(&draw->tagsMem, draw->instances * sizeof(SceneTags), 1);
+    rend_draw_ensure_storage(&draw->aabbMem, draw->instances * sizeof(GeoBox), alignof(GeoBox));
+
+    mem_as_t(draw->tagsMem, SceneTags)[draw->instances - 1] = tags;
+    mem_as_t(draw->aabbMem, GeoBox)[draw->instances - 1]    = aabb;
+  }
   return rend_draw_data(draw, draw->instances - 1);
 }

--- a/libs/rend/src/draw.c
+++ b/libs/rend/src/draw.c
@@ -111,7 +111,7 @@ ecs_system_define(RendDrawRequestGraphicSys) {
   EcsView* drawView = ecs_world_view_t(world, DrawReadView);
   for (EcsIterator* itr = ecs_view_itr(drawView); ecs_view_walk(itr);) {
     const RendDrawComp* comp = ecs_view_read_t(itr, RendDrawComp);
-    if (LIKELY(comp->graphic)) {
+    if (comp->instances && comp->graphic) {
       rend_draw_request_graphic(world, comp->graphic, graphicResItr, &numRequests);
     }
   }
@@ -129,6 +129,7 @@ ecs_module_init(rend_draw_module) {
       RendDrawRequestGraphicSys, ecs_view_id(DrawReadView), ecs_view_id(ResourceView));
 
   ecs_order(RendClearDrawsSys, RendOrder_DrawClear);
+  ecs_order(RendDrawRequestGraphicSys, RendOrder_DrawCollect + 1);
 }
 
 RendDrawComp* rend_draw_create(EcsWorld* world, const EcsEntityId entity) {

--- a/libs/rend/src/draw_internal.h
+++ b/libs/rend/src/draw_internal.h
@@ -1,26 +1,9 @@
 #pragma once
-#include "ecs_entity.h"
-#include "ecs_module.h"
-#include "geo_box.h"
-#include "scene_tag.h"
+#include "rend_draw.h"
 
 #include "rvk/pass_internal.h"
 #include "view_internal.h"
 
-ecs_comp_extern(RendDrawComp);
-
-RendDrawComp* rend_draw_create(EcsWorld*, EcsEntityId entity);
-EcsEntityId   rend_draw_graphic(const RendDrawComp*);
-bool          rend_draw_gather(RendDrawComp*, const RendView*);
-RvkPassDraw   rend_draw_output(const RendDrawComp*, RvkGraphic* graphic);
-
-void rend_draw_set_graphic(RendDrawComp*, EcsEntityId graphic);
-void rend_draw_set_vertex_count(RendDrawComp*, u32 vertexCount);
-
-/**
- * Update the data size per instance for the given draw.
- * NOTE: Clears all added instances.
- */
-void rend_draw_set_data_size(RendDrawComp*, u32 size);
-
-Mem rend_draw_add_instance(RendDrawComp*, SceneTags, GeoBox aabb);
+EcsEntityId rend_draw_graphic(const RendDrawComp*);
+bool        rend_draw_gather(RendDrawComp*, const RendView*);
+RvkPassDraw rend_draw_output(const RendDrawComp*, RvkGraphic* graphic);

--- a/libs/rend/src/instance.c
+++ b/libs/rend/src/instance.c
@@ -53,7 +53,7 @@ ecs_system_define(RendInstanceFillDrawsSys) {
     const SceneTags           tags          = tagComp ? tagComp->tags : SceneTags_Default;
 
     if (UNLIKELY(!ecs_world_has_t(world, renderable->graphic, RendDrawComp))) {
-      RendDrawComp* draw = rend_draw_create(world, renderable->graphic);
+      RendDrawComp* draw = rend_draw_create(world, renderable->graphic, RendDrawFlags_None);
       rend_draw_set_graphic(draw, renderable->graphic);
       rend_draw_set_data_size(draw, sizeof(RendInstanceData));
       continue;
@@ -88,7 +88,7 @@ ecs_system_define(RendInstanceFillUniqueDrawsSys) {
 
     RendDrawComp* draw = ecs_view_write_t(itr, RendDrawComp);
     if (UNLIKELY(!draw)) {
-      rend_draw_create(world, ecs_view_entity(itr));
+      rend_draw_create(world, ecs_view_entity(itr), RendDrawFlags_None);
       continue;
     }
 

--- a/libs/rend/src/view.c
+++ b/libs/rend/src/view.c
@@ -16,9 +16,11 @@ static bool rend_frustum_intersect(const GeoPlane frustum[4], const GeoBox* aabb
   return true;
 }
 
-RendView rend_view_create(const GeoMatrix* viewProj, const SceneTagFilter filter) {
+RendView
+rend_view_create(const EcsEntityId camera, const GeoMatrix* viewProj, const SceneTagFilter filter) {
   RendView result = {
-      result.filter = filter,
+      .camera = camera,
+      .filter = filter,
   };
   geo_matrix_frustum4(viewProj, result.frustum);
   return result;

--- a/libs/rend/src/view_internal.h
+++ b/libs/rend/src/view_internal.h
@@ -4,11 +4,12 @@
 #include "scene_tag.h"
 
 typedef struct {
+  EcsEntityId    camera;
   SceneTagFilter filter;
   GeoPlane       frustum[4]; // Left, Right, Top, Bottom.
 } RendView;
 
-RendView rend_view_create(const GeoMatrix* viewProj, SceneTagFilter);
+RendView rend_view_create(EcsEntityId camera, const GeoMatrix* viewProj, SceneTagFilter);
 
 /**
  * Check if an object is visible in the view.

--- a/libs/scene/include/scene_tag.h
+++ b/libs/scene/include/scene_tag.h
@@ -3,14 +3,12 @@
 #include "ecs_module.h"
 
 typedef enum {
-  SceneTags_None = 0,
-  SceneTags_Cam0 = 1 << 0,
-  SceneTags_Cam1 = 1 << 1,
-  SceneTags_Cam2 = 1 << 2,
-  SceneTags_Cam3 = 1 << 3,
+  SceneTags_None     = 0,
+  SceneTags_Geometry = 1 << 0,
+  SceneTags_Ui       = 1 << 1,
+  SceneTags_Debug    = 1 << 2,
 
-  SceneTags_CamAny  = SceneTags_Cam0 | SceneTags_Cam1 | SceneTags_Cam2 | SceneTags_Cam3,
-  SceneTags_Default = SceneTags_CamAny,
+  SceneTags_Default = SceneTags_Geometry,
 } SceneTags;
 
 typedef struct {

--- a/libs/scene/src/camera.c
+++ b/libs/scene/src/camera.c
@@ -28,7 +28,6 @@ static const f32       g_camOrthoFar             = +1e4f;
 ecs_comp_define_public(SceneCameraComp);
 ecs_comp_define_public(SceneCameraMovementComp);
 
-ecs_comp_define(SceneCameraInternalComp) { GapVector lastWindowedSize; };
 ecs_comp_define(SceneCameraSkyComp);
 
 ecs_view_define(GlobalTimeView) { ecs_access_read(SceneTimeComp); }
@@ -160,23 +159,11 @@ static void camera_update_lock(SceneCameraMovementComp* move, GapWindowComp* win
   }
 }
 
-static void camera_update_fullscreen(SceneCameraInternalComp* internal, GapWindowComp* win) {
-  if (gap_window_key_pressed(win, GapKey_F)) {
-    if (gap_window_mode(win) == GapWindowMode_Fullscreen) {
-      gap_window_resize(win, internal->lastWindowedSize, GapWindowMode_Windowed);
-    } else {
-      internal->lastWindowedSize = gap_window_param(win, GapParam_WindowSize);
-      gap_window_resize(win, gap_vector(0, 0), GapWindowMode_Fullscreen);
-    }
-  }
-}
-
 ecs_view_define(CameraUpdateView) {
   ecs_access_write(SceneCameraComp);
   ecs_access_write(SceneCameraMovementComp);
   ecs_access_write(SceneTransformComp);
   ecs_access_write(GapWindowComp);
-  ecs_access_maybe_write(SceneCameraInternalComp);
 }
 
 ecs_system_define(SceneCameraUpdateSys) {
@@ -190,20 +177,15 @@ ecs_system_define(SceneCameraUpdateSys) {
 
   EcsView* cameraView = ecs_world_view_t(world, CameraUpdateView);
   for (EcsIterator* itr = ecs_view_itr(cameraView); ecs_view_walk(itr);) {
-    SceneCameraComp*         cam      = ecs_view_write_t(itr, SceneCameraComp);
-    GapWindowComp*           win      = ecs_view_write_t(itr, GapWindowComp);
-    SceneTransformComp*      trans    = ecs_view_write_t(itr, SceneTransformComp);
-    SceneCameraMovementComp* move     = ecs_view_write_t(itr, SceneCameraMovementComp);
-    SceneCameraInternalComp* internal = ecs_view_write_t(itr, SceneCameraInternalComp);
-    if (!internal) {
-      internal = ecs_world_add_t(world, ecs_view_entity(itr), SceneCameraInternalComp);
-    }
+    SceneCameraComp*         cam   = ecs_view_write_t(itr, SceneCameraComp);
+    GapWindowComp*           win   = ecs_view_write_t(itr, GapWindowComp);
+    SceneTransformComp*      trans = ecs_view_write_t(itr, SceneTransformComp);
+    SceneCameraMovementComp* move  = ecs_view_write_t(itr, SceneCameraMovementComp);
 
     camera_update_move(cam, move, trans, win, deltaSeconds);
     camera_update_rotate(move, trans, win);
     camera_update_zoom(cam, win);
     camera_update_lock(move, win);
-    camera_update_fullscreen(internal, win);
 
     if (gap_window_key_pressed(win, GapKey_F1)) {
       cam->flags &= ~SceneCameraFlags_Orthographic;
@@ -225,7 +207,6 @@ ecs_system_define(SceneCameraUpdateSys) {
 ecs_module_init(scene_camera_module) {
   ecs_register_comp(SceneCameraComp);
   ecs_register_comp(SceneCameraMovementComp);
-  ecs_register_comp(SceneCameraInternalComp);
   ecs_register_comp_empty(SceneCameraSkyComp);
 
   ecs_register_view(GlobalTimeView);

--- a/libs/scene/src/grid.c
+++ b/libs/scene/src/grid.c
@@ -5,6 +5,7 @@
 #include "gap_window.h"
 #include "scene_grid.h"
 #include "scene_renderable.h"
+#include "scene_tag.h"
 
 static const u32 g_gridSegments          = 400;
 static const u32 g_gridHighlightInterval = 5;
@@ -44,6 +45,8 @@ ecs_system_define(SceneGridCreateSys) {
       gridEntity,
       SceneRenderableUniqueComp,
       .graphic = asset_lookup(world, assets, string_lit("graphics/scene/grid.gra")));
+
+  ecs_world_add_t(world, gridEntity, SceneTagComp, .tags = SceneTags_Debug);
 }
 
 ecs_system_define(SceneGridInputSys) {

--- a/libs/ui/CMakeLists.txt
+++ b/libs/ui/CMakeLists.txt
@@ -17,9 +17,9 @@ add_library(lib_ui STATIC
   src/widget.c
   )
 target_include_directories(lib_ui PUBLIC include)
-target_link_libraries(lib_ui PRIVATE lib_log)
 target_link_libraries(lib_ui PRIVATE lib_gap)
+target_link_libraries(lib_ui PRIVATE lib_log)
+target_link_libraries(lib_ui PRIVATE lib_rend)
 target_link_libraries(lib_ui PUBLIC lib_asset)
 target_link_libraries(lib_ui PUBLIC lib_core)
 target_link_libraries(lib_ui PUBLIC lib_ecs)
-target_link_libraries(lib_ui PUBLIC lib_scene)

--- a/libs/ui/include/ui_shape.h
+++ b/libs/ui/include/ui_shape.h
@@ -10,6 +10,7 @@
   X(0xE9BA, Logout)                                                                                \
   X(0xE5D0, Fullscreen)                                                                            \
   X(0xE5D1, FullscreenExit)                                                                        \
+  X(0xE89E, OpenInNew)                                                                             \
   X(0xE53B, Layers)                                                                                \
   X(0xE53C, LayersClear)                                                                           \
   X(0xEF5B, Monitor)                                                                               \

--- a/libs/ui/src/canvas.c
+++ b/libs/ui/src/canvas.c
@@ -127,10 +127,8 @@ static void ui_canvas_render(
   rend_draw_set_data_size(draw, (u32)renderState.output->size);
   rend_draw_set_vertex_count(draw, renderState.outputNumGlyphs * 6); // 6 verts per quad.
 
-  const SceneTags tags = SceneTags_Ui | SceneTags_Debug;
-  const Mem       data = dynstring_view(renderState.output);
-  const GeoBox    aabb = geo_box_inverted3();
-  mem_cpy(rend_draw_add_instance(draw, tags, aabb), data);
+  const Mem data = dynstring_view(renderState.output);
+  mem_cpy(rend_draw_add_instance(draw, SceneTags_None, (GeoBox){0}), data);
 
   dynstring_destroy(&dataBuffer);
 

--- a/libs/ui/src/canvas.c
+++ b/libs/ui/src/canvas.c
@@ -3,7 +3,7 @@
 #include "core_dynstring.h"
 #include "ecs_world.h"
 #include "gap_window.h"
-#include "scene_renderable.h"
+#include "rend_draw.h"
 #include "ui_register.h"
 
 #include "builder_internal.h"
@@ -100,10 +100,10 @@ static void ui_canvas_update_input(
 }
 
 static void ui_canvas_render(
-    UiCanvasComp*              canvas,
-    SceneRenderableUniqueComp* renderable,
-    const GapWindowComp*       window,
-    const AssetFtxComp*        font) {
+    UiCanvasComp*        canvas,
+    RendDrawComp*        draw,
+    const GapWindowComp* window,
+    const AssetFtxComp*  font) {
 
   // Ensure we have UiElement structures for all elements that are requested to be drawn.
   dynarray_resize(&canvas->elements, canvas->nextId);
@@ -124,9 +124,13 @@ static void ui_canvas_render(
   };
   const UiBuildResult result = ui_build(canvas->cmdBuffer, &buildCtx);
 
-  const Mem instData = scene_renderable_unique_data_set(renderable, renderState.output->size);
-  mem_cpy(instData, dynstring_view(renderState.output));
-  renderable->vertexCountOverride = renderState.outputNumGlyphs * 6; // 6 verts per quad.
+  rend_draw_set_data_size(draw, (u32)renderState.output->size);
+  rend_draw_set_vertex_count(draw, renderState.outputNumGlyphs * 6); // 6 verts per quad.
+
+  const SceneTags tags = SceneTags_Default;
+  const Mem       data = dynstring_view(renderState.output);
+  const GeoBox    aabb = geo_box_inverted3();
+  mem_cpy(rend_draw_add_instance(draw, tags, aabb), data);
 
   dynstring_destroy(&dataBuffer);
 
@@ -139,7 +143,7 @@ ecs_view_define(WindowView) { ecs_access_read(GapWindowComp); }
 
 ecs_view_define(CanvasBuildView) {
   ecs_access_write(UiCanvasComp);
-  ecs_access_write(SceneRenderableUniqueComp);
+  ecs_access_write(RendDrawComp);
 }
 
 static const UiGlobalResourcesComp* ui_global_resources(EcsWorld* world) {
@@ -167,8 +171,8 @@ ecs_system_define(UiCanvasBuildSys) {
 
   EcsView* buildView = ecs_world_view_t(world, CanvasBuildView);
   for (EcsIterator* itr = ecs_view_itr(buildView); ecs_view_walk(itr);) {
-    UiCanvasComp*              canvasComp = ecs_view_write_t(itr, UiCanvasComp);
-    SceneRenderableUniqueComp* renderable = ecs_view_write_t(itr, SceneRenderableUniqueComp);
+    UiCanvasComp* canvasComp = ecs_view_write_t(itr, UiCanvasComp);
+    RendDrawComp* draw       = ecs_view_write_t(itr, RendDrawComp);
     if (!ecs_view_maybe_jump(windowItr, canvasComp->window)) {
       // Destroy the canvas if the associated window is destroyed.
       ecs_world_entity_destroy(world, ecs_view_entity(itr));
@@ -176,8 +180,9 @@ ecs_system_define(UiCanvasBuildSys) {
     }
     const GapWindowComp* window = ecs_view_read_t(windowItr, GapWindowComp);
 
-    renderable->graphic = ui_resource_graphic(globalRes);
-    ui_canvas_render(canvasComp, renderable, window, font);
+    rend_draw_set_graphic(draw, ui_resource_graphic(globalRes));
+
+    ui_canvas_render(canvasComp, draw, window, font);
   }
 }
 
@@ -208,7 +213,7 @@ EcsEntityId ui_canvas_create(EcsWorld* world, const EcsEntityId window) {
       .window    = window,
       .cmdBuffer = ui_cmdbuffer_create(g_alloc_heap),
       .elements  = dynarray_create_t(g_alloc_heap, UiElement, 128));
-  ecs_world_add_t(world, canvasEntity, SceneRenderableUniqueComp);
+  rend_draw_create(world, canvasEntity);
   return canvasEntity;
 }
 

--- a/libs/ui/src/canvas.c
+++ b/libs/ui/src/canvas.c
@@ -214,7 +214,7 @@ EcsEntityId ui_canvas_create(EcsWorld* world, const EcsEntityId window) {
       .cmdBuffer = ui_cmdbuffer_create(g_alloc_heap),
       .elements  = dynarray_create_t(g_alloc_heap, UiElement, 128));
 
-  RendDrawComp* draw = rend_draw_create(world, canvasEntity);
+  RendDrawComp* draw = rend_draw_create(world, canvasEntity, RendDrawFlags_NoInstanceFiltering);
   rend_draw_set_camera_filter(draw, window);
 
   return canvasEntity;

--- a/libs/ui/src/canvas.c
+++ b/libs/ui/src/canvas.c
@@ -213,7 +213,10 @@ EcsEntityId ui_canvas_create(EcsWorld* world, const EcsEntityId window) {
       .window    = window,
       .cmdBuffer = ui_cmdbuffer_create(g_alloc_heap),
       .elements  = dynarray_create_t(g_alloc_heap, UiElement, 128));
-  rend_draw_create(world, canvasEntity);
+
+  RendDrawComp* draw = rend_draw_create(world, canvasEntity);
+  rend_draw_set_camera_filter(draw, window);
+
   return canvasEntity;
 }
 

--- a/libs/ui/src/canvas.c
+++ b/libs/ui/src/canvas.c
@@ -127,7 +127,7 @@ static void ui_canvas_render(
   rend_draw_set_data_size(draw, (u32)renderState.output->size);
   rend_draw_set_vertex_count(draw, renderState.outputNumGlyphs * 6); // 6 verts per quad.
 
-  const SceneTags tags = SceneTags_Default;
+  const SceneTags tags = SceneTags_Ui | SceneTags_Debug;
   const Mem       data = dynstring_view(renderState.output);
   const GeoBox    aabb = geo_box_inverted3();
   mem_cpy(rend_draw_add_instance(draw, tags, aabb), data);

--- a/libs/ui/src/cmd.c
+++ b/libs/ui/src/cmd.c
@@ -154,7 +154,7 @@ void ui_cmd_push_draw_glyph(
 
 UiCmd* ui_cmd_next(const UiCmdBuffer* buffer, UiCmd* prev) {
   if (!prev) {
-    return dynarray_begin_t(&buffer->commands, UiCmd);
+    return buffer->commands.size ? dynarray_begin_t(&buffer->commands, UiCmd) : null;
   }
   UiCmd* next = ++prev;
   return next == dynarray_end_t(&buffer->commands, UiCmd) ? null : next;


### PR DESCRIPTION
By creating draws directly we avoid the data copy that was needed when going through SceneRenderableUniqueComp.