### PR TITLE
Fix crash in draw insertion

### DIFF
--- a/libs/debug/src/grid.c
+++ b/libs/debug/src/grid.c
@@ -31,6 +31,7 @@ typedef struct {
 } DebugGridData;
 
 ASSERT(sizeof(DebugGridData) == 16, "Size needs to match the size defined in glsl");
+ASSERT(alignof(DebugGridData) == 16, "Alignment needs to match the glsl alignment");
 
 ecs_comp_define(DebugGridComp) {
   EcsEntityId drawEntity;

--- a/libs/debug/src/shape.c
+++ b/libs/debug/src/shape.c
@@ -222,6 +222,7 @@ ecs_system_define(DebugShapeRenderSys) {
         GeoColor  color;
       } DrawMeshData;
       ASSERT(sizeof(DrawMeshData) == 64, "Size needs to match the size defined in glsl");
+      ASSERT(alignof(DrawMeshData) == 16, "Alignment needs to match the glsl alignment");
 
       typedef struct {
         ALIGNAS(16)
@@ -229,6 +230,7 @@ ecs_system_define(DebugShapeRenderSys) {
         GeoColor  color;
       } DrawLineData;
       ASSERT(sizeof(DrawLineData) == 48, "Size needs to match the size defined in glsl");
+      ASSERT(alignof(DrawLineData) == 16, "Alignment needs to match the glsl alignment");
 
       switch (entry->type) {
       case DebugShapeType_BoxFill:

--- a/libs/rend/include/rend_draw.h
+++ b/libs/rend/include/rend_draw.h
@@ -20,8 +20,6 @@ typedef enum {
 /**
  * Low level api for submitting draws.
  * In most cases the scene apis should be preferred (SceneRenderableComp).
- *
- * Api is not thread-safe except for 'rend_draw_add_instance' which be called in parallel.
  */
 ecs_comp_extern(RendDrawComp);
 
@@ -65,10 +63,10 @@ Mem rend_draw_set_data(RendDrawComp*, usize size);
 
 /**
  * Add a new instance to the given draw.
+ * NOTE: Invalidates pointers from previous calls to this api.
  * NOTE: All instances need to use the same data-size.
  * NOTE: Tags and bounds are used to filter the draws per camera.
  * NOTE: Data size has to be consistent between all instances and across frames.
- * NOTE: Thread-safe to be called in parallel with itself.
  * NOTE: Returned pointer is always at least 16bit aligned, stronger alignment cannot be guaranteed.
  */
 #define rend_draw_add_instance_t(_DRAW_, _TYPE_, _TAGS_, _AABB_)                                   \

--- a/libs/rend/include/rend_draw.h
+++ b/libs/rend/include/rend_draw.h
@@ -69,6 +69,7 @@ Mem rend_draw_set_data(RendDrawComp*, usize size);
  * NOTE: Tags and bounds are used to filter the draws per camera.
  * NOTE: Data size has to be consistent between all instances and across frames.
  * NOTE: Thread-safe to be called in parallel with itself.
+ * NOTE: Returned pointer is always at least 16bit aligned, stronger alignment cannot be guaranteed.
  */
 #define rend_draw_add_instance_t(_DRAW_, _TYPE_, _TAGS_, _AABB_)                                   \
   ((_TYPE_*)rend_draw_add_instance((_DRAW_), sizeof(_TYPE_), (_TAGS_), (_AABB_)).ptr)

--- a/libs/rend/src/instance.c
+++ b/libs/rend/src/instance.c
@@ -20,6 +20,7 @@ typedef struct {
 } RendInstanceData;
 
 ASSERT(sizeof(RendInstanceData) == 48, "Size needs to match the size defined in glsl");
+ASSERT(alignof(RendInstanceData) == 16, "Alignment needs to match the glsl alignment");
 
 typedef struct {
   ALIGNAS(16)
@@ -39,6 +40,7 @@ typedef struct {
 } RendInstanceSkinnedData;
 
 ASSERT(sizeof(RendInstanceSkinnedData) == 3648, "Size needs to match the size defined in glsl");
+ASSERT(alignof(RendInstanceSkinnedData) == 16, "Alignment needs to match the glsl alignment");
 
 /**
  * Convert the given 4x4 matrix to a 4x3 matrix (dropping the last row) and then transpose to a 3x4.

--- a/libs/ui/src/builder_internal.h
+++ b/libs/ui/src/builder_internal.h
@@ -19,6 +19,7 @@ typedef struct {
 } UiGlyphData;
 
 ASSERT(sizeof(UiGlyphData) == 32, "Size needs to match the size defined in glsl");
+ASSERT(alignof(UiGlyphData) == 16, "Alignment needs to match the glsl alignment");
 
 typedef struct {
   u32 lineCount;

--- a/libs/vfx/src/particle.c
+++ b/libs/vfx/src/particle.c
@@ -27,6 +27,7 @@ typedef struct {
 } VfxParticleData;
 
 ASSERT(sizeof(VfxParticleData) == 48, "Size needs to match the size defined in glsl");
+ASSERT(alignof(VfxParticleData) == 16, "Alignment needs to match the glsl alignment");
 
 typedef enum {
   VfxRenderer_AtlasAcquired  = 1 << 0,

--- a/libs/vfx/src/particle_internal.h
+++ b/libs/vfx/src/particle_internal.h
@@ -36,6 +36,5 @@ void vfx_particle_init(RendDrawComp*, const AssetAtlasComp*);
 
 /**
  * Output a particle to the given draw.
- * NOTE: Thread-safe, multiple particles can be added to the same draw in parallel.
  */
 void vfx_particle_output(RendDrawComp*, const VfxParticle*);


### PR DESCRIPTION
Parallel draw insertion was unsafe when draw needed to grow. Fix for the time being is removing the unsafe parallelism on draw insertion.