### PR TITLE
Feature/UI text editor viewport

### DIFF
--- a/libs/ui/src/builder.c
+++ b/libs/ui/src/builder.c
@@ -264,6 +264,8 @@ static void ui_build_draw_text(UiBuildState* state, const UiDrawText* cmd) {
         state->ctx->userCtx,
         cmd->id,
         (UiBuildTextInfo){
+            .lineCount        = result.lineCount,
+            .maxLineCharWidth = result.maxLineCharWidth,
             .hoveredCharIndex = result.hoveredCharIndex,
         });
   }
@@ -303,11 +305,11 @@ static void ui_build_debug_inspector(UiBuildState* state, const UiId id, const U
   const UiBuildStyle styleShape     = {.color = {255, 0, 0, 178}, .layer = UiLayer_Overlay};
   const UiBuildStyle styleContainer = {.color = {0, 0, 255, 178}, .layer = UiLayer_Overlay};
   const UiBuildStyle styleText      = {
-      .color     = ui_color_white,
-      .outline   = 3,
-      .variation = 1,
-      .weight    = UiWeight_Bold,
-      .layer     = UiLayer_Overlay};
+           .color     = ui_color_white,
+           .outline   = 3,
+           .variation = 1,
+           .weight    = UiWeight_Bold,
+           .layer     = UiLayer_Overlay};
 
   ui_build_glyph(state, UiShape_Square, container.rect, styleContainer, 5, 0);
   ui_build_glyph(state, UiShape_Square, rect, styleShape, 5, 0);

--- a/libs/ui/src/builder_internal.h
+++ b/libs/ui/src/builder_internal.h
@@ -21,6 +21,9 @@ typedef struct {
 ASSERT(sizeof(UiGlyphData) == 32, "Size needs to match the size defined in glsl");
 
 typedef struct {
+  u32 lineCount;
+  u32 maxLineCharWidth;
+
   /**
    * Index of the character that was hovered in the text.
    * NOTE: Is 'sentinel_usize' when no character was hovered.

--- a/libs/ui/src/text.c
+++ b/libs/ui/src/text.c
@@ -422,10 +422,11 @@ UiTextBuildResult ui_text_build(
    */
   UiTextBackgroundCollector bgCollector = {.active = sentinel_u32};
   UiTextLine                lines[ui_text_max_lines];
-  u32                       lineCount  = 0;
-  f32                       lineY      = 0;
-  f32                       totalWidth = 0;
-  String                    remText    = text;
+  u32                       lineCount        = 0;
+  f32                       lineY            = 0;
+  f32                       totalWidth       = 0;
+  u32                       maxLineCharWidth = 0;
+  String                    remText          = text;
   while (!string_is_empty(remText)) {
     const f32 lineHeight = lineCount ? (1 + font->lineSpacing) * fontSize : fontSize;
     if (lineY + lineHeight >= totalRect.height - font->lineSpacing * fontSize) {
@@ -450,6 +451,7 @@ UiTextBuildResult ui_text_build(
 
     lines[lineIndex].posY = lineY;
     totalWidth            = math_max(totalWidth, lines[lineIndex].size.width);
+    maxLineCharWidth      = math_max(maxLineCharWidth, (u32)lines[lineIndex].text.size);
 
     if (flags & UiFlags_SingleLine) {
       break;
@@ -496,6 +498,7 @@ UiTextBuildResult ui_text_build(
   return (UiTextBuildResult){
       .rect             = rect,
       .lineCount        = lineCount,
+      .maxLineCharWidth = maxLineCharWidth,
       .hoveredCharIndex = state.hoveredCharIndex,
   };
 }

--- a/libs/ui/src/text_internal.h
+++ b/libs/ui/src/text_internal.h
@@ -26,6 +26,7 @@ typedef void (*UiTextBuildBackgroundFunc)(void* userCtx, const UiTextBackgroundI
 typedef struct {
   UiRect rect;
   u32    lineCount;
+  u32    maxLineCharWidth;
   /**
    * Byte index of the hovered character.
    * TODO: Does not support multi-line text atm (always returns a char on the last visible line).


### PR DESCRIPTION
If text does not fit inside the text editor rectangle the 'viewport' is adjusted to keep the cursor in the visible section.