### PR TITLE
Add soft boundaries to world

### DIFF
--- a/libs/debug/src/gizmo.c
+++ b/libs/debug/src/gizmo.c
@@ -254,7 +254,7 @@ static void gizmo_update_interaction_translation(DebugGizmoComp* comp, const Geo
 
   const GeoPlane plane   = gizmo_translation_plane(data->basePos, data->baseRot, section, ray);
   const f32      hitDist = geo_plane_intersect_ray(&plane, ray);
-  if (hitDist < 0) {
+  if (hitDist < 0 || hitDist > 1e3f) {
     return; // No intersection with the interaction plane.
   }
   const GeoVector inputPos = geo_ray_position(ray, hitDist);
@@ -277,11 +277,12 @@ static void gizmo_update_interaction(
   const GeoVector inputNormPos = geo_vector(input_cursor_x(input), input_cursor_y(input));
   const f32       inputAspect  = input_cursor_aspect(input);
   const GeoRay    inputRay     = scene_camera_ray(camera, cameraTrans, inputAspect, inputNormPos);
+  const bool      isBlocked    = gizmo_interaction_is_blocked(input);
 
   const DebugGizmoEntry* hoverEntry   = null;
   DebugGizmoSection      hoverSection = 0;
   GeoQueryRayHit         hit;
-  if (!gizmo_interaction_is_blocked(input) && geo_query_ray(comp->queryEnv, &inputRay, &hit)) {
+  if (!isBlocked && geo_query_ray(comp->queryEnv, &inputRay, &hit) && hit.time < 1e3f) {
     hoverEntry   = gizmo_entry(comp, gizmo_shape_index(hit.shapeId));
     hoverSection = gizmo_shape_section(hit.shapeId);
   }

--- a/libs/debug/src/inspector.c
+++ b/libs/debug/src/inspector.c
@@ -218,7 +218,10 @@ static void inspector_panel_draw_transform(
     inspector_panel_next(canvas, panelComp, table);
     ui_label(canvas, string_lit("Position"));
     ui_table_next_column(canvas, table);
-    inspector_panel_draw_editor_vec(canvas, &transform->position, 3);
+    if (inspector_panel_draw_editor_vec(canvas, &transform->position, 3)) {
+      // Clamp the position to a sane value.
+      transform->position = geo_vector_clamp(transform->position, 1e3f);
+    }
 
     inspector_panel_next(canvas, panelComp, table);
     ui_label(canvas, string_lit("Rotation"));

--- a/libs/geo/include/geo_vector.h
+++ b/libs/geo/include/geo_vector.h
@@ -121,6 +121,13 @@ GeoVector geo_vector_max(GeoVector x, GeoVector y);
 GeoVector geo_vector_sqrt(GeoVector);
 
 /**
+ * Clamp a vector so its magnitude does not exceed the given value.
+ *
+ * Pre-condition: maxMagnitude >= 0
+ */
+GeoVector geo_vector_clamp(GeoVector, f32 maxMagnitude);
+
+/**
  * Perspective divide: divide the vector by its w component.
  */
 GeoVector geo_vector_perspective_div(GeoVector);

--- a/libs/geo/src/query.c
+++ b/libs/geo/src/query.c
@@ -15,14 +15,14 @@ struct sGeoQueryEnv {
 static void geo_query_validate_pos(const GeoVector vec) {
   // Constrain the positions 1000 meters from the origin to avoid precision issues.
   diag_assert_msg(
-      geo_vector_mag_sqr(vec) < (1e4f * 1e4f),
+      geo_vector_mag_sqr(vec) <= (1e4f * 1e4f),
       "Position ({}) is out of bounds",
       geo_vector_fmt(vec));
 }
 
 static void geo_query_validate_dir(const GeoVector vec) {
   diag_assert_msg(
-      math_abs(geo_vector_mag_sqr(vec) - 1.0f) < 1e-6f,
+      math_abs(geo_vector_mag_sqr(vec) - 1.0f) <= 1e-6f,
       "Direction ({}) is not normalized",
       geo_vector_fmt(vec));
   return;
@@ -57,11 +57,16 @@ void geo_query_env_clear(GeoQueryEnv* env) {
 }
 
 void geo_query_insert_sphere(GeoQueryEnv* env, const GeoSphere sphere, const u64 id) {
+  geo_query_validate_pos(sphere.point);
+
   *dynarray_push_t(&env->spheres, GeoSphere) = sphere;
   *dynarray_push_t(&env->sphereIds, u64)     = id;
 }
 
 void geo_query_insert_capsule(GeoQueryEnv* env, const GeoCapsule capsule, const u64 id) {
+  geo_query_validate_pos(capsule.line.a);
+  geo_query_validate_pos(capsule.line.b);
+
   *dynarray_push_t(&env->capsules, GeoCapsule) = capsule;
   *dynarray_push_t(&env->capsuleIds, u64)      = id;
 }

--- a/libs/geo/test/test_vector.c
+++ b/libs/geo/test/test_vector.c
@@ -205,6 +205,13 @@ spec(vector) {
     check_eq_vector(geo_vector_sqrt(v), geo_vector(4, 8, 16));
   }
 
+  it("can clamp its magnitude") {
+    check_eq_vector(geo_vector_clamp(geo_vector(1, 2, 3), 10), geo_vector(1, 2, 3));
+    check_eq_vector(geo_vector_clamp(geo_vector(34, 0, 0), 2), geo_vector(2, 0, 0));
+    check_eq_vector(geo_vector_clamp(geo_vector(1, 2, 3), 0), geo_vector(0, 0, 0));
+    check_eq_vector(geo_vector_clamp(geo_vector(0, 0, 0), 0), geo_vector(0, 0, 0));
+  }
+
   it("divides each component by w when performing a perspective divide") {
     const GeoVector v1 = {.x = 1, .y = 2, .z = 4, .w = 4};
     const GeoVector v2 = {.x = .25, .y = .5, .z = 1};


### PR DESCRIPTION
QueryEnv asserts positions are less then 1e4 and inspector and gizmo's soft limit to 1e3. Some (very) conservative limits to avoid precision issues.