### PR TITLE
rend: Split 2D and Cube sampler descriptors

### DIFF
--- a/assets/textures/missing_cube.atx
+++ b/assets/textures/missing_cube.atx
@@ -1,0 +1,12 @@
+{
+  "type": "CubeMap",
+  "mipmaps": false,
+  "textures": [
+    "textures/missing.ptx",
+    "textures/missing.ptx",
+    "textures/missing.ptx",
+    "textures/missing.ptx",
+    "textures/missing.ptx",
+    "textures/missing.ptx"
+  ]
+}

--- a/libs/asset/include/asset_shader.h
+++ b/libs/asset/include/asset_shader.h
@@ -14,7 +14,8 @@ typedef enum {
 } AssetShaderKind;
 
 typedef enum {
-  AssetShaderResKind_Texture,
+  AssetShaderResKind_Texture2D,
+  AssetShaderResKind_TextureCube,
   AssetShaderResKind_UniformBuffer,
   AssetShaderResKind_StorageBuffer,
 

--- a/libs/asset/test/test_loader_shader_spv.c
+++ b/libs/asset/test/test_loader_shader_spv.c
@@ -58,12 +58,12 @@ static const struct {
         .entryPoint = string_static("main"),
         .resources =
             {
-                {AssetShaderResKind_Texture, .set = 0, .binding = 0},
-                {AssetShaderResKind_Texture, .set = 2, .binding = 0},
-                {AssetShaderResKind_Texture, .set = 2, .binding = 1},
-                {AssetShaderResKind_Texture, .set = 4, .binding = 0},
-                {AssetShaderResKind_Texture, .set = 4, .binding = 1},
-                {AssetShaderResKind_Texture, .set = 4, .binding = 7},
+                {AssetShaderResKind_Texture2D, .set = 0, .binding = 0},
+                {AssetShaderResKind_Texture2D, .set = 2, .binding = 0},
+                {AssetShaderResKind_Texture2D, .set = 2, .binding = 1},
+                {AssetShaderResKind_Texture2D, .set = 4, .binding = 0},
+                {AssetShaderResKind_Texture2D, .set = 4, .binding = 1},
+                {AssetShaderResKind_Texture2D, .set = 4, .binding = 7},
             },
         .resourceCount = 6,
     },

--- a/libs/rend/src/resource.c
+++ b/libs/rend/src/resource.c
@@ -23,7 +23,10 @@ ecs_comp_define_public(RendResShaderComp);
 ecs_comp_define_public(RendResMeshComp);
 ecs_comp_define_public(RendResTextureComp);
 
-ecs_comp_define(RendGlobalResComp) { EcsEntityId missingTex; };
+ecs_comp_define(RendGlobalResComp) {
+  EcsEntityId missingTex;
+  EcsEntityId missingTexCube;
+};
 ecs_comp_define(RendGlobalResLoadedComp);
 
 typedef enum {
@@ -203,17 +206,20 @@ ecs_system_define(RendGlobalResourceLoadSys) {
   RendGlobalResComp* resComp  = ecs_view_write_t(globalItr, RendGlobalResComp);
 
   if (!resComp) {
-    resComp = ecs_world_add_t(
-        world,
-        ecs_view_entity(globalItr),
-        RendGlobalResComp,
-        .missingTex =
-            rend_resource_request_persistent(world, assetMan, string_lit("textures/missing.ptx")));
+    resComp = ecs_world_add_t(world, ecs_view_entity(globalItr), RendGlobalResComp);
+    resComp->missingTex =
+        rend_resource_request_persistent(world, assetMan, string_lit("textures/missing.ptx"));
+    resComp->missingTexCube =
+        rend_resource_request_persistent(world, assetMan, string_lit("textures/missing_cube.atx"));
   }
 
   // Wait for all global resources to be loaded.
-  if (!rend_res_set_wellknown_texture(
-          world, plat, RvkRepositoryId_MissingTexture, resComp->missingTex)) {
+  bool ready = true;
+  ready &= rend_res_set_wellknown_texture(
+      world, plat, RvkRepositoryId_MissingTexture, resComp->missingTex);
+  ready &= rend_res_set_wellknown_texture(
+      world, plat, RvkRepositoryId_MissingTextureCube, resComp->missingTexCube);
+  if (!ready) {
     return;
   }
 

--- a/libs/rend/src/rvk/desc_internal.h
+++ b/libs/rend/src/rvk/desc_internal.h
@@ -13,7 +13,8 @@ typedef struct sRvkDescChunk RvkDescChunk;
 
 typedef enum {
   RvkDescKind_None,
-  RvkDescKind_CombinedImageSampler,
+  RvkDescKind_CombinedImageSampler2D,
+  RvkDescKind_CombinedImageSamplerCube,
   RvkDescKind_UniformBuffer,
   RvkDescKind_UniformBufferDynamic,
   RvkDescKind_StorageBuffer,

--- a/libs/rend/src/rvk/repository.c
+++ b/libs/rend/src/rvk/repository.c
@@ -23,6 +23,7 @@ struct sRvkRepository {
 String rvk_repository_id_str(const RvkRepositoryId id) {
   static const String g_names[] = {
       string_static("MissingTexture"),
+      string_static("MissingTextureCube"),
   };
   ASSERT(array_elems(g_names) == RvkRepositoryId_Count, "Incorrect number of names");
   return g_names[id];

--- a/libs/rend/src/rvk/repository_internal.h
+++ b/libs/rend/src/rvk/repository_internal.h
@@ -5,6 +5,7 @@ typedef struct sRvkTexture RvkTexture;
 
 typedef enum {
   RvkRepositoryId_MissingTexture,
+  RvkRepositoryId_MissingTextureCube,
 
   RvkRepositoryId_Count,
 } RvkRepositoryId;

--- a/libs/rend/src/rvk/shader.c
+++ b/libs/rend/src/rvk/shader.c
@@ -41,8 +41,10 @@ static String rvk_shader_kind_str(const AssetShaderKind kind) {
 
 static RvkDescKind rvk_shader_desc_kind(const AssetShaderResKind resKind) {
   switch (resKind) {
-  case AssetShaderResKind_Texture:
-    return RvkDescKind_CombinedImageSampler;
+  case AssetShaderResKind_Texture2D:
+    return RvkDescKind_CombinedImageSampler2D;
+  case AssetShaderResKind_TextureCube:
+    return RvkDescKind_CombinedImageSamplerCube;
   case AssetShaderResKind_UniformBuffer:
     // NOTE: This makes the assumption that all uniform-buffers will be bound as dynamic buffers.
     return RvkDescKind_UniformBufferDynamic;

--- a/libs/rend/src/rvk/texture.c
+++ b/libs/rend/src/rvk/texture.c
@@ -57,8 +57,8 @@ RvkTexture* rvk_texture_create(RvkDevice* dev, const AssetTextureComp* asset, St
 
   RvkTexture* texture = alloc_alloc_t(g_alloc_heap, RvkTexture);
   *texture            = (RvkTexture){
-                 .device  = dev,
-                 .dbgName = string_dup(g_alloc_heap, dbgName),
+      .device  = dev,
+      .dbgName = string_dup(g_alloc_heap, dbgName),
   };
 
   const VkFormat vkFormat = rvk_texture_format(asset->type, asset->flags, asset->channels);
@@ -102,6 +102,15 @@ void rvk_texture_destroy(RvkTexture* texture) {
 
   string_free(g_alloc_heap, texture->dbgName);
   alloc_free_t(g_alloc_heap, texture);
+}
+
+RvkDescKind rvk_texture_sampler_kind(RvkTexture* texture) {
+  switch (texture->image.type) {
+  case RvkImageType_ColorSourceCube:
+    return RvkDescKind_CombinedImageSamplerCube;
+  default:
+    return RvkDescKind_CombinedImageSampler2D;
+  }
 }
 
 bool rvk_texture_prepare(RvkTexture* texture, VkCommandBuffer vkCmdBuf) {

--- a/libs/rend/src/rvk/texture_internal.h
+++ b/libs/rend/src/rvk/texture_internal.h
@@ -2,6 +2,7 @@
 #include "asset_texture.h"
 #include "core_string.h"
 
+#include "desc_internal.h"
 #include "image_internal.h"
 #include "transfer_internal.h"
 
@@ -23,4 +24,5 @@ typedef struct sRvkTexture {
 
 RvkTexture* rvk_texture_create(RvkDevice*, const AssetTextureComp*, String dbgName);
 void        rvk_texture_destroy(RvkTexture*);
+RvkDescKind rvk_texture_sampler_kind(RvkTexture*);
 bool        rvk_texture_prepare(RvkTexture*, VkCommandBuffer);


### PR DESCRIPTION
Fixes the bug that we used a 2d image as a fallback to a cube sampler binding. 