### PR TITLE
ui: Draw canvas glyphs as instances

### DIFF
--- a/assets/graphics/ui/canvas.gra
+++ b/assets/graphics/ui/canvas.gra
@@ -14,6 +14,7 @@
       "filter": "Linear"
     }
   ],
+  "vertexCount": 6,
   "renderOrder": 100,
   "topology": "Triangles",
   "rasterizer": "Fill",

--- a/assets/graphics/ui/canvas.gra
+++ b/assets/graphics/ui/canvas.gra
@@ -18,6 +18,6 @@
   "topology": "Triangles",
   "rasterizer": "Fill",
   "blend": "Alpha",
-  "depth": "Always",
+  "depth": "None",
   "cull": "None"
 }

--- a/assets/shaders/include/binding.glsl
+++ b/assets/shaders/include/binding.glsl
@@ -5,13 +5,17 @@
 
 const u32 c_setGlobal   = 0;
 const u32 c_setGraphic  = 1;
-const u32 c_setInstance = 2;
+const u32 c_setDraw     = 2;
+const u32 c_setInstance = 3;
 
 #define bind_global(_BIND_IDX_) layout(set = c_setGlobal, binding = _BIND_IDX_)
 #define bind_global_data(_BIND_IDX_) layout(set = c_setGlobal, binding = _BIND_IDX_, std140)
 
 #define bind_graphic(_BIND_IDX_) layout(set = c_setGraphic, binding = _BIND_IDX_)
 #define bind_graphic_data(_BIND_IDX_) layout(set = c_setGraphic, binding = _BIND_IDX_, std140)
+
+#define bind_draw(_BIND_IDX_) layout(set = c_setDraw, binding = _BIND_IDX_)
+#define bind_draw_data(_BIND_IDX_) layout(set = c_setDraw, binding = _BIND_IDX_, std140)
 
 #define bind_instance(_BIND_IDX_) layout(set = c_setInstance, binding = _BIND_IDX_)
 #define bind_instance_data(_BIND_IDX_) layout(set = c_setInstance, binding = _BIND_IDX_, std140)

--- a/assets/shaders/ui/canvas.vert
+++ b/assets/shaders/ui/canvas.vert
@@ -4,9 +4,8 @@
 #include "binding.glsl"
 #include "color.glsl"
 #include "global.glsl"
+#include "instance.glsl"
 #include "ui.glsl"
