### PR TITLE
ecs: Global destruct order

### DIFF
--- a/libs/ecs/src/buffer_internal.h
+++ b/libs/ecs/src/buffer_internal.h
@@ -4,6 +4,7 @@
 #include "ecs_def.h"
 
 #include "entity_internal.h"
+#include "finalizer_internal.h"
 
 /**
  * Buffer for storing entity layout modifications to be applied at a later time.
@@ -26,6 +27,8 @@ typedef struct sEcsBufferCompData EcsBufferCompData;
 EcsBuffer ecs_buffer_create(Allocator*, const EcsDef* def);
 void      ecs_buffer_destroy(EcsBuffer*);
 void      ecs_buffer_clear(EcsBuffer*);
+
+void ecs_buffer_queue_finalize_all(EcsBuffer*, EcsFinalizer*);
 
 void  ecs_buffer_destroy_entity(EcsBuffer*, EcsEntityId);
 void* ecs_buffer_comp_add(EcsBuffer*, EcsEntityId, EcsCompId, Mem data);

--- a/libs/ecs/src/finalizer.c
+++ b/libs/ecs/src/finalizer.c
@@ -1,3 +1,5 @@
+#include "core_diag.h"
+
 #include "def_internal.h"
 #include "finalizer_internal.h"
 
@@ -14,7 +16,10 @@ EcsFinalizer ecs_finalizer_create(Allocator* alloc, const EcsDef* def) {
   };
 }
 
-void ecs_finalizer_destroy(EcsFinalizer* finalizer) { dynarray_destroy(&finalizer->entries); }
+void ecs_finalizer_destroy(EcsFinalizer* finalizer) {
+  diag_assert_msg(finalizer->entries.size == 0, "Finalizer cannot be destroyed with pending items");
+  dynarray_destroy(&finalizer->entries);
+}
 
 void ecs_finalizer_push(EcsFinalizer* finalizer, const EcsCompId compId, void* compData) {
   EcsCompDestructor destructor = ecs_def_comp_destructor(finalizer->def, compId);

--- a/libs/ecs/src/storage.c
+++ b/libs/ecs/src/storage.c
@@ -217,17 +217,13 @@ void ecs_storage_entity_move(
   }
 }
 
-void ecs_storage_entity_destroy(
-    EcsStorage* storage, EcsFinalizer* finalizer, const EcsEntityId id) {
+void ecs_storage_entity_destroy(EcsStorage* storage, const EcsEntityId id) {
 
   EcsEntityInfo* info = ecs_storage_entity_info_ptr(storage, id);
   diag_assert_msg(info, "Missing entity-info for entity '{}'", fmt_int(id));
 
   EcsArchetype* archetype = ecs_storage_archetype_ptr(storage, info->archetype);
   if (archetype) {
-    ecs_storage_queue_finalize_entity(storage, finalizer, id);
-    ecs_finalizer_flush(finalizer); // TODO: Remove this intermidate flush.
-
     const EcsEntityId movedEntity = ecs_archetype_remove(archetype, info->archetypeIndex);
     if (ecs_entity_valid(movedEntity)) {
       ecs_storage_entity_info_ptr(storage, movedEntity)->archetypeIndex = info->archetypeIndex;

--- a/libs/ecs/src/storage.c
+++ b/libs/ecs/src/storage.c
@@ -50,29 +50,30 @@ static EcsEntityInfo* ecs_storage_entity_info_ptr(EcsStorage* storage, const Ecs
   return info->serial == ecs_entity_id_serial(id) ? info : null;
 }
 
-static void ecs_storage_queue_finalize(EcsStorage* storage, EcsIterator* itr) {
+static void ecs_storage_queue_finalize(EcsFinalizer* finalizer, EcsIterator* itr) {
   EcsCompId compId = 0;
   for (usize i = 0; i != itr->compCount; ++i, ++compId) {
     compId = (EcsCompId)bitset_next(itr->mask, compId);
-    ecs_finalizer_push(&storage->finalizer, compId, itr->comps[i].ptr);
+    ecs_finalizer_push(finalizer, compId, itr->comps[i].ptr);
   }
 }
 
-static void ecs_storage_queue_finalize_archetype(EcsStorage* storage, const EcsArchetypeId id) {
+static void ecs_storage_queue_finalize_archetype(
+    EcsStorage* storage, EcsFinalizer* finalizer, const EcsArchetypeId id) {
+
   EcsArchetype* archetype = ecs_storage_archetype_ptr(storage, id);
   EcsIterator*  itr       = ecs_iterator_stack(archetype->mask);
   while (ecs_storage_itr_walk(storage, itr, id)) {
-    ecs_storage_queue_finalize(storage, itr);
+    ecs_storage_queue_finalize(finalizer, itr);
   }
 }
 
-static void ecs_storage_finalize_entity(
-    EcsStorage* storage, EcsArchetype* archetype, const u32 archetypeIndex, const BitSet mask) {
+static void ecs_storage_queue_finalize_entity(
+    EcsFinalizer* finalizer, EcsArchetype* archetype, const u32 archetypeIndex, const BitSet mask) {
 
   EcsIterator* itr = ecs_iterator_stack(mask);
   ecs_archetype_itr_jump(archetype, itr, archetypeIndex);
-  ecs_storage_queue_finalize(storage, itr);
-  ecs_finalizer_flush(&storage->finalizer);
+  ecs_storage_queue_finalize(finalizer, itr);
 }
 
 i8 ecs_compare_archetype(const void* a, const void* b) { return compare_u32(a, b); }
@@ -82,7 +83,6 @@ EcsStorage ecs_storage_create(Allocator* alloc, const EcsDef* def) {
 
   EcsStorage storage = (EcsStorage){
       .def             = def,
-      .finalizer       = ecs_finalizer_create(alloc, def),
       .entityAllocator = entity_allocator_create(alloc),
       .entities        = dynarray_create_t(alloc, EcsEntityInfo, ecs_starting_entities_capacity),
       .newEntities     = dynarray_create_t(alloc, EcsEntityId, 128),
@@ -94,24 +94,22 @@ EcsStorage ecs_storage_create(Allocator* alloc, const EcsDef* def) {
 }
 
 void ecs_storage_destroy(EcsStorage* storage) {
-  // Finalize (invoke destructors) on all components in the archetypes.
-  for (EcsArchetypeId archId = 0; archId != storage->archetypes.size; ++archId) {
-    ecs_storage_queue_finalize_archetype(storage, archId);
-  }
-  ecs_finalizer_flush(&storage->finalizer);
-
-  // Destoy the archetypes.
   for (EcsArchetypeId archId = 0; archId != storage->archetypes.size; ++archId) {
     EcsArchetype* arch = dynarray_at_t(&storage->archetypes, archId, EcsArchetype);
     ecs_archetype_destroy(arch);
   }
   dynarray_destroy(&storage->archetypes);
 
-  ecs_finalizer_destroy(&storage->finalizer);
   entity_allocator_destroy(&storage->entityAllocator);
 
   dynarray_destroy(&storage->entities);
   dynarray_destroy(&storage->newEntities);
+}
+
+void ecs_storage_queue_finalize_all(EcsStorage* storage, EcsFinalizer* finalizer) {
+  for (EcsArchetypeId archId = 0; archId != storage->archetypes.size; ++archId) {
+    ecs_storage_queue_finalize_archetype(storage, finalizer, archId);
+  }
 }
 
 EcsEntityId ecs_storage_entity_create(EcsStorage* storage) {
@@ -156,7 +154,10 @@ EcsArchetypeId ecs_storage_entity_archetype(EcsStorage* storage, const EcsEntity
 }
 
 void ecs_storage_entity_move(
-    EcsStorage* storage, const EcsEntityId id, const EcsArchetypeId newArchetypeId) {
+    EcsStorage*          storage,
+    EcsFinalizer*        finalizer,
+    const EcsEntityId    id,
+    const EcsArchetypeId newArchetypeId) {
 
   EcsEntityInfo* info              = ecs_storage_entity_info_ptr(storage, id);
   EcsArchetype*  oldArchetype      = ecs_storage_archetype_ptr(storage, info->archetype);
@@ -192,7 +193,8 @@ void ecs_storage_entity_move(
       bitset_xor(missing, newArchetype->mask);
       bitset_and(missing, oldArchetype->mask);
     }
-    ecs_storage_finalize_entity(storage, oldArchetype, oldArchetypeIndex, missing);
+    ecs_storage_queue_finalize_entity(finalizer, oldArchetype, oldArchetypeIndex, missing);
+    ecs_finalizer_flush(finalizer); // TODO: Remove this intermidate flush.
 
     const EcsEntityId movedEntity = ecs_archetype_remove(oldArchetype, oldArchetypeIndex);
     if (ecs_entity_valid(movedEntity)) {
@@ -201,14 +203,16 @@ void ecs_storage_entity_move(
   }
 }
 
-void ecs_storage_entity_destroy(EcsStorage* storage, const EcsEntityId id) {
+void ecs_storage_entity_destroy(
+    EcsStorage* storage, EcsFinalizer* finalizer, const EcsEntityId id) {
 
   EcsEntityInfo* info = ecs_storage_entity_info_ptr(storage, id);
   diag_assert_msg(info, "Missing entity-info for entity '{}'", fmt_int(id));
 
   EcsArchetype* archetype = ecs_storage_archetype_ptr(storage, info->archetype);
   if (archetype) {
-    ecs_storage_finalize_entity(storage, archetype, info->archetypeIndex, archetype->mask);
+    ecs_storage_queue_finalize_entity(finalizer, archetype, info->archetypeIndex, archetype->mask);
+    ecs_finalizer_flush(finalizer); // TODO: Remove this intermidate flush.
 
     const EcsEntityId movedEntity = ecs_archetype_remove(archetype, info->archetypeIndex);
     if (ecs_entity_valid(movedEntity)) {

--- a/libs/ecs/src/storage_internal.h
+++ b/libs/ecs/src/storage_internal.h
@@ -33,9 +33,8 @@ EcsEntityId    ecs_storage_entity_create(EcsStorage*);
 bool           ecs_storage_entity_exists(const EcsStorage*, EcsEntityId);
 BitSet         ecs_storage_entity_mask(EcsStorage*, EcsEntityId);
 EcsArchetypeId ecs_storage_entity_archetype(EcsStorage*, EcsEntityId);
-void           ecs_storage_entity_move(
-              EcsStorage*, EcsFinalizer*, EcsEntityId, EcsArchetypeId newArchetypeId);
-void ecs_storage_entity_destroy(EcsStorage*, EcsEntityId);
+void           ecs_storage_entity_move(EcsStorage*, EcsEntityId, EcsArchetypeId newArchetypeId);
+void           ecs_storage_entity_destroy(EcsStorage*, EcsEntityId);
 
 usize          ecs_storage_archetype_count(const EcsStorage*);
 usize          ecs_storage_archetype_entities_per_chunk(const EcsStorage*, EcsArchetypeId);

--- a/libs/ecs/src/storage_internal.h
+++ b/libs/ecs/src/storage_internal.h
@@ -11,7 +11,6 @@ typedef u32 EcsArchetypeId;
 
 typedef struct {
   const EcsDef* def;
-  EcsFinalizer  finalizer;
 
   EntityAllocator entityAllocator;
   DynArray        entities; // EcsEntityInfo[].
@@ -27,12 +26,15 @@ i8 ecs_compare_archetype(const void* a, const void* b);
 EcsStorage ecs_storage_create(Allocator*, const EcsDef*);
 void       ecs_storage_destroy(EcsStorage*);
 
+void ecs_storage_queue_finalize_all(EcsStorage*, EcsFinalizer*);
+
 EcsEntityId    ecs_storage_entity_create(EcsStorage*);
 bool           ecs_storage_entity_exists(const EcsStorage*, EcsEntityId);
 BitSet         ecs_storage_entity_mask(EcsStorage*, EcsEntityId);
 EcsArchetypeId ecs_storage_entity_archetype(EcsStorage*, EcsEntityId);
-void           ecs_storage_entity_move(EcsStorage*, EcsEntityId, EcsArchetypeId newArchetypeId);
-void           ecs_storage_entity_destroy(EcsStorage*, EcsEntityId);
+void           ecs_storage_entity_move(
+              EcsStorage*, EcsFinalizer*, EcsEntityId, EcsArchetypeId newArchetypeId);
+void ecs_storage_entity_destroy(EcsStorage*, EcsFinalizer*, EcsEntityId);
 
 usize          ecs_storage_archetype_count(const EcsStorage*);
 usize          ecs_storage_archetype_entities_per_chunk(const EcsStorage*, EcsArchetypeId);

--- a/libs/ecs/src/storage_internal.h
+++ b/libs/ecs/src/storage_internal.h
@@ -26,7 +26,7 @@ i8 ecs_compare_archetype(const void* a, const void* b);
 EcsStorage ecs_storage_create(Allocator*, const EcsDef*);
 void       ecs_storage_destroy(EcsStorage*);
 
-void ecs_storage_queue_finalize_entity(EcsStorage*, EcsFinalizer*, EcsEntityId);
+void ecs_storage_queue_finalize(EcsStorage*, EcsFinalizer*, EcsEntityId, BitSet mask);
 void ecs_storage_queue_finalize_all(EcsStorage*, EcsFinalizer*);
 
 EcsEntityId    ecs_storage_entity_create(EcsStorage*);

--- a/libs/ecs/src/storage_internal.h
+++ b/libs/ecs/src/storage_internal.h
@@ -35,7 +35,7 @@ BitSet         ecs_storage_entity_mask(EcsStorage*, EcsEntityId);
 EcsArchetypeId ecs_storage_entity_archetype(EcsStorage*, EcsEntityId);
 void           ecs_storage_entity_move(
               EcsStorage*, EcsFinalizer*, EcsEntityId, EcsArchetypeId newArchetypeId);
-void ecs_storage_entity_destroy(EcsStorage*, EcsFinalizer*, EcsEntityId);
+void ecs_storage_entity_destroy(EcsStorage*, EcsEntityId);
 
 usize          ecs_storage_archetype_count(const EcsStorage*);
 usize          ecs_storage_archetype_entities_per_chunk(const EcsStorage*, EcsArchetypeId);

--- a/libs/ecs/src/storage_internal.h
+++ b/libs/ecs/src/storage_internal.h
@@ -26,6 +26,7 @@ i8 ecs_compare_archetype(const void* a, const void* b);
 EcsStorage ecs_storage_create(Allocator*, const EcsDef*);
 void       ecs_storage_destroy(EcsStorage*);
 
+void ecs_storage_queue_finalize_entity(EcsStorage*, EcsFinalizer*, EcsEntityId);
 void ecs_storage_queue_finalize_all(EcsStorage*, EcsFinalizer*);
 
 EcsEntityId    ecs_storage_entity_create(EcsStorage*);

--- a/libs/ecs/src/world.c
+++ b/libs/ecs/src/world.c
@@ -304,7 +304,8 @@ void ecs_world_flush_internal(EcsWorld* world) {
   for (usize i = 0; i != bufferCount; ++i) {
     const EcsEntityId entity = ecs_buffer_entity(&world->buffer, i);
     if (ecs_buffer_entity_flags(&world->buffer, i) & EcsBufferEntityFlags_Destroy) {
-      ecs_storage_queue_finalize_entity(&world->storage, &world->finalizer, entity);
+      const BitSet mask = ecs_storage_entity_mask(&world->storage, entity);
+      ecs_storage_queue_finalize(&world->storage, &world->finalizer, entity, mask);
       // NOTE: Discard any component additions for the same entity in the buffer.
       ecs_world_queue_finalize_added(world, &world->buffer, i);
     }

--- a/libs/ecs/src/world.c
+++ b/libs/ecs/src/world.c
@@ -188,15 +188,16 @@ void ecs_world_destroy(EcsWorld* world) {
 
   // Finalize (invoke destructors) all components on all entities.
   ecs_storage_queue_finalize_all(&world->storage, &world->finalizer);
+  ecs_buffer_queue_finalize_all(&world->buffer, &world->finalizer);
+
   ecs_finalizer_flush(&world->finalizer);
   ecs_finalizer_destroy(&world->finalizer);
 
   ecs_storage_destroy(&world->storage);
+  ecs_buffer_destroy(&world->buffer);
 
   dynarray_for_t(&world->views, EcsView, view) { ecs_view_destroy(world->alloc, world->def, view); }
   dynarray_destroy(&world->views);
-
-  ecs_buffer_destroy(&world->buffer);
 
   log_d("Ecs world destroyed", log_param("archetypes", fmt_int(archetypeCount)));
 

--- a/libs/ecs/test/test_destruct.c
+++ b/libs/ecs/test/test_destruct.c
@@ -190,10 +190,10 @@ spec(destruct) {
 
     check_require(g_destructCount == 4);
     /**
-     * Destruction order is respected per entity for mid-frame destroys.
+     * Verify that destruction order is respected globally.
      */
