### PR TITLE
Gltf animation compatiblity improvements

### DIFF
--- a/assets/shaders/include/instance.glsl
+++ b/assets/shaders/include/instance.glsl
@@ -4,7 +4,7 @@
 #include "types.glsl"
 
 const u32 c_maxInstances = 2048;
-const u32 c_maxJoints    = 32; // Needs to match the maximum in rend_instance.c
+const u32 c_maxJoints    = 64; // Needs to match the maximum in rend_instance.c
 
 struct InstanceData {
   f32v4 posAndScale; // x, y, z position, w scale

--- a/assets/shaders/include/instance.glsl
+++ b/assets/shaders/include/instance.glsl
@@ -4,7 +4,7 @@
 #include "types.glsl"
 
 const u32 c_maxInstances = 2048;
-const u32 c_maxJoints    = 64; // Needs to match the maximum in rend_instance.c
+const u32 c_maxJoints    = 75; // Needs to match the maximum in rend_instance.c
 
 struct InstanceData {
   f32v4 posAndScale; // x, y, z position, w scale

--- a/libs/asset/include/asset_mesh.h
+++ b/libs/asset/include/asset_mesh.h
@@ -4,7 +4,7 @@
 #include "geo_matrix.h"
 
 #define asset_mesh_indices_max u32_max
-#define asset_mesh_joints_max 64
+#define asset_mesh_joints_max 75
 ASSERT(asset_mesh_joints_max <= u8_max, "Joint indices should be representable by a u8");
 
 typedef u32 AssetMeshIndex;

--- a/libs/asset/include/asset_mesh.h
+++ b/libs/asset/include/asset_mesh.h
@@ -4,7 +4,7 @@
 #include "geo_matrix.h"
 
 #define asset_mesh_indices_max u32_max
-#define asset_mesh_joints_max 32
+#define asset_mesh_joints_max 64
 ASSERT(asset_mesh_joints_max <= u8_max, "Joint indices should be representable by a u8");
 
 typedef u32 AssetMeshIndex;

--- a/libs/asset/src/loader_mesh_gltf.c
+++ b/libs/asset/src/loader_mesh_gltf.c
@@ -449,7 +449,8 @@ static void gltf_buffers_acquire(GltfLoad* ld, EcsWorld* w, AssetManagerComp* ma
   if (!(ld->bufferCount = gltf_json_elem_count(ld, buffers))) {
     goto Error;
   }
-  ld->buffers     = alloc_array_t(g_alloc_heap, GltfBuffer, ld->bufferCount);
+  ld->buffers = alloc_array_t(g_alloc_heap, GltfBuffer, ld->bufferCount);
+  mem_set(mem_create(ld->buffers, sizeof(GltfBuffer) * ld->bufferCount), 0);
   GltfBuffer* out = ld->buffers;
 
   json_for_elems(ld->jDoc, buffers, bufferElem) {
@@ -1196,7 +1197,9 @@ ecs_system_define(GltfLoadAssetSys) {
 
   Cleanup:
     for (GltfBuffer* buffer = ld->buffers; buffer != ld->buffers + ld->bufferCount; ++buffer) {
-      asset_release(world, buffer->entity);
+      if (buffer->entity) {
+        asset_release(world, buffer->entity);
+      }
     }
     ecs_world_remove_t(world, entity, AssetGltfLoadComp);
 

--- a/libs/asset/src/loader_mesh_gltf.c
+++ b/libs/asset/src/loader_mesh_gltf.c
@@ -972,8 +972,13 @@ static void gltf_build_mesh(GltfLoad* ld, AssetMeshComp* out, GltfError* err) {
           });
 
       if (meta.features & GltfFeature_Skinning) {
-        const u16*       vertJoints = &joints[attr * 4];
-        const GeoVector* vertWeight = (const GeoVector*)&weights[attr * 4];
+        const u16*      vertJoints  = &joints[attr * 4];
+        const GeoVector vertWeights = {
+            weights[attr * 4 + 0],
+            weights[attr * 4 + 1],
+            weights[attr * 4 + 2],
+            weights[attr * 4 + 3],
+        };
         const u16 j0 = vertJoints[0], j1 = vertJoints[1], j2 = vertJoints[2], j3 = vertJoints[3];
         const u32 jointMax = ld->jointCount;
         if (UNLIKELY(j0 >= jointMax || j1 >= jointMax || j2 >= jointMax || j3 >= jointMax)) {
@@ -983,7 +988,7 @@ static void gltf_build_mesh(GltfLoad* ld, AssetMeshComp* out, GltfError* err) {
         asset_mesh_builder_set_skin(
             builder,
             vertIdx,
-            (AssetMeshSkin){.joints = {(u8)j0, (u8)j1, (u8)j2, (u8)j3}, .weights = *vertWeight});
+            (AssetMeshSkin){.joints = {(u8)j0, (u8)j1, (u8)j2, (u8)j3}, .weights = vertWeights});
       }
     }
   }

--- a/libs/asset/src/loader_mesh_gltf.c
+++ b/libs/asset/src/loader_mesh_gltf.c
@@ -460,7 +460,11 @@ static void gltf_buffers_acquire(GltfLoad* ld, EcsWorld* w, AssetManagerComp* ma
     if (!gltf_json_field_str(ld, bufferElem, string_lit("uri"), &uri)) {
       goto Error;
     }
-    out->entity = asset_lookup(w, man, gltf_buffer_asset_id(ld, uri));
+    const String assetId = gltf_buffer_asset_id(ld, uri);
+    if (string_eq(assetId, ld->assetId)) {
+      goto Error; // Cannot load this same file again as a buffer.
+    }
+    out->entity = asset_lookup(w, man, assetId);
     asset_acquire(w, out->entity);
     ++out;
   }

--- a/libs/asset/src/loader_mesh_gltf.c
+++ b/libs/asset/src/loader_mesh_gltf.c
@@ -655,12 +655,15 @@ static void gltf_parse_skin(GltfLoad* ld, GltfError* err) {
     *outJoint++ = (GltfJoint){.nodeIndex = (u32)json_number(ld->jDoc, joint)};
   }
   u32 skeletonNodeIndex;
-  if (!gltf_json_field_u32(ld, skin, string_lit("skeleton"), &skeletonNodeIndex)) {
-    goto Error;
-  }
+  if (gltf_json_field_u32(ld, skin, string_lit("skeleton"), &skeletonNodeIndex)) {
+    // Optional node index of the root of the skeleton.
   if (sentinel_check(ld->rootJointIndex = gltf_node_to_joint_index(ld, skeletonNodeIndex))) {
     goto Error;
   }
+  } else {
+    ld->rootJointIndex = 0;
+  }
+
 Success:
   *err = GltfError_None;
   return;

--- a/libs/asset/src/loader_mesh_gltf.c
+++ b/libs/asset/src/loader_mesh_gltf.c
@@ -137,22 +137,22 @@ typedef AssetGltfLoadComp GltfLoad;
 static void ecs_destruct_gltf_load_comp(void* data) {
   AssetGltfLoadComp* comp = data;
   json_destroy(comp->jDoc);
-  if (comp->bufferCount) {
+  if (comp->buffers) {
     alloc_free_array_t(g_alloc_heap, comp->buffers, comp->bufferCount);
   }
-  if (comp->viewCount) {
+  if (comp->views) {
     alloc_free_array_t(g_alloc_heap, comp->views, comp->viewCount);
   }
-  if (comp->accessCount) {
+  if (comp->access) {
     alloc_free_array_t(g_alloc_heap, comp->access, comp->accessCount);
   }
-  if (comp->primCount) {
+  if (comp->prims) {
     alloc_free_array_t(g_alloc_heap, comp->prims, comp->primCount);
   }
-  if (comp->jointCount) {
+  if (comp->joints) {
     alloc_free_array_t(g_alloc_heap, comp->joints, comp->jointCount);
   }
-  if (comp->animCount) {
+  if (comp->anims) {
     alloc_free_array_t(g_alloc_heap, comp->anims, comp->animCount);
   }
   dynarray_destroy(&comp->animData);

--- a/libs/asset/src/loader_mesh_gltf.c
+++ b/libs/asset/src/loader_mesh_gltf.c
@@ -322,6 +322,17 @@ static void gltf_json_name(GltfLoad* ld, const JsonVal v, StringHash* out) {
       g_stringtable, gltf_json_field_str(ld, v, string_lit("name"), &str) ? str : string_empty);
 }
 
+static void gltf_json_transform(GltfLoad* ld, const JsonVal v, GltfTransform* out) {
+  out->t = geo_vector(0);
+  gltf_json_field_vec3(ld, v, string_lit("translation"), &out->t);
+
+  out->r = geo_quat_ident;
+  gltf_json_field_quat(ld, v, string_lit("rotation"), &out->r);
+
+  out->s = geo_vector(1, 1, 1);
+  gltf_json_field_vec3(ld, v, string_lit("scale"), &out->s);
+}
+
 static u32 gltf_node_to_joint_index(GltfLoad* ld, const u32 nodeIndex) {
   for (u32 i = 0; i != ld->jointCount; ++i) {
     if (ld->joints[i].nodeIndex == nodeIndex) {
@@ -704,16 +715,9 @@ static void gltf_parse_skeleton_nodes(GltfLoad* ld, GltfError* err) {
       goto Next; // This node is not part of the skeleton.
     }
     GltfJoint* out = &ld->joints[jointIndex];
+
     gltf_json_name(ld, node, &out->nameHash);
-
-    out->trans.t = geo_vector(0);
-    gltf_json_field_vec3(ld, node, string_lit("translation"), &out->trans.t);
-
-    out->trans.r = geo_quat_ident;
-    gltf_json_field_quat(ld, node, string_lit("rotation"), &out->trans.r);
-
-    out->trans.s = geo_vector(1, 1, 1);
-    gltf_json_field_vec3(ld, node, string_lit("scale"), &out->trans.s);
+    gltf_json_transform(ld, node, &out->trans);
 
     const JsonVal children = json_field(ld->jDoc, node, string_lit("children"));
     if (gltf_json_check(ld, children, JsonType_Array)) {

--- a/libs/core/include/core_bitset.h
+++ b/libs/core/include/core_bitset.h
@@ -94,6 +94,12 @@ void bitset_set(BitSet, usize idx);
 void bitset_set_all(BitSet, usize idx);
 
 /**
+ * Flip the bit at the given index.
+ * Pre-condition: idx < bitset_size
+ */
+void bitset_flip(BitSet, usize idx);
+
+/**
  * Unset the bit at the given index.
  * Pre-condition: idx < bitset_size
  */

--- a/libs/core/src/bitset.c
+++ b/libs/core/src/bitset.c
@@ -120,6 +120,11 @@ void bitset_set_all(const BitSet bits, const usize idx) {
   }
 }
 
+void bitset_flip(const BitSet bits, const usize idx) {
+  diag_assert(idx < bitset_size(bits));
+  *mem_at_u8(bits, bits_to_bytes(idx)) ^= 1u << bit_in_byte(idx);
+}
+
 void bitset_clear(const BitSet bits, const usize idx) {
   diag_assert(idx < bitset_size(bits));
   *mem_at_u8(bits, bits_to_bytes(idx)) &= ~(1u << bit_in_byte(idx));

--- a/libs/core/test/test_bitset.c
+++ b/libs/core/test/test_bitset.c
@@ -179,6 +179,19 @@ spec(bitset) {
     }
   }
 
+  it("can flip bits") {
+    u64    val[8] = {0};
+    BitSet bits   = bitset_from_array(val);
+
+    for (u32 i = 0; i != 234; ++i) {
+      check(!bitset_test(bits, i));
+      bitset_flip(bits, i);
+      check(bitset_test(bits, i));
+      bitset_flip(bits, i);
+      check(!bitset_test(bits, i));
+    }
+  }
+
   it("can bitwise 'or' two bitsets") {
     BitSet evenBits64   = bitset_from_var((u64){0});
     BitSet unevenBits64 = bitset_from_var((u64){0});

--- a/libs/debug/src/animation.c
+++ b/libs/debug/src/animation.c
@@ -48,9 +48,9 @@ static void animation_panel_draw_joints(
     ui_label(canvas, fmt_write_scratch("  {}", fmt_text(name)));
     ui_table_next_column(canvas, table);
 
-    bool enabled = (layer->mask.jointBits & (u64_lit(1) << jointIdx)) != 0;
+    bool enabled = scene_skeleton_mask_test(&layer->mask, jointIdx);
     if (ui_toggle(canvas, &enabled, .tooltip = string_lit("Enable / disable this joint."))) {
-      layer->mask.jointBits ^= u64_lit(1) << jointIdx;
+      scene_skeleton_mask_flip(&layer->mask, jointIdx);
     }
     ui_table_next_column(canvas, table);
 

--- a/libs/debug/src/animation.c
+++ b/libs/debug/src/animation.c
@@ -75,7 +75,7 @@ static void animation_panel_draw(
 
   if (anim) {
     UiTable table = ui_table(.spacing = ui_vector(10, 5));
-    ui_table_add_column(&table, UiTableColumn_Fixed, 225);
+    ui_table_add_column(&table, UiTableColumn_Fixed, 275);
     ui_table_add_column(&table, UiTableColumn_Fixed, 125);
     ui_table_add_column(&table, UiTableColumn_Fixed, 150);
     ui_table_add_column(&table, UiTableColumn_Fixed, 150);
@@ -186,6 +186,6 @@ ecs_module_init(debug_animation_module) {
 EcsEntityId debug_animation_panel_open(EcsWorld* world, const EcsEntityId window) {
   const EcsEntityId panelEntity = ui_canvas_create(world, window, UiCanvasCreateFlags_ToFront);
   ecs_world_add_t(
-      world, panelEntity, DebugAnimationPanelComp, .panel = ui_panel(ui_vector(850, 300)));
+      world, panelEntity, DebugAnimationPanelComp, .panel = ui_panel(ui_vector(875, 300)));
   return panelEntity;
 }

--- a/libs/rend/src/instance.c
+++ b/libs/rend/src/instance.c
@@ -10,7 +10,6 @@
 #include "draw_internal.h"
 
 #define rend_instance_max_draw_create 16
-#define rend_instance_max_joints 64
 
 typedef struct {
   ALIGNAS(16)
@@ -24,10 +23,10 @@ typedef struct {
   ALIGNAS(16)
   GeoVector posAndScale; // xyz: position, w: scale.
   GeoQuat   rot;
-  GeoMatrix jointDelta[rend_instance_max_joints];
+  GeoMatrix jointDelta[scene_skeleton_joints_max];
 } RendInstanceSkinnedData;
 
-ASSERT(sizeof(RendInstanceSkinnedData) == 4128, "Size needs to match the size defined in glsl");
+ASSERT(sizeof(RendInstanceSkinnedData) == 4832, "Size needs to match the size defined in glsl");
 
 ecs_view_define(RenderableView) {
   ecs_access_read(SceneRenderableComp);
@@ -86,11 +85,10 @@ ecs_system_define(RendInstanceFillDrawsSys) {
 
     const bool isSkinned = skeletonComp->jointCount != 0;
     if (isSkinned) {
-      diag_assert(skeletonComp->jointCount <= rend_instance_max_joints);
       const SceneSkeletonTemplComp* templ = ecs_view_read_t(drawItr, SceneSkeletonTemplComp);
       RendInstanceSkinnedData       data  = {
-          .posAndScale = geo_vector(position.x, position.y, position.z, scale),
-          .rot         = rotation,
+                 .posAndScale = geo_vector(position.x, position.y, position.z, scale),
+                 .rot         = rotation,
       };
       scene_skeleton_delta(skeletonComp, templ, data.jointDelta);
       rend_draw_add_instance(draw, mem_var(data), tags, aabb);

--- a/libs/rend/src/instance.c
+++ b/libs/rend/src/instance.c
@@ -10,7 +10,7 @@
 #include "draw_internal.h"
 
 #define rend_instance_max_draw_create 16
-#define rend_instance_max_joints 32
+#define rend_instance_max_joints 64
 
 typedef struct {
   ALIGNAS(16)
@@ -27,7 +27,7 @@ typedef struct {
   GeoMatrix jointDelta[rend_instance_max_joints];
 } RendInstanceSkinnedData;
 
-ASSERT(sizeof(RendInstanceSkinnedData) == 2080, "Size needs to match the size defined in glsl");
+ASSERT(sizeof(RendInstanceSkinnedData) == 4128, "Size needs to match the size defined in glsl");
 
 ecs_view_define(RenderableView) {
   ecs_access_read(SceneRenderableComp);
@@ -89,8 +89,8 @@ ecs_system_define(RendInstanceFillDrawsSys) {
       diag_assert(skeletonComp->jointCount <= rend_instance_max_joints);
       const SceneSkeletonTemplComp* templ = ecs_view_read_t(drawItr, SceneSkeletonTemplComp);
       RendInstanceSkinnedData       data  = {
-                 .posAndScale = geo_vector(position.x, position.y, position.z, scale),
-                 .rot         = rotation,
+          .posAndScale = geo_vector(position.x, position.y, position.z, scale),
+          .rot         = rotation,
       };
       scene_skeleton_delta(skeletonComp, templ, data.jointDelta);
       rend_draw_add_instance(draw, mem_var(data), tags, aabb);

--- a/libs/scene/include/scene_skeleton.h
+++ b/libs/scene/include/scene_skeleton.h
@@ -2,6 +2,8 @@
 #include "ecs_module.h"
 #include "geo_matrix.h"
 
+#define scene_skeleton_joints_max 75
+
 typedef struct {
   const u32* childIndices;
   u32        childCount;
@@ -9,7 +11,7 @@ typedef struct {
 } SceneSkeletonJoint;
 
 typedef struct {
-  u64 jointBits;
+  u8 jointBits[scene_skeleton_joints_max / 8 + 1];
 } SceneSkeletonMask;
 
 ecs_comp_extern(SceneSkeletonTemplComp);
@@ -42,5 +44,12 @@ u32 scene_skeleton_root_index(const SceneSkeletonTemplComp*);
 u32                       scene_skeleton_joint_count(const SceneSkeletonTemplComp*);
 const SceneSkeletonJoint* scene_skeleton_joint(const SceneSkeletonTemplComp*, u32 index);
 SceneAnimJointInfo scene_skeleton_anim_info(const SceneSkeletonTemplComp*, u32 anim, u32 joint);
+
+void scene_skeleton_mask_set(SceneSkeletonMask*, u32 joint);
+void scene_skeleton_mask_set_all(SceneSkeletonMask*);
+void scene_skeleton_mask_clear(SceneSkeletonMask*, u32 joint);
+void scene_skeleton_mask_clear_all(SceneSkeletonMask*);
+void scene_skeleton_mask_flip(SceneSkeletonMask*, u32 joint);
+bool scene_skeleton_mask_test(const SceneSkeletonMask*, u32 joint);
 
 void scene_skeleton_delta(const SceneSkeletonComp*, const SceneSkeletonTemplComp*, GeoMatrix* out);

--- a/libs/scene/src/skeleton.c
+++ b/libs/scene/src/skeleton.c
@@ -322,7 +322,14 @@ static GeoQuat anim_channel_get_quat(const SceneSkeletonChannel* ch, const f32 t
   const f32 fromT = ch->times[frame];
   const f32 toT   = ch->times[frame + 1];
   const f32 frac  = math_unlerp(fromT, toT, t);
-  return geo_quat_slerp(ch->values_quat[frame], ch->values_quat[frame + 1], frac);
+
+  const GeoQuat from = ch->values_quat[frame];
+  GeoQuat       to   = ch->values_quat[frame + 1];
+  if (geo_quat_dot(to, from) < 0) {
+    // Compensate for quaternion double-cover (two quaternions representing the same rot).
+    to = geo_quat_flip(to);
+  }
+  return geo_quat_slerp(from, to, frac);
 }
 
 static void anim_blend_vec(const GeoVector v, const f32 weight, f32* outWeight, GeoVector* outVec) {

--- a/libs/scene/src/skeleton.c
+++ b/libs/scene/src/skeleton.c
@@ -2,6 +2,7 @@
 #include "asset_manager.h"
 #include "asset_mesh.h"
 #include "core_alloc.h"
+#include "core_bitset.h"
 #include "core_diag.h"
 #include "core_math.h"
 #include "ecs_world.h"
@@ -141,8 +142,8 @@ static void scene_skeleton_init_from_templ(
         .duration = tl->anims[i].duration,
         .speed    = 1.0f,
         .weight   = 1.0f,
-        .mask     = {~u64_lit(0)},
     };
+    scene_skeleton_mask_set_all(&layers[i].mask);
   }
   ecs_world_add_t(world, entity, SceneAnimationComp, .layers = layers, .layerCount = tl->animCount);
 }
@@ -183,6 +184,8 @@ static bool scene_asset_is_loaded(EcsWorld* world, const EcsEntityId asset) {
 }
 
 static void scene_asset_templ_init(SceneSkeletonTemplComp* tl, const AssetMeshSkeletonComp* asset) {
+  diag_assert(asset->jointCount <= scene_skeleton_joints_max);
+
   tl->jointRootIndex = asset->rootJointIndex;
   tl->animData       = alloc_dup(g_alloc_heap, asset->animData, 1);
 
@@ -348,10 +351,6 @@ static void anim_blend_quat(GeoQuat q, const f32 weight, f32* outWeight, GeoQuat
   }
 }
 
-INLINE_HINT static bool anim_mask_test(const SceneSkeletonMask* mask, const u32 joint) {
-  return (mask->jointBits & (u64_lit(1) << joint)) != 0;
-}
-
 static void anim_sample_layer(
     const SceneSkeletonTemplComp* tl,
     const SceneAnimLayer*         layer,
@@ -360,7 +359,7 @@ static void anim_sample_layer(
     SceneJointPose*               out) {
   const SceneSkeletonAnim* anim = &tl->anims[layerIndex];
   for (u32 j = 0; j != tl->jointCount; ++j) {
-    if (!anim_mask_test(&layer->mask, j)) {
+    if (!scene_skeleton_mask_test(&layer->mask, j)) {
       continue; // Layer is disabled for this joint.
     }
 
@@ -505,6 +504,30 @@ scene_skeleton_anim_info(const SceneSkeletonTemplComp* tl, const u32 anim, const
       .frameCountR = tl->anims[anim].joints[joint][AssetMeshAnimTarget_Rotation].frameCount,
       .frameCountS = tl->anims[anim].joints[joint][AssetMeshAnimTarget_Scale].frameCount,
   };
+}
+
+void scene_skeleton_mask_set(SceneSkeletonMask* mask, const u32 joint) {
+  bitset_set(bitset_from_array(mask->jointBits), joint);
+}
+
+void scene_skeleton_mask_set_all(SceneSkeletonMask* mask) {
+  bitset_set_all(bitset_from_array(mask->jointBits), scene_skeleton_joints_max);
+}
+
+void scene_skeleton_mask_clear(SceneSkeletonMask* mask, const u32 joint) {
+  bitset_clear(bitset_from_array(mask->jointBits), joint);
+}
+
+void scene_skeleton_mask_clear_all(SceneSkeletonMask* mask) {
+  bitset_clear_all(bitset_from_array(mask->jointBits));
+}
+
+void scene_skeleton_mask_flip(SceneSkeletonMask* mask, const u32 joint) {
+  bitset_flip(bitset_from_array(mask->jointBits), joint);
+}
+
+bool scene_skeleton_mask_test(const SceneSkeletonMask* mask, const u32 joint) {
+  return bitset_test(bitset_from_array(mask->jointBits), joint);
 }
 
 void scene_skeleton_delta(


### PR DESCRIPTION
Changes:
- Support 32 bit indices
- Increase max joint count to 75
- Improve error handling of gltf loader
- Fix various unaligned loads in gltf loader
- Support not specifying a root joint
- Compensate for quaternion double-cover in anim channel sampling