-
-const u32 c_maxGlyphs = 1024;
 
 const u32   c_verticesPerGlyph                  = 6;
 const f32v2 c_unitPositions[c_verticesPerGlyph] = {
@@ -37,10 +36,8 @@ struct GlyphData {
 };
 
 bind_global_data(0) readonly uniform Global { GlobalData u_global; };
-bind_instance_data(0) readonly uniform Instance {
-  DrawData  u_draw;
-  GlyphData u_glyphs[c_maxGlyphs];
-};
+bind_draw_data(0) readonly uniform Draw { DrawData u_draw; };
+bind_instance_data(0) readonly uniform Instance { GlyphData u_glyphs[c_maxInstances]; };
 
 bind_internal(0) out f32v2 out_texCoord;
 bind_internal(1) out flat f32v2 out_texOrigin;
@@ -52,9 +49,7 @@ bind_internal(6) out flat f32 out_aspectRatio;
 bind_internal(7) out flat f32 out_cornerFrac;
 
 void main() {
-  const u32       glyphIndex   = in_vertexIndex / c_verticesPerGlyph;
-  const u32       vertIndex    = in_vertexIndex % c_verticesPerGlyph;
-  const GlyphData glyphData    = u_glyphs[glyphIndex];
+  const GlyphData glyphData    = u_glyphs[in_instanceIndex];
   const f32v2     glyphPos     = glyphData.rect.xy;
   const f32v2     glyphSize    = glyphData.rect.zw;
   const f32v4     glyphColor   = color_from_u32(glyphData.data.x);
@@ -66,7 +61,7 @@ void main() {
   /**
    * Compute the ui positions of the vertices.
    */
-  const f32v2 uiPos = glyphPos + c_unitPositions[vertIndex] * glyphSize;
+  const f32v2 uiPos = glyphPos + c_unitPositions[in_vertexIndex] * glyphSize;
 
   /**
    * Compute the x and y position in the texture atlas based on the glyphIndex.
@@ -75,7 +70,7 @@ void main() {
       f32v2(mod(atlasIndex, u_draw.glyphsPerDim), floor(atlasIndex * u_draw.invGlyphsPerDim));
 
   out_vertexPosition = ui_norm_to_ndc(uiPos * u_global.resolution.zw);
-  out_texCoord       = c_unitTexCoords[vertIndex];
+  out_texCoord       = c_unitTexCoords[in_vertexIndex];
   out_texOrigin      = texOrigin;
   out_texScale       = u_draw.invGlyphsPerDim;
   out_color          = glyphColor;

--- a/libs/rend/include/rend_draw.h
+++ b/libs/rend/include/rend_draw.h
@@ -37,13 +37,13 @@ void rend_draw_set_camera_filter(RendDrawComp*, EcsEntityId camera);
 void rend_draw_set_vertex_count(RendDrawComp*, u32 vertexCount);
 
 /**
- * Update the data size per instance for the given draw.
- * NOTE: Clears all added instances.
+ * Set the 'per draw' data.
  */
-void rend_draw_set_data_size(RendDrawComp*, u32 size);
+void rend_draw_set_data(RendDrawComp*, Mem data);
 
 /**
  * Add a new instance to the given draw.
+ * NOTE: All instances need to use the same data-size.
  * NOTE: Tags and bounds are used to filter the draws per camera.
  */
-Mem rend_draw_add_instance(RendDrawComp*, SceneTags, GeoBox aabb);
+void rend_draw_add_instance(RendDrawComp*, Mem data, SceneTags, GeoBox aabb);

--- a/libs/rend/src/instance.c
+++ b/libs/rend/src/instance.c
@@ -55,7 +55,6 @@ ecs_system_define(RendInstanceFillDrawsSys) {
     if (UNLIKELY(!ecs_world_has_t(world, renderable->graphic, RendDrawComp))) {
       RendDrawComp* draw = rend_draw_create(world, renderable->graphic, RendDrawFlags_None);
       rend_draw_set_graphic(draw, renderable->graphic);
-      rend_draw_set_data_size(draw, sizeof(RendInstanceData));
       continue;
     }
 
@@ -67,10 +66,14 @@ ecs_system_define(RendInstanceFillDrawsSys) {
     const f32       scale    = scaleComp ? scaleComp->scale : 1.0f;
     const GeoBox    aabb     = geo_box_transform3(&boundsComp->local, position, rotation, scale);
 
-    *mem_as_t(rend_draw_add_instance(draw, tags, aabb), RendInstanceData) = (RendInstanceData){
-        .posAndScale = geo_vector(position.x, position.y, position.z, scale),
-        .rot         = rotation,
-    };
+    rend_draw_add_instance(
+        draw,
+        mem_struct(
+            RendInstanceData,
+            .posAndScale = geo_vector(position.x, position.y, position.z, scale),
+            .rot         = rotation),
+        tags,
+        aabb);
   }
 }
 
@@ -94,9 +97,8 @@ ecs_system_define(RendInstanceFillUniqueDrawsSys) {
 
     rend_draw_set_graphic(draw, renderable->graphic);
     rend_draw_set_vertex_count(draw, renderable->vertexCountOverride);
-    rend_draw_set_data_size(draw, (u32)data.size);
     const GeoBox aabb = geo_box_inverted3(); // No bounds known for unique draws.
-    mem_cpy(rend_draw_add_instance(draw, tags, aabb), data);
+    rend_draw_add_instance(draw, data, tags, aabb);
   }
 }
 

--- a/libs/rend/src/rvk/graphic_internal.h
+++ b/libs/rend/src/rvk/graphic_internal.h
@@ -23,8 +23,9 @@ typedef struct {
 typedef enum {
   RvkGraphicFlags_Ready        = 1 << 0,
   RvkGraphicFlags_GlobalData   = 1 << 1,
-  RvkGraphicFlags_InstanceData = 1 << 2,
-  RvkGraphicFlags_Invalid      = 1 << 3,
+  RvkGraphicFlags_DrawData     = 1 << 2,
+  RvkGraphicFlags_InstanceData = 1 << 3,
+  RvkGraphicFlags_Invalid      = 1 << 4,
 } RvkGraphicFlags;
 
 typedef struct {

--- a/libs/rend/src/rvk/pass_internal.h
+++ b/libs/rend/src/rvk/pass_internal.h
@@ -26,9 +26,10 @@ typedef enum {
 typedef struct sRvkPassDraw {
   RvkGraphic* graphic;
   u32         vertexCountOverride;
-  u32         instanceCount;
-  Mem         data;
-  u32         dataStride;
+  Mem         drawData;
+  u32         instCount;
+  Mem         instData;
+  u32         instDataStride;
 } RvkPassDraw;
 
 typedef struct sRvkPassDrawList {


### PR DESCRIPTION
This removes the maximum glyph per canvas limitation as the render backend can split the instances across draws as needed by the device's uniform buffer limit.