-    check_eq_int(g_destructs[0], ecs_comp_id(DestructCompA));
-    check_eq_int(g_destructs[1], ecs_comp_id(DestructCompB));
+    check_eq_int(g_destructs[0], ecs_comp_id(DestructCompB));
+    check_eq_int(g_destructs[1], ecs_comp_id(DestructCompA));
     check_eq_int(g_destructs[2], ecs_comp_id(DestructCompA));
     check_eq_int(g_destructs[3], ecs_comp_id(DestructCompC));
 

--- a/libs/ecs/test/test_destruct.c
+++ b/libs/ecs/test/test_destruct.c
@@ -107,10 +107,10 @@ spec(destruct) {
 
     check_require(g_destructCount == 4);
     /**
-     * Destruction order is respected per entity for mid-frame destroys.
+     * Verify that destruction order is respected globally.
      */
-    check_eq_int(g_destructs[0], ecs_comp_id(DestructCompA));
-    check_eq_int(g_destructs[1], ecs_comp_id(DestructCompB));
+    check_eq_int(g_destructs[0], ecs_comp_id(DestructCompB));
+    check_eq_int(g_destructs[1], ecs_comp_id(DestructCompA));
     check_eq_int(g_destructs[2], ecs_comp_id(DestructCompA));
     check_eq_int(g_destructs[3], ecs_comp_id(DestructCompC));
 
@@ -138,7 +138,7 @@ spec(destruct) {
 
     check_require(g_destructCount == 4);
     /**
-     * Destruction order is respected globally on shutdown.
+     * Verify that destruction order is respected globally.
      */
     check_eq_int(g_destructs[0], ecs_comp_id(DestructCompB));
     check_eq_int(g_destructs[1], ecs_comp_id(DestructCompA));

--- a/libs/ecs/test/test_destruct.c
+++ b/libs/ecs/test/test_destruct.c
@@ -226,10 +226,10 @@ spec(destruct) {
 
     check_require(g_destructCount == 4);
     /**
-     * Destruction order is respected per entity for mid-frame destroys.
+     * Verify that destruction order is respected globally.
      */
-    check_eq_int(g_destructs[0], ecs_comp_id(DestructCompA));
-    check_eq_int(g_destructs[1], ecs_comp_id(DestructCompB));
+    check_eq_int(g_destructs[0], ecs_comp_id(DestructCompB));
+    check_eq_int(g_destructs[1], ecs_comp_id(DestructCompA));
     check_eq_int(g_destructs[2], ecs_comp_id(DestructCompA));
     check_eq_int(g_destructs[3], ecs_comp_id(DestructCompC));
 


### PR DESCRIPTION
Refactors in the ecs to respect the destruction order globally (even for flushes) instead of per entity.