### PR TITLE
ecs: Re-use job graph memory

### DIFF
--- a/libs/check/src/runner.c
+++ b/libs/check/src/runner.c
@@ -95,7 +95,7 @@ CheckResultType check_run(CheckDef* check, const CheckRunFlags flags) {
   }
 
   // Execute all tasks.
-  jobs_scheduler_wait_help(jobs_scheduler_run(graph));
+  jobs_scheduler_wait_help(jobs_scheduler_run(graph, g_alloc_page));
 
   // Observe the results.
   const usize           numFailed  = ctx.numFailedTests;

--- a/libs/debug/src/stats.c
+++ b/libs/debug/src/stats.c
@@ -286,7 +286,7 @@ static void debug_stats_draw_interface(
     const i64       pageDelta         = allocStats->pageCounter - stats->allocPrevPageCounter;
     const FormatArg pageDeltaColor    = pageDelta > 0 ? fmt_ui_color(ui_color_red) : fmt_nop();
     const i64       heapDelta         = allocStats->heapCounter - stats->allocPrevHeapCounter;
-    const FormatArg heapDeltaColor    = pageDelta > 0 ? fmt_ui_color(ui_color_yellow) : fmt_nop();
+    const FormatArg heapDeltaColor    = heapDelta > 0 ? fmt_ui_color(ui_color_yellow) : fmt_nop();
     const i64       persistDelta      = allocStats->persistCounter - stats->allocPrevPersistCounter;
     const FormatArg persistDeltaColor = persistDelta > 0 ? fmt_ui_color(ui_color_red) : fmt_nop();
 

--- a/libs/ecs/src/runner.c
+++ b/libs/ecs/src/runner.c
@@ -173,9 +173,9 @@ static void runner_collect_systems(EcsRunner* runner, RunnerSystemEntry* output)
   for (EcsSystemId sysId = 0; sysId != systemCount; ++sysId) {
     EcsSystemDef* sysDef = dynarray_at_t(&def->systems, sysId, EcsSystemDef);
     output[sysId]        = (RunnerSystemEntry){
-        .id    = sysId,
-        .order = sysDef->order,
-        .def   = sysDef,
+               .id    = sysId,
+               .order = sysDef->order,
+               .def   = sysDef,
     };
   }
 
@@ -217,11 +217,11 @@ EcsRunner* ecs_runner_create(Allocator* alloc, EcsWorld* world, const EcsRunnerF
 
   EcsRunner* runner = alloc_alloc_t(alloc, EcsRunner);
   *runner           = (EcsRunner){
-      .world            = world,
-      .graph            = jobs_graph_create(alloc, string_lit("ecs_runner"), taskCount),
-      .flags            = flags,
-      .systemTaskLookup = alloc_array_t(alloc, JobTaskId, systemCount),
-      .alloc            = alloc,
+                .world            = world,
+                .graph            = jobs_graph_create(alloc, string_lit("ecs_runner"), taskCount),
+                .flags            = flags,
+                .systemTaskLookup = alloc_array_t(alloc, JobTaskId, systemCount),
+                .alloc            = alloc,
   };
 
   RunnerSystemEntry* systems = alloc_array_t(alloc, RunnerSystemEntry, systemCount);
@@ -269,7 +269,7 @@ JobId ecs_run_async(EcsRunner* runner) {
 
   runner->flags |= EcsRunnerPrivateFlags_Running;
   ecs_world_busy_set(runner->world);
-  return jobs_scheduler_run(runner->graph);
+  return jobs_scheduler_run(runner->graph, g_alloc_page);
 }
 
 void ecs_run_sync(EcsRunner* runner) {

--- a/libs/ecs/src/runner.c
+++ b/libs/ecs/src/runner.c
@@ -53,6 +53,7 @@ struct sEcsRunner {
   u32        flags;
   JobTaskId* systemTaskLookup;
   Allocator* alloc;
+  Mem        jobMem;
 };
 
 THREAD_LOCAL bool        g_ecsRunningSystem;
@@ -242,6 +243,11 @@ EcsRunner* ecs_runner_create(Allocator* alloc, EcsWorld* world, const EcsRunnerF
   if (flags & EcsRunnerFlags_DumpGraphDot) {
     graph_dump_dot(runner);
   }
+
+  // Allocate the runtime memory required to run the graph (reused for every run).
+  // NOTE: +64 for bump allocator overhead.
+  const usize jobMemSize = jobs_scheduler_mem_size(runner->graph) + 64;
+  runner->jobMem         = alloc_alloc(alloc, jobMemSize, jobs_scheduler_mem_align(runner->graph));
   return runner;
 }
 
@@ -251,6 +257,7 @@ void ecs_runner_destroy(EcsRunner* runner) {
   const EcsDef* def = ecs_world_def(runner->world);
   alloc_free_array_t(runner->alloc, runner->systemTaskLookup, def->systems.size);
   jobs_graph_destroy(runner->graph);
+  alloc_free(runner->alloc, runner->jobMem);
   alloc_free_t(runner->alloc, runner);
 }
 
@@ -266,10 +273,11 @@ bool ecs_running(const EcsRunner* runner) {
 
 JobId ecs_run_async(EcsRunner* runner) {
   diag_assert_msg(!ecs_running(runner), "Runner is currently already running");
+  Allocator* jobAlloc = alloc_bump_create(runner->jobMem);
 
   runner->flags |= EcsRunnerPrivateFlags_Running;
   ecs_world_busy_set(runner->world);
-  return jobs_scheduler_run(runner->graph, g_alloc_page);
+  return jobs_scheduler_run(runner->graph, jobAlloc);
 }
 
 void ecs_run_sync(EcsRunner* runner) {

--- a/libs/jobs/include/jobs_scheduler.h
+++ b/libs/jobs/include/jobs_scheduler.h
@@ -12,7 +12,7 @@ typedef u64 JobId;
  * Returns a handle to the running job.
  * Pre-condition: g_jobsIsWorker == true
  */
-JobId jobs_scheduler_run(JobGraph* graph);
+JobId jobs_scheduler_run(JobGraph* graph, Allocator*);
 
 /**
  * Check if the given job has finished yet.

--- a/libs/jobs/include/jobs_scheduler.h
+++ b/libs/jobs/include/jobs_scheduler.h
@@ -33,3 +33,9 @@ void jobs_scheduler_wait(JobId);
  * Pre-condition: g_jobsIsWorking == false
  */
 void jobs_scheduler_wait_help(JobId);
+
+/**
+ * Query the required memory size and alignment to run the given job graph.
+ */
+usize jobs_scheduler_mem_size(const JobGraph*);
+usize jobs_scheduler_mem_align(const JobGraph*);

--- a/libs/jobs/src/job.c
+++ b/libs/jobs/src/job.c
@@ -20,6 +20,7 @@ Job* job_create(Allocator* alloc, const JobId id, const JobGraph* graph) {
   // Initialize per-job data.
   data->id           = id;
   data->graph        = graph;
+  data->jobAlloc     = alloc;
   data->dependencies = (i64)jobs_graph_task_leaf_count(graph);
 
   // Initialize per-task data.
@@ -30,7 +31,6 @@ Job* job_create(Allocator* alloc, const JobId id, const JobGraph* graph) {
   return data;
 }
 
-void job_destroy(Allocator* alloc, Job* job) {
-  const usize size = sizeof(Job) + sizeof(JobTaskData) * jobs_graph_task_count(job->graph);
-  alloc_free(alloc, mem_create(job, size));
+void job_destroy(Job* job) {
+  alloc_free(job->jobAlloc, mem_create(job, job_mem_req_size(job->graph)));
 }

--- a/libs/jobs/src/job.c
+++ b/libs/jobs/src/job.c
@@ -3,9 +3,19 @@
 
 #include "job_internal.h"
 
+usize job_mem_req_size(const JobGraph* graph) {
+  return sizeof(Job) + sizeof(JobTaskData) * jobs_graph_task_count(graph);
+}
+
+usize job_mem_req_align(const JobGraph* graph) {
+  (void)graph;
+  return job_size;
+}
+
 Job* job_create(Allocator* alloc, const JobId id, const JobGraph* graph) {
-  const usize size = sizeof(Job) + sizeof(JobTaskData) * jobs_graph_task_count(graph);
-  Job*        data = alloc_alloc(alloc, size, job_size).ptr;
+  const usize size  = job_mem_req_size(graph);
+  const usize align = job_mem_req_align(graph);
+  Job*        data  = alloc_alloc(alloc, size, align).ptr;
 
   // Initialize per-job data.
   data->id           = id;

--- a/libs/jobs/src/job_internal.h
+++ b/libs/jobs/src/job_internal.h
@@ -22,6 +22,7 @@ ASSERT(sizeof(JobTaskData) == job_size, "Invalid JobTaskData size");
 typedef struct {
   ALIGNAS(job_size) JobId id;
   const JobGraph* graph;
+  Allocator*      jobAlloc;
   i64             dependencies; // Remaining dependencies (leaf tasks).
   JobTaskData     taskData[];   // Allocated after this struct.
 } Job;
@@ -32,4 +33,4 @@ usize job_mem_req_size(const JobGraph*);
 usize job_mem_req_align(const JobGraph*);
 
 Job* job_create(Allocator*, const JobId id, const JobGraph*);
-void job_destroy(Allocator*, Job*);
+void job_destroy(Job*);

--- a/libs/jobs/src/job_internal.h
+++ b/libs/jobs/src/job_internal.h
@@ -28,5 +28,8 @@ typedef struct {
 
 ASSERT(sizeof(Job) == job_size, "Invalid Job size");
 
+usize job_mem_req_size(const JobGraph*);
+usize job_mem_req_align(const JobGraph*);
+
 Job* job_create(Allocator*, const JobId id, const JobGraph*);
 void job_destroy(Allocator*, Job*);

--- a/libs/jobs/src/scheduler.c
+++ b/libs/jobs/src/scheduler.c
@@ -100,7 +100,7 @@ void jobs_scheduler_finish(Job* job) {
   thread_mutex_lock(g_jobMutex);
   {
     // Cleanup job data.
-    job_destroy(g_alloc_heap, job);
+    job_destroy(job);
 
     // Remove it from 'g_runningJobs'.
     for (usize i = 0; i != g_runningJobs.size; ++i) {

--- a/libs/jobs/src/scheduler.c
+++ b/libs/jobs/src/scheduler.c
@@ -114,3 +114,6 @@ void jobs_scheduler_finish(Job* job) {
   thread_mutex_unlock(g_jobMutex);
   thread_cond_broadcast(g_jobCondition);
 }
+
+usize jobs_scheduler_mem_size(const JobGraph* graph) { return job_mem_req_size(graph); }
+usize jobs_scheduler_mem_align(const JobGraph* graph) { return job_mem_req_align(graph); }

--- a/libs/jobs/src/scheduler.c
+++ b/libs/jobs/src/scheduler.c
@@ -37,7 +37,7 @@ void scheduler_teardown() {
   dynarray_destroy(&g_runningJobs);
 }
 
-JobId jobs_scheduler_run(JobGraph* graph) {
+JobId jobs_scheduler_run(JobGraph* graph, Allocator* alloc) {
   diag_assert_msg(jobs_graph_validate(graph), "Given job graph is invalid");
   diag_assert_msg(g_jobsIsWorker, "Only job-workers can run jobs");
 
@@ -46,7 +46,7 @@ JobId jobs_scheduler_run(JobGraph* graph) {
     return id; // Job has no roots tasks; nothing to do.
   }
 
-  Job* job = job_create(g_alloc_heap, id, graph);
+  Job* job = job_create(alloc, id, graph);
   thread_mutex_lock(g_jobMutex);
   *dynarray_push_t(&g_runningJobs, Job*) = job;
   thread_mutex_unlock(g_jobMutex);

--- a/libs/jobs/test/test_executor.c
+++ b/libs/jobs/test/test_executor.c
@@ -75,10 +75,10 @@ spec(executor) {
       }
     }
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
     check_eq_int((usize)counter, g_numTasks);
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
     check_eq_int((usize)counter, g_numTasks * 2);
 
     jobs_graph_destroy(jobGraph);
@@ -111,10 +111,10 @@ spec(executor) {
       }
     }
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
     check_eq_int((usize)counter, 0);
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
     check_eq_int((usize)counter, 0);
 
     jobs_graph_destroy(jobGraph);
@@ -135,10 +135,10 @@ spec(executor) {
           task_flags);
     }
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
     check_eq_int((usize)counter, g_numTasks);
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
     check_eq_int((usize)counter, g_numTasks * 2);
 
     jobs_graph_destroy(jobGraph);
@@ -175,7 +175,7 @@ spec(executor) {
       rootLayer = false;
     }
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(graph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(graph, g_alloc_page));
     check_eq_int(data[0], sum);
 
     dynarray_destroy(&dependencies);
@@ -206,7 +206,7 @@ spec(executor) {
       jobs_graph_task_depend(graph, initTask, task);
     }
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(graph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(graph, g_alloc_page));
     array_for_t(data, i64, val) { check_eq_int(*val, 42); }
 
     jobs_graph_destroy(graph);
@@ -227,8 +227,8 @@ spec(executor) {
           task_flags | JobTaskFlags_ThreadAffinity);
     }
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
 
     jobs_graph_destroy(jobGraph);
   }
@@ -250,8 +250,8 @@ spec(executor) {
       }
     }
 
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
-    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
+    jobs_scheduler_wait_help(jobs_scheduler_run(jobGraph, g_alloc_page));
 
     jobs_graph_destroy(jobGraph);
   }

--- a/libs/jobs/test/test_scheduler.c
+++ b/libs/jobs/test/test_scheduler.c
@@ -12,7 +12,7 @@ spec(scheduler) {
     JobGraph* jobGraph = jobs_graph_create(g_alloc_heap, string_lit("TestJob"), 1);
     jobs_graph_add_task(jobGraph, string_lit("TestTask"), test_task_nop, mem_empty, task_flags);
 
-    JobId id = jobs_scheduler_run(jobGraph);
+    JobId id = jobs_scheduler_run(jobGraph, g_alloc_page);
     jobs_scheduler_wait_help(id);
     check(jobs_scheduler_is_finished(id));
 
@@ -29,7 +29,7 @@ spec(scheduler) {
 
     // Start the graph multiple times.
     for (usize i = 0; i != g_numRuns; ++i) {
-      *dynarray_push_t(&jobIds, JobId) = jobs_scheduler_run(jobGraph);
+      *dynarray_push_t(&jobIds, JobId) = jobs_scheduler_run(jobGraph, g_alloc_page);
     }
 
     // Wait for all jobs to finish.


### PR DESCRIPTION
Avoids doing a new page allocation every frame.