### PR TITLE
core: Set the win32 scheduling interval

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -57,6 +57,9 @@ target_include_directories(lib_core PUBLIC include)
 if(${VOLO_PLATFORM} STREQUAL "linux")
   # Link against the math library on linux.
   target_link_libraries(lib_core PRIVATE m)
+elseif(${VOLO_PLATFORM} STREQUAL "win32")
+  # Link against 'winmm.lib' (Windows Multimedia API) for controlling the scheduling interval.
+  target_link_libraries(lib_core winmm.lib)
 endif()
 
 add_executable(lib_core_test

--- a/libs/core/src/init.c
+++ b/libs/core/src/init.c
@@ -42,6 +42,7 @@ void core_teardown() {
     g_initializedThread = false;
   }
   if (g_thread_tid == g_thread_main_tid && g_intialized) {
+    thread_teardown();
     alloc_teardown();
     g_intialized = false;
   }

--- a/libs/core/src/init_internal.h
+++ b/libs/core/src/init_internal.h
@@ -27,6 +27,7 @@ void thread_init_thread();
  * Fired once when the core library is torn down.
  */
 void alloc_teardown();
+void thread_teardown();
 void tty_teardown();
 
 /**

--- a/libs/core/src/thread.c
+++ b/libs/core/src/thread.c
@@ -42,12 +42,16 @@ THREAD_LOCAL String g_thread_name;
 u16                 g_thread_core_count;
 
 void thread_init() {
+  thread_pal_init();
+
   g_thread_pid        = thread_pal_pid();
   g_thread_main_tid   = thread_pal_tid();
   g_thread_name       = string_lit("volo_main");
   g_thread_core_count = thread_pal_core_count();
   thread_pal_set_name(g_thread_name);
 }
+
+void thread_teardown() { thread_pal_teardown(); }
 
 void thread_init_thread() { g_thread_tid = thread_pal_tid(); }
 

--- a/libs/core/src/thread_internal.h
+++ b/libs/core/src/thread_internal.h
@@ -11,6 +11,9 @@
 ASSERT(false, "Unsupported platform");
 #endif
 
+void thread_pal_init();
+void thread_pal_teardown();
+
 i64  thread_pal_pid();
 i64  thread_pal_tid();
 u16  thread_pal_core_count();

--- a/libs/core/src/thread_pal_linux.c
+++ b/libs/core/src/thread_pal_linux.c
@@ -10,6 +10,9 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+void thread_pal_init() {}
+void thread_pal_teardown() {}
+
 i64 thread_pal_pid() { return syscall(SYS_getpid); }
 i64 thread_pal_tid() { return syscall(SYS_gettid); }
 

--- a/libs/core/src/thread_pal_win32.c
+++ b/libs/core/src/thread_pal_win32.c
@@ -6,7 +6,7 @@
 #include "thread_internal.h"
 
 #include <Windows.h>
-#include <timeapi.h>
+#include <mmsystem.h> // Part of the Windows Multimedia API (winmm.lib).
 
 /**
  * Requested minimum OS scheduling interval in milliseconds.

--- a/libs/core/src/thread_pal_win32.c
+++ b/libs/core/src/thread_pal_win32.c
@@ -6,6 +6,26 @@
 #include "thread_internal.h"
 
 #include <Windows.h>
+#include <timeapi.h>
+
+/**
+ * Requested minimum OS scheduling interval in milliseconds.
+ * This is a tradeoff between overhead due to many context switches if set too low and taking a long
+ * time to wake threads when set too high.
+ */
+static const u32 g_win32SchedulingInterval = 2;
+
+void thread_pal_init() {
+  if (timeBeginPeriod(g_win32SchedulingInterval) != TIMERR_NOERROR) {
+    diag_assert_fail("Failed to set win32 scheduling interval");
+  }
+}
+
+void thread_pal_teardown() {
+  if (timeEndPeriod(g_win32SchedulingInterval) != TIMERR_NOERROR) {
+    diag_assert_fail("Failed to restore win32 scheduling interval");
+  }
+}
 
 i64 thread_pal_pid() { return GetCurrentProcessId(); }
 i64 thread_pal_tid() { return GetCurrentThreadId(); }
@@ -114,22 +134,16 @@ void thread_pal_join(ThreadHandle thread) {
 void thread_pal_yield() { SwitchToThread(); }
 
 void thread_pal_sleep(const TimeDuration duration) {
-  static const TimeDuration g_minSleep = time_milliseconds(15);
-
   /**
-   * On Win32 Sleep() only has granularity to about 10 - 15ms due to the default scheduling period.
+   * On Win32 Sleep() only has granularity up to the scheduling period.
    * To sill provide support for short sleeps we do the bulk of the waiting using Sleep() and then
    * do a loop of yielding our timeslice until the desired duration is met.
-   *
-   * TODO: Is it worth it to change the global scheduling period?
-   * Requires linking with the Winmm dll.
-   * https://docs.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod
    */
   TimeSteady start = time_steady_clock();
 
   // Bulk of the sleeping.
-  if (duration > g_minSleep) {
-    Sleep((DWORD)((duration - g_minSleep) / time_millisecond));
+  if (duration > time_milliseconds(g_win32SchedulingInterval)) {
+    Sleep((DWORD)((duration - time_milliseconds(g_win32SchedulingInterval)) / time_millisecond));
   }
 
   // Wait for the remaining time by yielding our timeslice.


### PR DESCRIPTION
Makes thread wake-up faster and sleeps more precise at the tradeoff of a few more context switches.