### PR TITLE
Small optimization for geo_query_frustum_all

### DIFF
--- a/libs/geo/include/geo_box.h
+++ b/libs/geo/include/geo_box.h
@@ -98,14 +98,21 @@ GeoBox geo_box_from_line(GeoVector from, GeoVector to);
 GeoBox geo_box_from_quad(GeoVector center, f32 sizeX, f32 sizeY, GeoQuat rotation);
 
 /**
+ * Calculate the bounding box of the frustum formed by the given 8 corners.
+ * NOTE: Defines the frustum by its corner points.
+ */
+GeoBox geo_box_from_frustum(const GeoVector frustum[8]);
+
+/**
  * Test if two boxes are overlapping.
  */
 bool geo_box_overlap(const GeoBox* x, const GeoBox* y);
 
 /**
- * Test if the box intersects the given four frustum planes.
+ * Test if the box intersects a partial frustum given by four side planes.
  * Conservative approximation, false positives are possible but false negatives are not.
  * NOTE: If the given box is inverted its considered to always be intersecting.
+ * NOTE: Defines a partial frustum by its four side planes.
  */
 bool geo_box_intersect_frustum4_approx(const GeoBox*, const GeoPlane frustum[4]);
 

--- a/libs/geo/include/geo_query.h
+++ b/libs/geo/include/geo_query.h
@@ -10,7 +10,7 @@ typedef struct sAllocator Allocator;
 /**
  * Maximum number of objects that can be hit using a single query, additional objects are ignored.
  */
-#define geo_query_max_hits 128
+#define geo_query_max_hits 512
 
 /**
  * Geometry layer mask.

--- a/libs/geo/src/box.c
+++ b/libs/geo/src/box.c
@@ -354,6 +354,14 @@ geo_box_from_quad(const GeoVector center, const f32 sizeX, const f32 sizeY, cons
 #endif
 }
 
+GeoBox geo_box_from_frustum(const GeoVector frustum[8]) {
+  GeoBox result = geo_box_inverted3();
+  for (u32 i = 0; i != 8; ++i) {
+    result = geo_box_encapsulate(&result, frustum[i]);
+  }
+  return result;
+}
+
 bool geo_box_overlap(const GeoBox* x, const GeoBox* y) {
 #if geo_box_simd_enable
   const SimdVec xMin = simd_vec_load(x->min.comps);

--- a/libs/geo/src/query.c
+++ b/libs/geo/src/query.c
@@ -307,11 +307,16 @@ u32 geo_query_frustum_all(
     u64                   out[geo_query_max_hits]) {
   u32 count = 0;
 
+  const GeoBox queryBounds = geo_box_from_frustum(frustum);
+
   for (u32 primIdx = 0; primIdx != GeoQueryPrim_Count; ++primIdx) {
     const GeoQueryPrim* prim = &env->prims[primIdx];
     for (u32 i = 0; i != prim->count; ++i) {
       if (!geo_query_filter_layer(filter, prim->layers[i])) {
         continue; // Layer not included in filter.
+      }
+      if (!geo_box_overlap(&prim->bounds[i], &queryBounds)) {
+        continue; // Bounds do not intersect; no need to test against the shape.
       }
       if (!geo_prim_intersect_frustum(prim, i, frustum)) {
         continue; // Miss.

--- a/libs/scene/include/scene_collision.h
+++ b/libs/scene/include/scene_collision.h
@@ -13,7 +13,7 @@ ecs_comp_extern(SceneScaleComp);
 /**
  * Maximum number of entities that can be hit using a single query, additional entities are ignored.
  */
-#define scene_query_max_hits 128
+#define scene_query_max_hits 512
 
 typedef enum {
   SceneLayer_Debug        = 1 << 0,


### PR DESCRIPTION
Use bounds as an early out to speed up smaller queries.