### PR TITLE
Startup time optimization

### DIFF
--- a/libs/asset/src/loader_behavior.c
+++ b/libs/asset/src/loader_behavior.c
@@ -75,59 +75,60 @@ static void behavior_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
-    const DataType nodeType = data_declare_t(g_dataReg, AssetAiNodeDef);
+    const DataType nodeType = data_declare_t(reg, AssetAiNodeDef);
 
-    data_reg_struct_t(g_dataReg, AssetAiNodeDefInvert);
-    data_reg_field_t(g_dataReg, AssetAiNodeDefInvert, child, nodeType, .container = DataContainer_Pointer);
-    data_reg_comment_t(g_dataReg, AssetAiNodeDefInvert, "Evaluates the child node and inverts its result.\nEvaluates to 'Running' if the child evaluates to 'Running', 'Success' if the child evaluated to 'Failure', otherwise to 'Failure'.");
+    data_reg_struct_t(reg, AssetAiNodeDefInvert);
+    data_reg_field_t(reg, AssetAiNodeDefInvert, child, nodeType, .container = DataContainer_Pointer);
+    data_reg_comment_t(reg, AssetAiNodeDefInvert, "Evaluates the child node and inverts its result.\nEvaluates to 'Running' if the child evaluates to 'Running', 'Success' if the child evaluated to 'Failure', otherwise to 'Failure'.");
 
-    data_reg_struct_t(g_dataReg, AssetAiNodeDefTry);
-    data_reg_field_t(g_dataReg, AssetAiNodeDefTry, child, nodeType, .container = DataContainer_Pointer);
-    data_reg_comment_t(g_dataReg, AssetAiNodeDefTry, "Evaluates the child node.\nEvaluates to 'Running' if the child evaluates to 'Failure' or 'Running', otherwise to 'Success'.");
+    data_reg_struct_t(reg, AssetAiNodeDefTry);
+    data_reg_field_t(reg, AssetAiNodeDefTry, child, nodeType, .container = DataContainer_Pointer);
+    data_reg_comment_t(reg, AssetAiNodeDefTry, "Evaluates the child node.\nEvaluates to 'Running' if the child evaluates to 'Failure' or 'Running', otherwise to 'Success'.");
 
-    data_reg_struct_t(g_dataReg, AssetAiNodeDefRepeat);
-    data_reg_field_t(g_dataReg, AssetAiNodeDefRepeat, child, nodeType, .container = DataContainer_Pointer);
-    data_reg_comment_t(g_dataReg, AssetAiNodeDefRepeat, "Evaluates the child node.\nEvaluates to 'Running' if the child evaluates to 'Success' or 'Running', otherwise to 'Failure'.");
+    data_reg_struct_t(reg, AssetAiNodeDefRepeat);
+    data_reg_field_t(reg, AssetAiNodeDefRepeat, child, nodeType, .container = DataContainer_Pointer);
+    data_reg_comment_t(reg, AssetAiNodeDefRepeat, "Evaluates the child node.\nEvaluates to 'Running' if the child evaluates to 'Success' or 'Running', otherwise to 'Failure'.");
 
-    data_reg_struct_t(g_dataReg, AssetAiNodeDefParallel);
-    data_reg_field_t(g_dataReg, AssetAiNodeDefParallel, children, nodeType, .container = DataContainer_Array);
-    data_reg_comment_t(g_dataReg, AssetAiNodeDefParallel, "Evaluates all children.\nEvaluates to 'Success' if any child evaluated to 'Success', 'Running' if any child evaluates to 'Running', otherwise to 'Failure'.");
+    data_reg_struct_t(reg, AssetAiNodeDefParallel);
+    data_reg_field_t(reg, AssetAiNodeDefParallel, children, nodeType, .container = DataContainer_Array);
+    data_reg_comment_t(reg, AssetAiNodeDefParallel, "Evaluates all children.\nEvaluates to 'Success' if any child evaluated to 'Success', 'Running' if any child evaluates to 'Running', otherwise to 'Failure'.");
 
-    data_reg_struct_t(g_dataReg, AssetAiNodeDefSelector);
-    data_reg_field_t(g_dataReg, AssetAiNodeDefSelector, children, nodeType, .container = DataContainer_Array);
-    data_reg_comment_t(g_dataReg, AssetAiNodeDefSelector, "Evaluates children until a child evaluates to 'Running' or 'Success'.\nEvaluates to 'Success' if any child evaluated to 'Success', 'Running' if any child evaluated to 'Running', otherwise to 'Failure'.");
+    data_reg_struct_t(reg, AssetAiNodeDefSelector);
+    data_reg_field_t(reg, AssetAiNodeDefSelector, children, nodeType, .container = DataContainer_Array);
+    data_reg_comment_t(reg, AssetAiNodeDefSelector, "Evaluates children until a child evaluates to 'Running' or 'Success'.\nEvaluates to 'Success' if any child evaluated to 'Success', 'Running' if any child evaluated to 'Running', otherwise to 'Failure'.");
 
-    data_reg_struct_t(g_dataReg, AssetAiNodeDefSequence);
-    data_reg_field_t(g_dataReg, AssetAiNodeDefSequence, children, nodeType, .container = DataContainer_Array);
-    data_reg_comment_t(g_dataReg, AssetAiNodeDefSequence, "Evaluates children until a child evaluates to 'Failure'.\nEvaluates to 'Success' if all children evaluated to 'Success', 'Running' if any child evaluated to 'Running', otherwise to 'Failure'.");
+    data_reg_struct_t(reg, AssetAiNodeDefSequence);
+    data_reg_field_t(reg, AssetAiNodeDefSequence, children, nodeType, .container = DataContainer_Array);
+    data_reg_comment_t(reg, AssetAiNodeDefSequence, "Evaluates children until a child evaluates to 'Failure'.\nEvaluates to 'Success' if all children evaluated to 'Success', 'Running' if any child evaluated to 'Running', otherwise to 'Failure'.");
 
-    data_reg_struct_t(g_dataReg, AssetAiNodeDefCondition);
-    data_reg_field_t(g_dataReg, AssetAiNodeDefCondition, script, data_prim_t(String), .flags = DataFlags_HideName);
-    data_reg_comment_t(g_dataReg, AssetAiNodeDefCondition, "Evaluate the script condition.\nEvaluates to 'Success' when the script condition is truthy or 'Failure' if its not.");
+    data_reg_struct_t(reg, AssetAiNodeDefCondition);
+    data_reg_field_t(reg, AssetAiNodeDefCondition, script, data_prim_t(String), .flags = DataFlags_HideName);
+    data_reg_comment_t(reg, AssetAiNodeDefCondition, "Evaluate the script condition.\nEvaluates to 'Success' when the script condition is truthy or 'Failure' if its not.");
 
-    data_reg_struct_t(g_dataReg, AssetAiNodeDefExecute);
-    data_reg_field_t(g_dataReg, AssetAiNodeDefExecute, script, data_prim_t(String), .flags = DataFlags_HideName);
-    data_reg_comment_t(g_dataReg, AssetAiNodeDefExecute, "Execute the script expression.\nEvaluates to 'Success'.");
+    data_reg_struct_t(reg, AssetAiNodeDefExecute);
+    data_reg_field_t(reg, AssetAiNodeDefExecute, script, data_prim_t(String), .flags = DataFlags_HideName);
+    data_reg_comment_t(reg, AssetAiNodeDefExecute, "Execute the script expression.\nEvaluates to 'Success'.");
 
-    data_reg_union_t(g_dataReg, AssetAiNodeDef, type);
-    data_reg_union_name_t(g_dataReg, AssetAiNodeDef, name);
-    data_reg_choice_empty(g_dataReg, AssetAiNodeDef, AssetAiNode_Running);
-    data_reg_choice_empty(g_dataReg, AssetAiNodeDef, AssetAiNode_Success);
-    data_reg_choice_empty(g_dataReg, AssetAiNodeDef, AssetAiNode_Failure);
-    data_reg_choice_t(g_dataReg, AssetAiNodeDef, AssetAiNode_Invert, data_invert, t_AssetAiNodeDefInvert);
-    data_reg_choice_t(g_dataReg, AssetAiNodeDef, AssetAiNode_Try, data_try, t_AssetAiNodeDefTry);
-    data_reg_choice_t(g_dataReg, AssetAiNodeDef, AssetAiNode_Repeat, data_repeat, t_AssetAiNodeDefRepeat);
-    data_reg_choice_t(g_dataReg, AssetAiNodeDef, AssetAiNode_Parallel, data_parallel, t_AssetAiNodeDefParallel);
-    data_reg_choice_t(g_dataReg, AssetAiNodeDef, AssetAiNode_Selector, data_selector, t_AssetAiNodeDefSelector);
-    data_reg_choice_t(g_dataReg, AssetAiNodeDef, AssetAiNode_Sequence, data_sequence, t_AssetAiNodeDefSequence);
-    data_reg_choice_t(g_dataReg, AssetAiNodeDef, AssetAiNode_Condition, data_condition, t_AssetAiNodeDefCondition);
-    data_reg_choice_t(g_dataReg, AssetAiNodeDef, AssetAiNode_Execute, data_execute, t_AssetAiNodeDefExecute);
+    data_reg_union_t(reg, AssetAiNodeDef, type);
+    data_reg_union_name_t(reg, AssetAiNodeDef, name);
+    data_reg_choice_empty(reg, AssetAiNodeDef, AssetAiNode_Running);
+    data_reg_choice_empty(reg, AssetAiNodeDef, AssetAiNode_Success);
+    data_reg_choice_empty(reg, AssetAiNodeDef, AssetAiNode_Failure);
+    data_reg_choice_t(reg, AssetAiNodeDef, AssetAiNode_Invert, data_invert, t_AssetAiNodeDefInvert);
+    data_reg_choice_t(reg, AssetAiNodeDef, AssetAiNode_Try, data_try, t_AssetAiNodeDefTry);
+    data_reg_choice_t(reg, AssetAiNodeDef, AssetAiNode_Repeat, data_repeat, t_AssetAiNodeDefRepeat);
+    data_reg_choice_t(reg, AssetAiNodeDef, AssetAiNode_Parallel, data_parallel, t_AssetAiNodeDefParallel);
+    data_reg_choice_t(reg, AssetAiNodeDef, AssetAiNode_Selector, data_selector, t_AssetAiNodeDefSelector);
+    data_reg_choice_t(reg, AssetAiNodeDef, AssetAiNode_Sequence, data_sequence, t_AssetAiNodeDefSequence);
+    data_reg_choice_t(reg, AssetAiNodeDef, AssetAiNode_Condition, data_condition, t_AssetAiNodeDefCondition);
+    data_reg_choice_t(reg, AssetAiNodeDef, AssetAiNode_Execute, data_execute, t_AssetAiNodeDefExecute);
     // clang-format on
 
     g_dataNodeMeta = data_meta_t(nodeType);
+    g_dataReg      = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }

--- a/libs/asset/src/loader_font.c
+++ b/libs/asset/src/loader_font.c
@@ -252,7 +252,7 @@ f32 asset_font_glyph_dist(
        * Analytical solutions for quadratic beziers exist but have not been explored yet.
        */
 
-      const u32      steps = 5;
+      const u32      steps = 4;
       AssetFontPoint prev  = start;
       for (usize j = 1; j != steps; ++j) {
         const f32            t           = j / (f32)steps;

--- a/libs/asset/src/loader_ftx.c
+++ b/libs/asset/src/loader_ftx.c
@@ -60,26 +60,27 @@ static void ftx_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
-    data_reg_struct_t(g_dataReg, FtxDefFont);
-    data_reg_field_t(g_dataReg, FtxDefFont, id, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, FtxDefFont, variation, data_prim_t(u8), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, FtxDefFont, yOffset, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, FtxDefFont, spacing, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, FtxDefFont, characters, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, FtxDefFont);
+    data_reg_field_t(reg, FtxDefFont, id, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, FtxDefFont, variation, data_prim_t(u8), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, FtxDefFont, yOffset, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, FtxDefFont, spacing, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, FtxDefFont, characters, data_prim_t(String), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, FtxDef);
-    data_reg_field_t(g_dataReg, FtxDef, size, data_prim_t(u32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, FtxDef, glyphSize, data_prim_t(u32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, FtxDef, border, data_prim_t(u32));
-    data_reg_field_t(g_dataReg, FtxDef, lineSpacing, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, FtxDef, baseline, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, FtxDef, fonts, t_FtxDefFont, .container = DataContainer_Array, .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, FtxDef);
+    data_reg_field_t(reg, FtxDef, size, data_prim_t(u32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, FtxDef, glyphSize, data_prim_t(u32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, FtxDef, border, data_prim_t(u32));
+    data_reg_field_t(reg, FtxDef, lineSpacing, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, FtxDef, baseline, data_prim_t(f32));
+    data_reg_field_t(reg, FtxDef, fonts, t_FtxDefFont, .container = DataContainer_Array, .flags = DataFlags_NotEmpty);
     // clang-format on
 
     g_dataFtxDefMeta = data_meta_t(t_FtxDef);
+    g_dataReg        = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }

--- a/libs/asset/src/loader_graphic.c
+++ b/libs/asset/src/loader_graphic.c
@@ -21,94 +21,95 @@ static void graphic_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
-    data_reg_enum_t(g_dataReg, AssetGraphicTopology);
-    data_reg_const_t(g_dataReg, AssetGraphicTopology, Triangles);
-    data_reg_const_t(g_dataReg, AssetGraphicTopology, TriangleStrip);
-    data_reg_const_t(g_dataReg, AssetGraphicTopology, TriangleFan);
-    data_reg_const_t(g_dataReg, AssetGraphicTopology, Lines);
-    data_reg_const_t(g_dataReg, AssetGraphicTopology, LineStrip);
-    data_reg_const_t(g_dataReg, AssetGraphicTopology, Points);
+    data_reg_enum_t(reg, AssetGraphicTopology);
+    data_reg_const_t(reg, AssetGraphicTopology, Triangles);
+    data_reg_const_t(reg, AssetGraphicTopology, TriangleStrip);
+    data_reg_const_t(reg, AssetGraphicTopology, TriangleFan);
+    data_reg_const_t(reg, AssetGraphicTopology, Lines);
+    data_reg_const_t(reg, AssetGraphicTopology, LineStrip);
+    data_reg_const_t(reg, AssetGraphicTopology, Points);
 
-    data_reg_enum_t(g_dataReg, AssetGraphicRasterizer);
-    data_reg_const_t(g_dataReg, AssetGraphicRasterizer, Fill);
-    data_reg_const_t(g_dataReg, AssetGraphicRasterizer, Lines);
-    data_reg_const_t(g_dataReg, AssetGraphicRasterizer, Points);
+    data_reg_enum_t(reg, AssetGraphicRasterizer);
+    data_reg_const_t(reg, AssetGraphicRasterizer, Fill);
+    data_reg_const_t(reg, AssetGraphicRasterizer, Lines);
+    data_reg_const_t(reg, AssetGraphicRasterizer, Points);
 
-    data_reg_enum_t(g_dataReg, AssetGraphicBlend);
-    data_reg_const_t(g_dataReg, AssetGraphicBlend, None);
-    data_reg_const_t(g_dataReg, AssetGraphicBlend, Alpha);
-    data_reg_const_t(g_dataReg, AssetGraphicBlend, Additive);
-    data_reg_const_t(g_dataReg, AssetGraphicBlend, AlphaAdditive);
-    data_reg_const_t(g_dataReg, AssetGraphicBlend, PreMultiplied);
+    data_reg_enum_t(reg, AssetGraphicBlend);
+    data_reg_const_t(reg, AssetGraphicBlend, None);
+    data_reg_const_t(reg, AssetGraphicBlend, Alpha);
+    data_reg_const_t(reg, AssetGraphicBlend, Additive);
+    data_reg_const_t(reg, AssetGraphicBlend, AlphaAdditive);
+    data_reg_const_t(reg, AssetGraphicBlend, PreMultiplied);
 
-    data_reg_enum_t(g_dataReg, AssetGraphicWrap);
-    data_reg_const_t(g_dataReg, AssetGraphicWrap, Repeat);
-    data_reg_const_t(g_dataReg, AssetGraphicWrap, Clamp);
-    data_reg_const_t(g_dataReg, AssetGraphicWrap, Zero);
+    data_reg_enum_t(reg, AssetGraphicWrap);
+    data_reg_const_t(reg, AssetGraphicWrap, Repeat);
+    data_reg_const_t(reg, AssetGraphicWrap, Clamp);
+    data_reg_const_t(reg, AssetGraphicWrap, Zero);
 
-    data_reg_enum_t(g_dataReg, AssetGraphicFilter);
-    data_reg_const_t(g_dataReg, AssetGraphicFilter, Nearest);
-    data_reg_const_t(g_dataReg, AssetGraphicFilter, Linear);
+    data_reg_enum_t(reg, AssetGraphicFilter);
+    data_reg_const_t(reg, AssetGraphicFilter, Nearest);
+    data_reg_const_t(reg, AssetGraphicFilter, Linear);
 
-    data_reg_enum_t(g_dataReg, AssetGraphicAniso);
-    data_reg_const_t(g_dataReg, AssetGraphicAniso, None);
-    data_reg_const_t(g_dataReg, AssetGraphicAniso, x2);
-    data_reg_const_t(g_dataReg, AssetGraphicAniso, x4);
-    data_reg_const_t(g_dataReg, AssetGraphicAniso, x8);
-    data_reg_const_t(g_dataReg, AssetGraphicAniso, x16);
+    data_reg_enum_t(reg, AssetGraphicAniso);
+    data_reg_const_t(reg, AssetGraphicAniso, None);
+    data_reg_const_t(reg, AssetGraphicAniso, x2);
+    data_reg_const_t(reg, AssetGraphicAniso, x4);
+    data_reg_const_t(reg, AssetGraphicAniso, x8);
+    data_reg_const_t(reg, AssetGraphicAniso, x16);
 
-    data_reg_enum_t(g_dataReg, AssetGraphicDepth);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, Less);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, LessOrEqual);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, Equal);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, Greater);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, Always);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, LessNoWrite);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, LessOrEqualNoWrite);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, EqualNoWrite);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, GreaterNoWrite);
-    data_reg_const_t(g_dataReg, AssetGraphicDepth, AlwaysNoWrite);
+    data_reg_enum_t(reg, AssetGraphicDepth);
+    data_reg_const_t(reg, AssetGraphicDepth, Less);
+    data_reg_const_t(reg, AssetGraphicDepth, LessOrEqual);
+    data_reg_const_t(reg, AssetGraphicDepth, Equal);
+    data_reg_const_t(reg, AssetGraphicDepth, Greater);
+    data_reg_const_t(reg, AssetGraphicDepth, Always);
+    data_reg_const_t(reg, AssetGraphicDepth, LessNoWrite);
+    data_reg_const_t(reg, AssetGraphicDepth, LessOrEqualNoWrite);
+    data_reg_const_t(reg, AssetGraphicDepth, EqualNoWrite);
+    data_reg_const_t(reg, AssetGraphicDepth, GreaterNoWrite);
+    data_reg_const_t(reg, AssetGraphicDepth, AlwaysNoWrite);
 
-    data_reg_enum_t(g_dataReg, AssetGraphicCull);
-    data_reg_const_t(g_dataReg, AssetGraphicCull, None);
-    data_reg_const_t(g_dataReg, AssetGraphicCull, Back);
-    data_reg_const_t(g_dataReg, AssetGraphicCull, Front);
+    data_reg_enum_t(reg, AssetGraphicCull);
+    data_reg_const_t(reg, AssetGraphicCull, None);
+    data_reg_const_t(reg, AssetGraphicCull, Back);
+    data_reg_const_t(reg, AssetGraphicCull, Front);
 
-    data_reg_struct_t(g_dataReg, AssetGraphicOverride);
-    data_reg_field_t(g_dataReg, AssetGraphicOverride, name, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetGraphicOverride, binding, data_prim_t(u8));
-    data_reg_field_t(g_dataReg, AssetGraphicOverride, value, data_prim_t(f64));
+    data_reg_struct_t(reg, AssetGraphicOverride);
+    data_reg_field_t(reg, AssetGraphicOverride, name, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetGraphicOverride, binding, data_prim_t(u8));
+    data_reg_field_t(reg, AssetGraphicOverride, value, data_prim_t(f64));
 
-    data_reg_struct_t(g_dataReg, AssetGraphicShader);
-    data_reg_field_t(g_dataReg, AssetGraphicShader, shaderId, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetGraphicShader, overrides, t_AssetGraphicOverride, .container = DataContainer_Array, .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, AssetGraphicShader);
+    data_reg_field_t(reg, AssetGraphicShader, shaderId, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetGraphicShader, overrides, t_AssetGraphicOverride, .container = DataContainer_Array, .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, AssetGraphicSampler);
-    data_reg_field_t(g_dataReg, AssetGraphicSampler, textureId, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetGraphicSampler, wrap, t_AssetGraphicWrap, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetGraphicSampler, filter, t_AssetGraphicFilter, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetGraphicSampler, anisotropy, t_AssetGraphicAniso, .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, AssetGraphicSampler);
+    data_reg_field_t(reg, AssetGraphicSampler, textureId, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetGraphicSampler, wrap, t_AssetGraphicWrap, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetGraphicSampler, filter, t_AssetGraphicFilter, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetGraphicSampler, anisotropy, t_AssetGraphicAniso, .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, AssetGraphicComp);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, shaders, t_AssetGraphicShader, .container = DataContainer_Array, .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, samplers, t_AssetGraphicSampler, .container = DataContainer_Array, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, meshId, data_prim_t(String), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, vertexCount, data_prim_t(u32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, renderOrder, data_prim_t(i32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, topology, t_AssetGraphicTopology, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, rasterizer, t_AssetGraphicRasterizer, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, lineWidth, data_prim_t(u16), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, depthClamp, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, depthBias, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, blend, t_AssetGraphicBlend, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, depth, t_AssetGraphicDepth, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetGraphicComp, cull, t_AssetGraphicCull, .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, AssetGraphicComp);
+    data_reg_field_t(reg, AssetGraphicComp, shaders, t_AssetGraphicShader, .container = DataContainer_Array, .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetGraphicComp, samplers, t_AssetGraphicSampler, .container = DataContainer_Array, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetGraphicComp, meshId, data_prim_t(String), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetGraphicComp, vertexCount, data_prim_t(u32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetGraphicComp, renderOrder, data_prim_t(i32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetGraphicComp, topology, t_AssetGraphicTopology, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetGraphicComp, rasterizer, t_AssetGraphicRasterizer, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetGraphicComp, lineWidth, data_prim_t(u16), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetGraphicComp, depthClamp, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetGraphicComp, depthBias, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetGraphicComp, blend, t_AssetGraphicBlend, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetGraphicComp, depth, t_AssetGraphicDepth, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetGraphicComp, cull, t_AssetGraphicCull, .flags = DataFlags_Opt);
     // clang-format on
 
     g_dataMeta = data_meta_t(t_AssetGraphicComp);
+    g_dataReg  = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }

--- a/libs/asset/src/loader_inputmap.c
+++ b/libs/asset/src/loader_inputmap.c
@@ -52,7 +52,7 @@ static void inputmap_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
     /**
@@ -61,122 +61,123 @@ static void inputmap_datareg_init() {
      * undesired dependency on the gap library.
      * NOTE: This is a virtual data type, meaning there is no matching AssetInputKey C type.
      */
-    data_reg_enum_t(g_dataReg, AssetInputKey);
-    data_reg_const_custom(g_dataReg, AssetInputKey, MouseLeft,    0);
-    data_reg_const_custom(g_dataReg, AssetInputKey, MouseRight,   1);
-    data_reg_const_custom(g_dataReg, AssetInputKey, MouseMiddle,  2);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Shift,        3);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Control,      4);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alt,          5);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Backspace,    6);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Delete,       7);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Tab,          8);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Tilde,        9);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Return,       10);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Escape,       11);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Space,        12);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Plus,         13);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Minus,        14);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Home,         15);
-    data_reg_const_custom(g_dataReg, AssetInputKey, End,          16);
-    data_reg_const_custom(g_dataReg, AssetInputKey, PageUp,       17);
-    data_reg_const_custom(g_dataReg, AssetInputKey, PageDown,     18);
-    data_reg_const_custom(g_dataReg, AssetInputKey, ArrowUp,      19);
-    data_reg_const_custom(g_dataReg, AssetInputKey, ArrowDown,    20);
-    data_reg_const_custom(g_dataReg, AssetInputKey, ArrowRight,   21);
-    data_reg_const_custom(g_dataReg, AssetInputKey, ArrowLeft,    22);
-    data_reg_const_custom(g_dataReg, AssetInputKey, BracketLeft,  23);
-    data_reg_const_custom(g_dataReg, AssetInputKey, BracketRight, 24);
-    data_reg_const_custom(g_dataReg, AssetInputKey, A,            25);
-    data_reg_const_custom(g_dataReg, AssetInputKey, B,            26);
-    data_reg_const_custom(g_dataReg, AssetInputKey, C,            27);
-    data_reg_const_custom(g_dataReg, AssetInputKey, D,            28);
-    data_reg_const_custom(g_dataReg, AssetInputKey, E,            29);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F,            30);
-    data_reg_const_custom(g_dataReg, AssetInputKey, G,            31);
-    data_reg_const_custom(g_dataReg, AssetInputKey, H,            32);
-    data_reg_const_custom(g_dataReg, AssetInputKey, I,            33);
-    data_reg_const_custom(g_dataReg, AssetInputKey, J,            34);
-    data_reg_const_custom(g_dataReg, AssetInputKey, K,            35);
-    data_reg_const_custom(g_dataReg, AssetInputKey, L,            36);
-    data_reg_const_custom(g_dataReg, AssetInputKey, M,            37);
-    data_reg_const_custom(g_dataReg, AssetInputKey, N,            38);
-    data_reg_const_custom(g_dataReg, AssetInputKey, O,            39);
-    data_reg_const_custom(g_dataReg, AssetInputKey, P,            40);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Q,            41);
-    data_reg_const_custom(g_dataReg, AssetInputKey, R,            42);
-    data_reg_const_custom(g_dataReg, AssetInputKey, S,            43);
-    data_reg_const_custom(g_dataReg, AssetInputKey, T,            44);
-    data_reg_const_custom(g_dataReg, AssetInputKey, U,            45);
-    data_reg_const_custom(g_dataReg, AssetInputKey, V,            46);
-    data_reg_const_custom(g_dataReg, AssetInputKey, W,            47);
-    data_reg_const_custom(g_dataReg, AssetInputKey, X,            48);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Y,            49);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Z,            50);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha0,       51);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha1,       52);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha2,       53);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha3,       54);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha4,       55);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha5,       56);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha6,       57);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha7,       58);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha8,       59);
-    data_reg_const_custom(g_dataReg, AssetInputKey, Alpha9,       60);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F1,           61);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F2,           62);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F3,           63);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F4,           64);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F5,           65);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F6,           66);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F7,           67);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F8,           68);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F9,           69);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F10,          70);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F11,          71);
-    data_reg_const_custom(g_dataReg, AssetInputKey, F12,          72);
+    data_reg_enum_t(reg, AssetInputKey);
+    data_reg_const_custom(reg, AssetInputKey, MouseLeft,    0);
+    data_reg_const_custom(reg, AssetInputKey, MouseRight,   1);
+    data_reg_const_custom(reg, AssetInputKey, MouseMiddle,  2);
+    data_reg_const_custom(reg, AssetInputKey, Shift,        3);
+    data_reg_const_custom(reg, AssetInputKey, Control,      4);
+    data_reg_const_custom(reg, AssetInputKey, Alt,          5);
+    data_reg_const_custom(reg, AssetInputKey, Backspace,    6);
+    data_reg_const_custom(reg, AssetInputKey, Delete,       7);
+    data_reg_const_custom(reg, AssetInputKey, Tab,          8);
+    data_reg_const_custom(reg, AssetInputKey, Tilde,        9);
+    data_reg_const_custom(reg, AssetInputKey, Return,       10);
+    data_reg_const_custom(reg, AssetInputKey, Escape,       11);
+    data_reg_const_custom(reg, AssetInputKey, Space,        12);
+    data_reg_const_custom(reg, AssetInputKey, Plus,         13);
+    data_reg_const_custom(reg, AssetInputKey, Minus,        14);
+    data_reg_const_custom(reg, AssetInputKey, Home,         15);
+    data_reg_const_custom(reg, AssetInputKey, End,          16);
+    data_reg_const_custom(reg, AssetInputKey, PageUp,       17);
+    data_reg_const_custom(reg, AssetInputKey, PageDown,     18);
+    data_reg_const_custom(reg, AssetInputKey, ArrowUp,      19);
+    data_reg_const_custom(reg, AssetInputKey, ArrowDown,    20);
+    data_reg_const_custom(reg, AssetInputKey, ArrowRight,   21);
+    data_reg_const_custom(reg, AssetInputKey, ArrowLeft,    22);
+    data_reg_const_custom(reg, AssetInputKey, BracketLeft,  23);
+    data_reg_const_custom(reg, AssetInputKey, BracketRight, 24);
+    data_reg_const_custom(reg, AssetInputKey, A,            25);
+    data_reg_const_custom(reg, AssetInputKey, B,            26);
+    data_reg_const_custom(reg, AssetInputKey, C,            27);
+    data_reg_const_custom(reg, AssetInputKey, D,            28);
+    data_reg_const_custom(reg, AssetInputKey, E,            29);
+    data_reg_const_custom(reg, AssetInputKey, F,            30);
+    data_reg_const_custom(reg, AssetInputKey, G,            31);
+    data_reg_const_custom(reg, AssetInputKey, H,            32);
+    data_reg_const_custom(reg, AssetInputKey, I,            33);
+    data_reg_const_custom(reg, AssetInputKey, J,            34);
+    data_reg_const_custom(reg, AssetInputKey, K,            35);
+    data_reg_const_custom(reg, AssetInputKey, L,            36);
+    data_reg_const_custom(reg, AssetInputKey, M,            37);
+    data_reg_const_custom(reg, AssetInputKey, N,            38);
+    data_reg_const_custom(reg, AssetInputKey, O,            39);
+    data_reg_const_custom(reg, AssetInputKey, P,            40);
+    data_reg_const_custom(reg, AssetInputKey, Q,            41);
+    data_reg_const_custom(reg, AssetInputKey, R,            42);
+    data_reg_const_custom(reg, AssetInputKey, S,            43);
+    data_reg_const_custom(reg, AssetInputKey, T,            44);
+    data_reg_const_custom(reg, AssetInputKey, U,            45);
+    data_reg_const_custom(reg, AssetInputKey, V,            46);
+    data_reg_const_custom(reg, AssetInputKey, W,            47);
+    data_reg_const_custom(reg, AssetInputKey, X,            48);
+    data_reg_const_custom(reg, AssetInputKey, Y,            49);
+    data_reg_const_custom(reg, AssetInputKey, Z,            50);
+    data_reg_const_custom(reg, AssetInputKey, Alpha0,       51);
+    data_reg_const_custom(reg, AssetInputKey, Alpha1,       52);
+    data_reg_const_custom(reg, AssetInputKey, Alpha2,       53);
+    data_reg_const_custom(reg, AssetInputKey, Alpha3,       54);
+    data_reg_const_custom(reg, AssetInputKey, Alpha4,       55);
+    data_reg_const_custom(reg, AssetInputKey, Alpha5,       56);
+    data_reg_const_custom(reg, AssetInputKey, Alpha6,       57);
+    data_reg_const_custom(reg, AssetInputKey, Alpha7,       58);
+    data_reg_const_custom(reg, AssetInputKey, Alpha8,       59);
+    data_reg_const_custom(reg, AssetInputKey, Alpha9,       60);
+    data_reg_const_custom(reg, AssetInputKey, F1,           61);
+    data_reg_const_custom(reg, AssetInputKey, F2,           62);
+    data_reg_const_custom(reg, AssetInputKey, F3,           63);
+    data_reg_const_custom(reg, AssetInputKey, F4,           64);
+    data_reg_const_custom(reg, AssetInputKey, F5,           65);
+    data_reg_const_custom(reg, AssetInputKey, F6,           66);
+    data_reg_const_custom(reg, AssetInputKey, F7,           67);
+    data_reg_const_custom(reg, AssetInputKey, F8,           68);
+    data_reg_const_custom(reg, AssetInputKey, F9,           69);
+    data_reg_const_custom(reg, AssetInputKey, F10,          70);
+    data_reg_const_custom(reg, AssetInputKey, F11,          71);
+    data_reg_const_custom(reg, AssetInputKey, F12,          72);
 
     /**
      * Blockers correspond to the 'InputBlocker' values as defined in 'input_manager.h'.
      * NOTE: This is a virtual data type, meaning there is no matching AssetInputBlocker C type.
      */
-    data_reg_enum_t(g_dataReg, AssetInputBlocker);
-    data_reg_const_custom(g_dataReg, AssetInputBlocker, TextInput, 0);
-    data_reg_const_custom(g_dataReg, AssetInputBlocker, HoveringUi, 1);
-    data_reg_const_custom(g_dataReg, AssetInputBlocker, HoveringGizmo, 2);
-    data_reg_const_custom(g_dataReg, AssetInputBlocker, PrefabCreateMode, 3);
-    data_reg_const_custom(g_dataReg, AssetInputBlocker, CursorLocked, 4);
+    data_reg_enum_t(reg, AssetInputBlocker);
+    data_reg_const_custom(reg, AssetInputBlocker, TextInput, 0);
+    data_reg_const_custom(reg, AssetInputBlocker, HoveringUi, 1);
+    data_reg_const_custom(reg, AssetInputBlocker, HoveringGizmo, 2);
+    data_reg_const_custom(reg, AssetInputBlocker, PrefabCreateMode, 3);
+    data_reg_const_custom(reg, AssetInputBlocker, CursorLocked, 4);
 
     /**
      * Modifiers correspond to the 'InputModifier' values as defined in 'input_manager.h'.
      * NOTE: This is a virtual data type, meaning there is no matching AssetInputModifier C type.
      */
-    data_reg_enum_t(g_dataReg, AssetInputModifier);
-    data_reg_const_custom(g_dataReg, AssetInputModifier, Shift, 0);
-    data_reg_const_custom(g_dataReg, AssetInputModifier, Control, 1);
-    data_reg_const_custom(g_dataReg, AssetInputModifier, Alt, 2);
+    data_reg_enum_t(reg, AssetInputModifier);
+    data_reg_const_custom(reg, AssetInputModifier, Shift, 0);
+    data_reg_const_custom(reg, AssetInputModifier, Control, 1);
+    data_reg_const_custom(reg, AssetInputModifier, Alt, 2);
 
-    data_reg_enum_t(g_dataReg, AssetInputType);
-    data_reg_const_t(g_dataReg, AssetInputType, Pressed);
-    data_reg_const_t(g_dataReg, AssetInputType, Released);
-    data_reg_const_t(g_dataReg, AssetInputType, Down);
+    data_reg_enum_t(reg, AssetInputType);
+    data_reg_const_t(reg, AssetInputType, Pressed);
+    data_reg_const_t(reg, AssetInputType, Released);
+    data_reg_const_t(reg, AssetInputType, Down);
 
-    data_reg_struct_t(g_dataReg, AssetInputBindingDef);
-    data_reg_field_t(g_dataReg, AssetInputBindingDef, type, t_AssetInputType);
-    data_reg_field_t(g_dataReg, AssetInputBindingDef, key, t_AssetInputKey);
-    data_reg_field_t(g_dataReg, AssetInputBindingDef, requiredModifiers, t_AssetInputModifier, .container = DataContainer_Array, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetInputBindingDef, illegalModifiers, t_AssetInputModifier, .container = DataContainer_Array, .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, AssetInputBindingDef);
+    data_reg_field_t(reg, AssetInputBindingDef, type, t_AssetInputType);
+    data_reg_field_t(reg, AssetInputBindingDef, key, t_AssetInputKey);
+    data_reg_field_t(reg, AssetInputBindingDef, requiredModifiers, t_AssetInputModifier, .container = DataContainer_Array, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetInputBindingDef, illegalModifiers, t_AssetInputModifier, .container = DataContainer_Array, .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, AssetInputActionDef);
-    data_reg_field_t(g_dataReg, AssetInputActionDef, name, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetInputActionDef, blockers, t_AssetInputBlocker, .container = DataContainer_Array, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetInputActionDef, bindings, t_AssetInputBindingDef, .container = DataContainer_Array, .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetInputActionDef);
+    data_reg_field_t(reg, AssetInputActionDef, name, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetInputActionDef, blockers, t_AssetInputBlocker, .container = DataContainer_Array, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetInputActionDef, bindings, t_AssetInputBindingDef, .container = DataContainer_Array, .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetInputMapDef);
-    data_reg_field_t(g_dataReg, AssetInputMapDef, actions, t_AssetInputActionDef, .container = DataContainer_Array);
+    data_reg_struct_t(reg, AssetInputMapDef);
+    data_reg_field_t(reg, AssetInputMapDef, actions, t_AssetInputActionDef, .container = DataContainer_Array);
     // clang-format on
 
     g_dataInputMapDefMeta = data_meta_t(t_AssetInputMapDef);
+    g_dataReg             = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }
@@ -223,10 +224,10 @@ static void asset_inputmap_build(
   array_ptr_for_t(def->actions, AssetInputActionDef, actionDef) {
     const usize            bindingCount = actionDef->bindings.count;
     const AssetInputAction action       = {
-        .nameHash     = stringtable_add(g_stringtable, actionDef->name),
-        .blockerBits  = asset_inputmap_blocker_bits(actionDef),
-        .bindingIndex = (u16)outBindings->size,
-        .bindingCount = (u16)bindingCount,
+              .nameHash     = stringtable_add(g_stringtable, actionDef->name),
+              .blockerBits  = asset_inputmap_blocker_bits(actionDef),
+              .bindingIndex = (u16)outBindings->size,
+              .bindingCount = (u16)bindingCount,
     };
     if (dynarray_search_binary(outActions, asset_inputmap_compare_action, &action)) {
       *err = InputMapError_DuplicateAction;

--- a/libs/asset/src/loader_mesh_pme.c
+++ b/libs/asset/src/loader_mesh_pme.c
@@ -63,50 +63,51 @@ static void pme_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
-    data_reg_enum_t(g_dataReg, PmeType);
-    data_reg_const_t(g_dataReg, PmeType, Triangle);
-    data_reg_const_t(g_dataReg, PmeType, Quad);
-    data_reg_const_t(g_dataReg, PmeType, Cube);
-    data_reg_const_t(g_dataReg, PmeType, Capsule);
-    data_reg_const_t(g_dataReg, PmeType, Cone);
-    data_reg_const_t(g_dataReg, PmeType, Cylinder);
-    data_reg_const_t(g_dataReg, PmeType, Hemisphere);
+    data_reg_enum_t(reg, PmeType);
+    data_reg_const_t(reg, PmeType, Triangle);
+    data_reg_const_t(reg, PmeType, Quad);
+    data_reg_const_t(reg, PmeType, Cube);
+    data_reg_const_t(reg, PmeType, Capsule);
+    data_reg_const_t(reg, PmeType, Cone);
+    data_reg_const_t(reg, PmeType, Cylinder);
+    data_reg_const_t(reg, PmeType, Hemisphere);
 
-    data_reg_enum_t(g_dataReg, PmeAxis);
-    data_reg_const_t(g_dataReg, PmeAxis, Up);
-    data_reg_const_t(g_dataReg, PmeAxis, Down);
-    data_reg_const_t(g_dataReg, PmeAxis, Right);
-    data_reg_const_t(g_dataReg, PmeAxis, Left);
-    data_reg_const_t(g_dataReg, PmeAxis, Forward);
-    data_reg_const_t(g_dataReg, PmeAxis, Backward);
+    data_reg_enum_t(reg, PmeAxis);
+    data_reg_const_t(reg, PmeAxis, Up);
+    data_reg_const_t(reg, PmeAxis, Down);
+    data_reg_const_t(reg, PmeAxis, Right);
+    data_reg_const_t(reg, PmeAxis, Left);
+    data_reg_const_t(reg, PmeAxis, Forward);
+    data_reg_const_t(reg, PmeAxis, Backward);
 
-    data_reg_struct_t(g_dataReg, PmeBounds);
-    data_reg_field_t(g_dataReg, PmeBounds, minX, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, PmeBounds, minY, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, PmeBounds, minZ, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, PmeBounds, maxX, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, PmeBounds, maxY, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, PmeBounds, maxZ, data_prim_t(f32));
+    data_reg_struct_t(reg, PmeBounds);
+    data_reg_field_t(reg, PmeBounds, minX, data_prim_t(f32));
+    data_reg_field_t(reg, PmeBounds, minY, data_prim_t(f32));
+    data_reg_field_t(reg, PmeBounds, minZ, data_prim_t(f32));
+    data_reg_field_t(reg, PmeBounds, maxX, data_prim_t(f32));
+    data_reg_field_t(reg, PmeBounds, maxY, data_prim_t(f32));
+    data_reg_field_t(reg, PmeBounds, maxZ, data_prim_t(f32));
 
-    data_reg_struct_t(g_dataReg, PmeDef);
-    data_reg_field_t(g_dataReg, PmeDef, type, t_PmeType);
-    data_reg_field_t(g_dataReg, PmeDef, axis, t_PmeAxis);
-    data_reg_field_t(g_dataReg, PmeDef, subdivisions, data_prim_t(u32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, PmeDef, length, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, PmeDef, scaleX, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, PmeDef, scaleY, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, PmeDef, scaleZ, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, PmeDef, offsetX, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, PmeDef, offsetY, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, PmeDef, offsetZ, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, PmeDef, uncapped, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, PmeDef, bounds, t_PmeBounds, .container = DataContainer_Pointer, .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, PmeDef);
+    data_reg_field_t(reg, PmeDef, type, t_PmeType);
+    data_reg_field_t(reg, PmeDef, axis, t_PmeAxis);
+    data_reg_field_t(reg, PmeDef, subdivisions, data_prim_t(u32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, PmeDef, length, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, PmeDef, scaleX, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, PmeDef, scaleY, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, PmeDef, scaleZ, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, PmeDef, offsetX, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, PmeDef, offsetY, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, PmeDef, offsetZ, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, PmeDef, uncapped, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, PmeDef, bounds, t_PmeBounds, .container = DataContainer_Pointer, .flags = DataFlags_Opt);
     // clang-format on
 
     g_dataPmeDefMeta = data_meta_t(t_PmeDef);
+    g_dataReg        = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }

--- a/libs/asset/src/loader_prefab.c
+++ b/libs/asset/src/loader_prefab.c
@@ -140,103 +140,104 @@ static void prefab_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
-    data_reg_struct_t(g_dataReg, AssetPrefabVec3Def);
-    data_reg_field_t(g_dataReg, AssetPrefabVec3Def, x, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabVec3Def, y, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabVec3Def, z, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, AssetPrefabVec3Def);
+    data_reg_field_t(reg, AssetPrefabVec3Def, x, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabVec3Def, y, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabVec3Def, z, data_prim_t(f32), .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabShapeSphereDef);
-    data_reg_field_t(g_dataReg, AssetPrefabShapeSphereDef, offset, t_AssetPrefabVec3Def, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabShapeSphereDef, radius, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetPrefabShapeSphereDef);
+    data_reg_field_t(reg, AssetPrefabShapeSphereDef, offset, t_AssetPrefabVec3Def, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabShapeSphereDef, radius, data_prim_t(f32), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabShapeCapsuleDef);
-    data_reg_field_t(g_dataReg, AssetPrefabShapeCapsuleDef, offset, t_AssetPrefabVec3Def, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabShapeCapsuleDef, radius, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabShapeCapsuleDef, height, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetPrefabShapeCapsuleDef);
+    data_reg_field_t(reg, AssetPrefabShapeCapsuleDef, offset, t_AssetPrefabVec3Def, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabShapeCapsuleDef, radius, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabShapeCapsuleDef, height, data_prim_t(f32), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabShapeBoxDef);
-    data_reg_field_t(g_dataReg, AssetPrefabShapeBoxDef, min, t_AssetPrefabVec3Def);
-    data_reg_field_t(g_dataReg, AssetPrefabShapeBoxDef, max, t_AssetPrefabVec3Def);
+    data_reg_struct_t(reg, AssetPrefabShapeBoxDef);
+    data_reg_field_t(reg, AssetPrefabShapeBoxDef, min, t_AssetPrefabVec3Def);
+    data_reg_field_t(reg, AssetPrefabShapeBoxDef, max, t_AssetPrefabVec3Def);
 
-    data_reg_union_t(g_dataReg, AssetPrefabShapeDef, type);
-    data_reg_choice_t(g_dataReg, AssetPrefabShapeDef, AssetPrefabShape_Sphere, data_sphere, t_AssetPrefabShapeSphereDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabShapeDef, AssetPrefabShape_Capsule, data_capsule, t_AssetPrefabShapeCapsuleDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabShapeDef, AssetPrefabShape_Box, data_box, t_AssetPrefabShapeBoxDef);
+    data_reg_union_t(reg, AssetPrefabShapeDef, type);
+    data_reg_choice_t(reg, AssetPrefabShapeDef, AssetPrefabShape_Sphere, data_sphere, t_AssetPrefabShapeSphereDef);
+    data_reg_choice_t(reg, AssetPrefabShapeDef, AssetPrefabShape_Capsule, data_capsule, t_AssetPrefabShapeCapsuleDef);
+    data_reg_choice_t(reg, AssetPrefabShapeDef, AssetPrefabShape_Box, data_box, t_AssetPrefabShapeBoxDef);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitRenderableDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitRenderableDef, graphicId, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetPrefabTraitRenderableDef);
+    data_reg_field_t(reg, AssetPrefabTraitRenderableDef, graphicId, data_prim_t(String), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitVfxDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitVfxDef, assetId, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetPrefabTraitVfxDef);
+    data_reg_field_t(reg, AssetPrefabTraitVfxDef, assetId, data_prim_t(String), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitLifetimeDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitLifetimeDef, duration, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetPrefabTraitLifetimeDef);
+    data_reg_field_t(reg, AssetPrefabTraitLifetimeDef, duration, data_prim_t(f32), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitScaleDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitScaleDef, scale, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetPrefabTraitScaleDef);
+    data_reg_field_t(reg, AssetPrefabTraitScaleDef, scale, data_prim_t(f32), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitMovementDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitMovementDef, speed, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitMovementDef, accelerationNorm, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitMovementDef, rotationSpeed, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitMovementDef, radius, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitMovementDef, moveAnimation, data_prim_t(String));
+    data_reg_struct_t(reg, AssetPrefabTraitMovementDef);
+    data_reg_field_t(reg, AssetPrefabTraitMovementDef, speed, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitMovementDef, accelerationNorm, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitMovementDef, rotationSpeed, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitMovementDef, radius, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitMovementDef, moveAnimation, data_prim_t(String));
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitHealthDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitHealthDef, amount, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitHealthDef, deathDestroyDelay, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetPrefabTraitHealthDef, deathVfxId, data_prim_t(String), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetPrefabTraitHealthDef);
+    data_reg_field_t(reg, AssetPrefabTraitHealthDef, amount, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitHealthDef, deathDestroyDelay, data_prim_t(f32));
+    data_reg_field_t(reg, AssetPrefabTraitHealthDef, deathVfxId, data_prim_t(String), .flags = DataFlags_Opt | DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitAttackDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitAttackDef, weaponId, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitAttackDef, aimJoint, data_prim_t(String), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitAttackDef, aimSpeed, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitAttackDef, targetDistanceMin, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitAttackDef, targetDistanceMax, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitAttackDef, targetLineOfSightRadius, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitAttackDef, targetExcludeUnreachable, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitAttackDef, targetExcludeObscured, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, AssetPrefabTraitAttackDef);
+    data_reg_field_t(reg, AssetPrefabTraitAttackDef, weaponId, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitAttackDef, aimJoint, data_prim_t(String), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitAttackDef, aimSpeed, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitAttackDef, targetDistanceMin, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabTraitAttackDef, targetDistanceMax, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitAttackDef, targetLineOfSightRadius, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabTraitAttackDef, targetExcludeUnreachable, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabTraitAttackDef, targetExcludeObscured, data_prim_t(bool), .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitCollisionDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitCollisionDef, navBlocker, data_prim_t(bool));
-    data_reg_field_t(g_dataReg, AssetPrefabTraitCollisionDef, shape, t_AssetPrefabShapeDef);
+    data_reg_struct_t(reg, AssetPrefabTraitCollisionDef);
+    data_reg_field_t(reg, AssetPrefabTraitCollisionDef, navBlocker, data_prim_t(bool));
+    data_reg_field_t(reg, AssetPrefabTraitCollisionDef, shape, t_AssetPrefabShapeDef);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitBrainDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitBrainDef, behaviorId, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetPrefabTraitBrainDef);
+    data_reg_field_t(reg, AssetPrefabTraitBrainDef, behaviorId, data_prim_t(String), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabTraitSpawnerDef);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitSpawnerDef, prefabId, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitSpawnerDef, radius, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitSpawnerDef, count, data_prim_t(u32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitSpawnerDef, maxInstances, data_prim_t(u32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitSpawnerDef, intervalMin, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabTraitSpawnerDef, intervalMax, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, AssetPrefabTraitSpawnerDef);
+    data_reg_field_t(reg, AssetPrefabTraitSpawnerDef, prefabId, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitSpawnerDef, radius, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabTraitSpawnerDef, count, data_prim_t(u32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabTraitSpawnerDef, maxInstances, data_prim_t(u32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabTraitSpawnerDef, intervalMin, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabTraitSpawnerDef, intervalMax, data_prim_t(f32), .flags = DataFlags_Opt);
 
-    data_reg_union_t(g_dataReg, AssetPrefabTraitDef, type);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Renderable, data_renderable, t_AssetPrefabTraitRenderableDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Vfx, data_vfx, t_AssetPrefabTraitVfxDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Lifetime, data_lifetime, t_AssetPrefabTraitLifetimeDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Scale, data_scale, t_AssetPrefabTraitScaleDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Movement, data_movement, t_AssetPrefabTraitMovementDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Health, data_health, t_AssetPrefabTraitHealthDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Attack, data_attack, t_AssetPrefabTraitAttackDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Collision, data_collision, t_AssetPrefabTraitCollisionDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Brain, data_brain, t_AssetPrefabTraitBrainDef);
-    data_reg_choice_t(g_dataReg, AssetPrefabTraitDef, AssetPrefabTrait_Spawner, data_spawner, t_AssetPrefabTraitSpawnerDef);
+    data_reg_union_t(reg, AssetPrefabTraitDef, type);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Renderable, data_renderable, t_AssetPrefabTraitRenderableDef);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Vfx, data_vfx, t_AssetPrefabTraitVfxDef);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Lifetime, data_lifetime, t_AssetPrefabTraitLifetimeDef);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Scale, data_scale, t_AssetPrefabTraitScaleDef);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Movement, data_movement, t_AssetPrefabTraitMovementDef);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Health, data_health, t_AssetPrefabTraitHealthDef);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Attack, data_attack, t_AssetPrefabTraitAttackDef);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Collision, data_collision, t_AssetPrefabTraitCollisionDef);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Brain, data_brain, t_AssetPrefabTraitBrainDef);
+    data_reg_choice_t(reg, AssetPrefabTraitDef, AssetPrefabTrait_Spawner, data_spawner, t_AssetPrefabTraitSpawnerDef);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabDef);
-    data_reg_field_t(g_dataReg, AssetPrefabDef, name, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetPrefabDef, isUnit, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetPrefabDef, traits, t_AssetPrefabTraitDef, .container = DataContainer_Array);
+    data_reg_struct_t(reg, AssetPrefabDef);
+    data_reg_field_t(reg, AssetPrefabDef, name, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetPrefabDef, isUnit, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetPrefabDef, traits, t_AssetPrefabTraitDef, .container = DataContainer_Array);
 
-    data_reg_struct_t(g_dataReg, AssetPrefabMapDef);
-    data_reg_field_t(g_dataReg, AssetPrefabMapDef, prefabs, t_AssetPrefabDef, .container = DataContainer_Array);
+    data_reg_struct_t(reg, AssetPrefabMapDef);
+    data_reg_field_t(reg, AssetPrefabMapDef, prefabs, t_AssetPrefabDef, .container = DataContainer_Array);
     // clang-format on
 
     g_dataMapDefMeta = data_meta_t(t_AssetPrefabMapDef);
+    g_dataReg        = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }

--- a/libs/asset/src/loader_texture.c
+++ b/libs/asset/src/loader_texture.c
@@ -9,6 +9,53 @@
 
 #include "repo_internal.h"
 
+static const f32 g_textureSrgbToFloat[] = {
+    0.0f,          0.000303527f, 0.000607054f, 0.00091058103f, 0.001214108f, 0.001517635f,
+    0.0018211621f, 0.002124689f, 0.002428216f, 0.002731743f,   0.00303527f,  0.0033465356f,
+    0.003676507f,  0.004024717f, 0.004391442f, 0.0047769533f,  0.005181517f, 0.0056053917f,
+    0.0060488326f, 0.006512091f, 0.00699541f,  0.0074990317f,  0.008023192f, 0.008568125f,
+    0.009134057f,  0.009721218f, 0.010329823f, 0.010960094f,   0.011612245f, 0.012286487f,
+    0.012983031f,  0.013702081f, 0.014443844f, 0.015208514f,   0.015996292f, 0.016807375f,
+    0.017641952f,  0.018500218f, 0.019382361f, 0.020288562f,   0.02121901f,  0.022173883f,
+    0.023153365f,  0.02415763f,  0.025186857f, 0.026241222f,   0.027320892f, 0.028426038f,
+    0.029556843f,  0.03071345f,  0.03189604f,  0.033104774f,   0.03433981f,  0.035601325f,
+    0.036889452f,  0.038204376f, 0.039546248f, 0.04091521f,    0.042311423f, 0.043735042f,
+    0.045186214f,  0.046665095f, 0.048171833f, 0.049706575f,   0.051269468f, 0.052860655f,
+    0.05448028f,   0.056128494f, 0.057805434f, 0.05951124f,    0.06124607f,  0.06301003f,
+    0.06480328f,   0.06662595f,  0.06847818f,  0.07036011f,    0.07227186f,  0.07421358f,
+    0.07618539f,   0.07818743f,  0.08021983f,  0.082282715f,   0.084376216f, 0.086500466f,
+    0.088655606f,  0.09084173f,  0.09305898f,  0.095307484f,   0.09758736f,  0.09989874f,
+    0.10224175f,   0.10461649f,  0.10702311f,  0.10946172f,    0.111932434f, 0.11443538f,
+    0.116970696f,  0.11953845f,  0.12213881f,  0.12477186f,    0.12743773f,  0.13013652f,
+    0.13286836f,   0.13563336f,  0.13843165f,  0.14126332f,    0.1441285f,   0.1470273f,
+    0.14995982f,   0.15292618f,  0.1559265f,   0.15896086f,    0.16202943f,  0.16513224f,
+    0.16826946f,   0.17144115f,  0.17464745f,  0.17788847f,    0.1811643f,   0.18447503f,
+    0.1878208f,    0.19120172f,  0.19461787f,  0.19806935f,    0.2015563f,   0.20507877f,
+    0.2086369f,    0.21223079f,  0.21586053f,  0.21952623f,    0.22322798f,  0.22696589f,
+    0.23074007f,   0.23455065f,  0.23839766f,  0.2422812f,     0.2462014f,   0.25015837f,
+    0.25415218f,   0.2581829f,   0.26225072f,  0.26635566f,    0.27049786f,  0.27467737f,
+    0.27889434f,   0.2831488f,   0.2874409f,   0.2917707f,     0.29613832f,  0.30054384f,
+    0.30498737f,   0.30946895f,  0.31398875f,  0.31854683f,    0.32314324f,  0.32777813f,
+    0.33245158f,   0.33716366f,  0.34191445f,  0.3467041f,     0.3515327f,   0.35640025f,
+    0.36130688f,   0.3662527f,   0.37123778f,  0.37626222f,    0.3813261f,   0.38642952f,
+    0.39157256f,   0.3967553f,   0.40197787f,  0.4072403f,     0.4125427f,   0.41788515f,
+    0.42326775f,   0.42869055f,  0.4341537f,   0.43965724f,    0.44520125f,  0.45078585f,
+    0.45641106f,   0.46207705f,  0.46778384f,  0.47353154f,    0.47932023f,  0.48514998f,
+    0.4910209f,    0.49693304f,  0.5028866f,   0.50888145f,    0.5149178f,   0.5209957f,
+    0.52711535f,   0.5332766f,   0.5394797f,   0.5457247f,     0.5520116f,   0.5583406f,
+    0.5647117f,    0.57112503f,  0.57758063f,  0.5840786f,     0.590619f,    0.597202f,
+    0.60382754f,   0.61049575f,  0.61720675f,  0.62396055f,    0.63075733f,  0.637597f,
+    0.6444799f,    0.6514058f,   0.65837497f,  0.66538745f,    0.67244333f,  0.6795426f,
+    0.68668544f,   0.69387203f,  0.70110214f,  0.70837605f,    0.7156938f,   0.72305536f,
+    0.730461f,     0.7379107f,   0.7454045f,   0.75294244f,    0.76052475f,  0.7681514f,
+    0.77582246f,   0.78353804f,  0.79129815f,  0.79910296f,    0.8069525f,   0.8148468f,
+    0.822786f,     0.8307701f,   0.83879924f,  0.84687346f,    0.8549928f,   0.8631574f,
+    0.87136734f,   0.8796226f,   0.8879232f,   0.89626956f,    0.90466136f,  0.913099f,
+    0.92158204f,   0.93011117f,  0.9386859f,   0.9473069f,     0.9559735f,   0.9646866f,
+    0.9734455f,    0.98225087f,  0.9911022f,   1.0f,
+};
+ASSERT(array_elems(g_textureSrgbToFloat) == 256, "Incorrect srgb lut size");
+
 ecs_comp_define_public(AssetTextureComp);
 
 static void ecs_destruct_texture_comp(void* data) {
@@ -149,14 +196,25 @@ GeoColor asset_texture_at(const AssetTextureComp* tex, const u32 layer, const us
       res.r = 1.0f;
       res.g = 1.0f;
       res.b = 1.0f;
-      res.a = ((AssetTexturePixelB1*)pixelsMip0)[index].r * g_u8MaxInv;
-      goto ColorDecode;
+      if (tex->flags & AssetTextureFlags_Srgb) {
+        res.a = g_textureSrgbToFloat[((AssetTexturePixelB1*)pixelsMip0)[index].r];
+      } else {
+        res.a = ((AssetTexturePixelB1*)pixelsMip0)[index].r * g_u8MaxInv;
+      }
+      return res;
     case AssetTextureChannels_Four:
-      res.r = ((AssetTexturePixelB4*)pixelsMip0)[index].r * g_u8MaxInv;
-      res.g = ((AssetTexturePixelB4*)pixelsMip0)[index].g * g_u8MaxInv;
-      res.b = ((AssetTexturePixelB4*)pixelsMip0)[index].b * g_u8MaxInv;
-      res.a = ((AssetTexturePixelB4*)pixelsMip0)[index].a * g_u8MaxInv;
-      goto ColorDecode;
+      if (tex->flags & AssetTextureFlags_Srgb) {
+        res.r = g_textureSrgbToFloat[((AssetTexturePixelB4*)pixelsMip0)[index].r];
+        res.g = g_textureSrgbToFloat[((AssetTexturePixelB4*)pixelsMip0)[index].g];
+        res.b = g_textureSrgbToFloat[((AssetTexturePixelB4*)pixelsMip0)[index].b];
+        res.a = g_textureSrgbToFloat[((AssetTexturePixelB4*)pixelsMip0)[index].a];
+      } else {
+        res.r = ((AssetTexturePixelB4*)pixelsMip0)[index].r * g_u8MaxInv;
+        res.g = ((AssetTexturePixelB4*)pixelsMip0)[index].g * g_u8MaxInv;
+        res.b = ((AssetTexturePixelB4*)pixelsMip0)[index].b * g_u8MaxInv;
+        res.a = ((AssetTexturePixelB4*)pixelsMip0)[index].a * g_u8MaxInv;
+      }
+      return res;
     }
   }
   // 16 bit unsigned pixels.
@@ -168,13 +226,13 @@ GeoColor asset_texture_at(const AssetTextureComp* tex, const u32 layer, const us
       res.g = 1.0f;
       res.b = 1.0f;
       res.a = ((AssetTexturePixelU1*)pixelsMip0)[index].r * g_u16MaxInv;
-      goto ColorDecode;
+      return res;
     case AssetTextureChannels_Four:
       res.r = ((AssetTexturePixelU4*)pixelsMip0)[index].r * g_u16MaxInv;
       res.g = ((AssetTexturePixelU4*)pixelsMip0)[index].g * g_u16MaxInv;
       res.b = ((AssetTexturePixelU4*)pixelsMip0)[index].b * g_u16MaxInv;
       res.a = ((AssetTexturePixelU4*)pixelsMip0)[index].a * g_u16MaxInv;
-      goto ColorDecode;
+      return res;
     }
   }
   // 32 bit floating point pixels.
@@ -185,29 +243,19 @@ GeoColor asset_texture_at(const AssetTextureComp* tex, const u32 layer, const us
       res.g = 1.0f;
       res.b = 1.0f;
       res.a = ((AssetTexturePixelF1*)pixelsMip0)[index].r;
-      goto ColorDecode;
+      return res;
     case AssetTextureChannels_Four:
       res.r = ((AssetTexturePixelF4*)pixelsMip0)[index].r;
       res.g = ((AssetTexturePixelF4*)pixelsMip0)[index].g;
       res.b = ((AssetTexturePixelF4*)pixelsMip0)[index].b;
       res.a = ((AssetTexturePixelF4*)pixelsMip0)[index].a;
-      goto ColorDecode;
+      return res;
     }
   }
   case AssetTextureType_Count:
     break;
   }
   UNREACHABLE
-
-ColorDecode:
-  if (tex->flags & AssetTextureFlags_Srgb) {
-    // Simple approximation of the srgb curve: https://en.wikipedia.org/wiki/SRGB.
-    res.r = math_pow_f32(res.r, 2.2f);
-    res.g = math_pow_f32(res.g, 2.2f);
-    res.b = math_pow_f32(res.b, 2.2f);
-    res.a = math_pow_f32(res.a, 2.2f);
-  }
-  return res;
 }
 
 GeoColor asset_texture_sample(

--- a/libs/asset/src/loader_texture_atx.c
+++ b/libs/asset/src/loader_texture_atx.c
@@ -62,24 +62,25 @@ static void atx_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
-    data_reg_enum_t(g_dataReg, AtxType);
-    data_reg_const_t(g_dataReg, AtxType, Array);
-    data_reg_const_t(g_dataReg, AtxType, Cube);
-    data_reg_const_t(g_dataReg, AtxType, CubeDiffIrradiance);
-    data_reg_const_t(g_dataReg, AtxType, CubeSpecIrradiance);
+    data_reg_enum_t(reg, AtxType);
+    data_reg_const_t(reg, AtxType, Array);
+    data_reg_const_t(reg, AtxType, Cube);
+    data_reg_const_t(reg, AtxType, CubeDiffIrradiance);
+    data_reg_const_t(reg, AtxType, CubeSpecIrradiance);
 
-    data_reg_struct_t(g_dataReg, AtxDef);
-    data_reg_field_t(g_dataReg, AtxDef, type, t_AtxType);
-    data_reg_field_t(g_dataReg, AtxDef, mipmaps, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AtxDef, sizeX, data_prim_t(u32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AtxDef, sizeY, data_prim_t(u32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AtxDef, textures, data_prim_t(String), .flags = DataFlags_NotEmpty, .container = DataContainer_Array);
+    data_reg_struct_t(reg, AtxDef);
+    data_reg_field_t(reg, AtxDef, type, t_AtxType);
+    data_reg_field_t(reg, AtxDef, mipmaps, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AtxDef, sizeX, data_prim_t(u32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AtxDef, sizeY, data_prim_t(u32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AtxDef, textures, data_prim_t(String), .flags = DataFlags_NotEmpty, .container = DataContainer_Array);
     // clang-format on
 
     g_dataAtxDefMeta = data_meta_t(t_AtxDef);
+    g_dataReg        = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }

--- a/libs/asset/src/loader_texture_atx.c
+++ b/libs/asset/src/loader_texture_atx.c
@@ -23,6 +23,7 @@
 #define atx_max_textures 100
 #define atx_max_layers 256
 #define atx_max_size 2048
+#define atx_max_generates_per_tick 1
 #define atx_spec_irradiance_mips 5
 
 static const GeoQuat g_cubeFaceRot[] = {
@@ -605,6 +606,8 @@ ecs_system_define(AtxLoadUpdateSys) {
   EcsView*     loadView   = ecs_world_view_t(world, LoadView);
   EcsIterator* textureItr = ecs_view_itr(ecs_world_view_t(world, TextureView));
 
+  u32 numGenerates = 0;
+
   for (EcsIterator* itr = ecs_view_itr(loadView); ecs_view_walk(itr);) {
     const EcsEntityId entity = ecs_view_entity(itr);
     AssetAtxLoadComp* load   = ecs_view_write_t(itr, AssetAtxLoadComp);
@@ -653,6 +656,9 @@ ecs_system_define(AtxLoadUpdateSys) {
     dynarray_for_t(&load->textures, EcsEntityId, texAsset) { asset_release(world, *texAsset); }
 
   Next:
+    if (++numGenerates == atx_max_generates_per_tick) {
+      break;
+    }
     continue;
   }
 }

--- a/libs/asset/src/loader_texture_ptx.c
+++ b/libs/asset/src/loader_texture_ptx.c
@@ -212,7 +212,7 @@ static GeoColor ptx_sample_brdf_integration(const f32 roughness, const f32 nDotV
   f32 outScale = 0;
   f32 outBias  = 0;
 
-  enum { SampleCount = 256 };
+  enum { SampleCount = 128 };
   for (u32 i = 0; i != SampleCount; ++i) {
     const GeoVector halfDir  = importance_sample_ggx(i, SampleCount, roughness);
     const f32       vDotH    = math_max(geo_vector_dot(view, halfDir), 0);

--- a/libs/asset/src/loader_texture_ptx.c
+++ b/libs/asset/src/loader_texture_ptx.c
@@ -51,40 +51,41 @@ static void ptx_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
-    data_reg_enum_t(g_dataReg, PtxType);
-    data_reg_const_t(g_dataReg, PtxType, One);
-    data_reg_const_t(g_dataReg, PtxType, Zero);
-    data_reg_const_t(g_dataReg, PtxType, Checker);
-    data_reg_const_t(g_dataReg, PtxType, Circle);
-    data_reg_const_t(g_dataReg, PtxType, NoisePerlin);
-    data_reg_const_t(g_dataReg, PtxType, NoiseWhite);
-    data_reg_const_t(g_dataReg, PtxType, NoiseWhiteGauss);
-    data_reg_const_t(g_dataReg, PtxType, BrdfIntegration);
+    data_reg_enum_t(reg, PtxType);
+    data_reg_const_t(reg, PtxType, One);
+    data_reg_const_t(reg, PtxType, Zero);
+    data_reg_const_t(reg, PtxType, Checker);
+    data_reg_const_t(reg, PtxType, Circle);
+    data_reg_const_t(reg, PtxType, NoisePerlin);
+    data_reg_const_t(reg, PtxType, NoiseWhite);
+    data_reg_const_t(reg, PtxType, NoiseWhiteGauss);
+    data_reg_const_t(reg, PtxType, BrdfIntegration);
 
-    data_reg_enum_t(g_dataReg, AssetTextureChannels);
-    data_reg_const_t(g_dataReg, AssetTextureChannels, One);
-    data_reg_const_t(g_dataReg, AssetTextureChannels, Four);
+    data_reg_enum_t(reg, AssetTextureChannels);
+    data_reg_const_t(reg, AssetTextureChannels, One);
+    data_reg_const_t(reg, AssetTextureChannels, Four);
 
-    data_reg_enum_t(g_dataReg, AssetTextureType);
-    data_reg_const_t(g_dataReg, AssetTextureType, U8);
-    data_reg_const_t(g_dataReg, AssetTextureType, U16);
-    data_reg_const_t(g_dataReg, AssetTextureType, F32);
+    data_reg_enum_t(reg, AssetTextureType);
+    data_reg_const_t(reg, AssetTextureType, U8);
+    data_reg_const_t(reg, AssetTextureType, U16);
+    data_reg_const_t(reg, AssetTextureType, F32);
 
-    data_reg_struct_t(g_dataReg, PtxDef);
-    data_reg_field_t(g_dataReg, PtxDef, type, t_PtxType);
-    data_reg_field_t(g_dataReg, PtxDef, pixelType, t_AssetTextureType, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, PtxDef, channels, t_AssetTextureChannels);
-    data_reg_field_t(g_dataReg, PtxDef, mipmaps, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, PtxDef, size, data_prim_t(u32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, PtxDef, frequency, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, PtxDef, power, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, PtxDef, seed, data_prim_t(u32), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, PtxDef);
+    data_reg_field_t(reg, PtxDef, type, t_PtxType);
+    data_reg_field_t(reg, PtxDef, pixelType, t_AssetTextureType, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, PtxDef, channels, t_AssetTextureChannels);
+    data_reg_field_t(reg, PtxDef, mipmaps, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, PtxDef, size, data_prim_t(u32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, PtxDef, frequency, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, PtxDef, power, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, PtxDef, seed, data_prim_t(u32), .flags = DataFlags_NotEmpty);
     // clang-format on
 
     g_dataPtxDefMeta = data_meta_t(t_PtxDef);
+    g_dataReg        = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }

--- a/libs/asset/src/loader_vfx.c
+++ b/libs/asset/src/loader_vfx.c
@@ -102,103 +102,104 @@ static void vfx_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
-    data_reg_struct_t(g_dataReg, VfxVec2Def);
-    data_reg_field_t(g_dataReg, VfxVec2Def, x, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxVec2Def, y, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxVec2Def);
+    data_reg_field_t(reg, VfxVec2Def, x, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxVec2Def, y, data_prim_t(f32), .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, VfxVec3Def);
-    data_reg_field_t(g_dataReg, VfxVec3Def, x, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxVec3Def, y, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxVec3Def, z, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxVec3Def);
+    data_reg_field_t(reg, VfxVec3Def, x, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxVec3Def, y, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxVec3Def, z, data_prim_t(f32), .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, VfxRotDef);
-    data_reg_field_t(g_dataReg, VfxRotDef, x, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxRotDef, y, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxRotDef, z, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxRotDef);
+    data_reg_field_t(reg, VfxRotDef, x, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxRotDef, y, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxRotDef, z, data_prim_t(f32), .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, VfxColorDef);
-    data_reg_field_t(g_dataReg, VfxColorDef, r, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, VfxColorDef, g, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, VfxColorDef, b, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, VfxColorDef, a, data_prim_t(f32));
+    data_reg_struct_t(reg, VfxColorDef);
+    data_reg_field_t(reg, VfxColorDef, r, data_prim_t(f32));
+    data_reg_field_t(reg, VfxColorDef, g, data_prim_t(f32));
+    data_reg_field_t(reg, VfxColorDef, b, data_prim_t(f32));
+    data_reg_field_t(reg, VfxColorDef, a, data_prim_t(f32));
 
-    data_reg_struct_t(g_dataReg, VfxConeDef);
-    data_reg_field_t(g_dataReg, VfxConeDef, angle, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxConeDef, radius, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxConeDef, position, t_VfxVec3Def, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxConeDef, rotation, t_VfxRotDef, .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxConeDef);
+    data_reg_field_t(reg, VfxConeDef, angle, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxConeDef, radius, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxConeDef, position, t_VfxVec3Def, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxConeDef, rotation, t_VfxRotDef, .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, VfxRangeScalarDef);
-    data_reg_field_t(g_dataReg, VfxRangeScalarDef, min, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxRangeScalarDef, max, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxRangeScalarDef);
+    data_reg_field_t(reg, VfxRangeScalarDef, min, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxRangeScalarDef, max, data_prim_t(f32), .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, VfxRangeDurationDef);
-    data_reg_field_t(g_dataReg, VfxRangeDurationDef, min, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxRangeDurationDef, max, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxRangeDurationDef);
+    data_reg_field_t(reg, VfxRangeDurationDef, min, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxRangeDurationDef, max, data_prim_t(f32), .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, VfxRangeRotationDef);
-    data_reg_field_t(g_dataReg, VfxRangeRotationDef, base, t_VfxRotDef, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxRangeRotationDef, random, t_VfxRotDef, .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxRangeRotationDef);
+    data_reg_field_t(reg, VfxRangeRotationDef, base, t_VfxRotDef, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxRangeRotationDef, random, t_VfxRotDef, .flags = DataFlags_Opt);
 
-    data_reg_enum_t(g_dataReg, AssetVfxSpace);
-    data_reg_const_t(g_dataReg, AssetVfxSpace, Local);
-    data_reg_const_t(g_dataReg, AssetVfxSpace, World);
+    data_reg_enum_t(reg, AssetVfxSpace);
+    data_reg_const_t(reg, AssetVfxSpace, Local);
+    data_reg_const_t(reg, AssetVfxSpace, World);
 
-    data_reg_enum_t(g_dataReg, AssetVfxBlend);
-    data_reg_const_t(g_dataReg, AssetVfxBlend, None);
-    data_reg_const_t(g_dataReg, AssetVfxBlend, Alpha);
-    data_reg_const_t(g_dataReg, AssetVfxBlend, Additive);
+    data_reg_enum_t(reg, AssetVfxBlend);
+    data_reg_const_t(reg, AssetVfxBlend, None);
+    data_reg_const_t(reg, AssetVfxBlend, Alpha);
+    data_reg_const_t(reg, AssetVfxBlend, Additive);
 
-    data_reg_enum_t(g_dataReg, AssetVfxFacing);
-    data_reg_const_t(g_dataReg, AssetVfxFacing, Local);
-    data_reg_const_t(g_dataReg, AssetVfxFacing, BillboardSphere);
-    data_reg_const_t(g_dataReg, AssetVfxFacing, BillboardCylinder);
+    data_reg_enum_t(reg, AssetVfxFacing);
+    data_reg_const_t(reg, AssetVfxFacing, Local);
+    data_reg_const_t(reg, AssetVfxFacing, BillboardSphere);
+    data_reg_const_t(reg, AssetVfxFacing, BillboardCylinder);
 
-    data_reg_struct_t(g_dataReg, VfxSpriteDef);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, atlasEntry, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, color, t_VfxColorDef, .container = DataContainer_Pointer, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, blend, t_AssetVfxBlend, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, facing, t_AssetVfxFacing, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, flipbookCount, data_prim_t(u16), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, flipbookTime, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, size, t_VfxVec2Def);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, fadeInTime, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, fadeOutTime, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, scaleInTime, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, scaleOutTime, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxSpriteDef, geometryFade, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxSpriteDef);
+    data_reg_field_t(reg, VfxSpriteDef, atlasEntry, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, VfxSpriteDef, color, t_VfxColorDef, .container = DataContainer_Pointer, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxSpriteDef, blend, t_AssetVfxBlend, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxSpriteDef, facing, t_AssetVfxFacing, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxSpriteDef, flipbookCount, data_prim_t(u16), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxSpriteDef, flipbookTime, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxSpriteDef, size, t_VfxVec2Def);
+    data_reg_field_t(reg, VfxSpriteDef, fadeInTime, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxSpriteDef, fadeOutTime, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxSpriteDef, scaleInTime, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxSpriteDef, scaleOutTime, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxSpriteDef, geometryFade, data_prim_t(bool), .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, VfxLightDef);
-    data_reg_field_t(g_dataReg, VfxLightDef, radiance, t_VfxColorDef, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxLightDef, attenuationLinear, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxLightDef, attenuationQuad, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxLightDef, fadeInTime, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxLightDef, fadeOutTime, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxLightDef, turbulenceFrequency, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxLightDef);
+    data_reg_field_t(reg, VfxLightDef, radiance, t_VfxColorDef, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxLightDef, attenuationLinear, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxLightDef, attenuationQuad, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxLightDef, fadeInTime, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxLightDef, fadeOutTime, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxLightDef, turbulenceFrequency, data_prim_t(f32), .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, VfxEmitterDef);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, cone, t_VfxConeDef, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, force, t_VfxVec3Def, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, space, t_AssetVfxSpace, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, sprite, t_VfxSpriteDef, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, light, t_VfxLightDef, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, speed, t_VfxRangeScalarDef, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, expandForce, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, count, data_prim_t(u32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, interval, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, scale, t_VfxRangeScalarDef, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, lifetime, t_VfxRangeDurationDef, .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxEmitterDef, rotation, t_VfxRangeRotationDef, .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, VfxEmitterDef);
+    data_reg_field_t(reg, VfxEmitterDef, cone, t_VfxConeDef, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, force, t_VfxVec3Def, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, space, t_AssetVfxSpace, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, sprite, t_VfxSpriteDef, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, light, t_VfxLightDef, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, speed, t_VfxRangeScalarDef, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, expandForce, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, count, data_prim_t(u32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, interval, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, scale, t_VfxRangeScalarDef, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, lifetime, t_VfxRangeDurationDef, .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxEmitterDef, rotation, t_VfxRangeRotationDef, .flags = DataFlags_Opt);
 
-    data_reg_struct_t(g_dataReg, VfxDef);
-    data_reg_field_t(g_dataReg, VfxDef, ignoreTransformRotation, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, VfxDef, emitters, t_VfxEmitterDef, .container = DataContainer_Array);
+    data_reg_struct_t(reg, VfxDef);
+    data_reg_field_t(reg, VfxDef, ignoreTransformRotation, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxDef, emitters, t_VfxEmitterDef, .container = DataContainer_Array);
     // clang-format on
 
     g_dataVfxDefMeta = data_meta_t(t_VfxDef);
+    g_dataReg        = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }

--- a/libs/asset/src/loader_weapon.c
+++ b/libs/asset/src/loader_weapon.c
@@ -87,66 +87,67 @@ static void weapon_datareg_init() {
   }
   thread_spinlock_lock(&g_initLock);
   if (!g_dataReg) {
-    g_dataReg = data_reg_create(g_alloc_persist);
+    DataReg* reg = data_reg_create(g_alloc_persist);
 
     // clang-format off
-    data_reg_struct_t(g_dataReg, AssetWeaponEffectProjDef);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, originJoint, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, launchTowardsTarget, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, seekTowardsTarget, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, delay, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, lifetime, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, spreadAngle, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, speed, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, damage, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, damageRadius, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, destroyDelay, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, impactLifetime, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, vfxIdProjectile, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectProjDef, vfxIdImpact, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetWeaponEffectProjDef);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, originJoint, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, launchTowardsTarget, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, seekTowardsTarget, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, delay, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, lifetime, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, spreadAngle, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, speed, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, damage, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, damageRadius, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, destroyDelay, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, impactLifetime, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, vfxIdProjectile, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectProjDef, vfxIdImpact, data_prim_t(String), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetWeaponEffectDmgDef);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectDmgDef, originJoint, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectDmgDef, delay, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponEffectDmgDef, damage, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectDmgDef, radius, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectDmgDef, vfxIdImpact, data_prim_t(String), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetWeaponEffectDmgDef);
+    data_reg_field_t(reg, AssetWeaponEffectDmgDef, originJoint, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectDmgDef, delay, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponEffectDmgDef, damage, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectDmgDef, radius, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectDmgDef, vfxIdImpact, data_prim_t(String), .flags = DataFlags_Opt | DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetWeaponEffectVfxDef);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectVfxDef, assetId, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectVfxDef, scale, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectVfxDef, waitUntilFinished, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectVfxDef, delay, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponEffectVfxDef, duration, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponEffectVfxDef, originJoint, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_struct_t(reg, AssetWeaponEffectVfxDef);
+    data_reg_field_t(reg, AssetWeaponEffectVfxDef, assetId, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectVfxDef, scale, data_prim_t(f32), .flags = DataFlags_Opt | DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectVfxDef, waitUntilFinished, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetWeaponEffectVfxDef, delay, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponEffectVfxDef, duration, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponEffectVfxDef, originJoint, data_prim_t(String), .flags = DataFlags_NotEmpty);
 
-    data_reg_struct_t(g_dataReg, AssetWeaponEffectAnimDef);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectAnimDef, layer, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectAnimDef, delay, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponEffectAnimDef, speed, data_prim_t(f32), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponEffectAnimDef, durationMax, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_struct_t(reg, AssetWeaponEffectAnimDef);
+    data_reg_field_t(reg, AssetWeaponEffectAnimDef, layer, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectAnimDef, delay, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponEffectAnimDef, speed, data_prim_t(f32), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponEffectAnimDef, durationMax, data_prim_t(f32), .flags = DataFlags_Opt);
 
-    data_reg_union_t(g_dataReg, AssetWeaponEffectDef, type);
-    data_reg_choice_t(g_dataReg, AssetWeaponEffectDef, AssetWeaponEffect_Projectile, data_proj, t_AssetWeaponEffectProjDef);
-    data_reg_choice_t(g_dataReg, AssetWeaponEffectDef, AssetWeaponEffect_Damage, data_dmg, t_AssetWeaponEffectDmgDef);
-    data_reg_choice_t(g_dataReg, AssetWeaponEffectDef, AssetWeaponEffect_Animation, data_anim, t_AssetWeaponEffectAnimDef);
-    data_reg_choice_t(g_dataReg, AssetWeaponEffectDef, AssetWeaponEffect_Vfx, data_vfx, t_AssetWeaponEffectVfxDef);
+    data_reg_union_t(reg, AssetWeaponEffectDef, type);
+    data_reg_choice_t(reg, AssetWeaponEffectDef, AssetWeaponEffect_Projectile, data_proj, t_AssetWeaponEffectProjDef);
+    data_reg_choice_t(reg, AssetWeaponEffectDef, AssetWeaponEffect_Damage, data_dmg, t_AssetWeaponEffectDmgDef);
+    data_reg_choice_t(reg, AssetWeaponEffectDef, AssetWeaponEffect_Animation, data_anim, t_AssetWeaponEffectAnimDef);
+    data_reg_choice_t(reg, AssetWeaponEffectDef, AssetWeaponEffect_Vfx, data_vfx, t_AssetWeaponEffectVfxDef);
 
-    data_reg_struct_t(g_dataReg, AssetWeaponDef);
-    data_reg_field_t(g_dataReg, AssetWeaponDef, name, data_prim_t(String), .flags = DataFlags_NotEmpty);
-    data_reg_field_t(g_dataReg, AssetWeaponDef, intervalMin, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponDef, intervalMax, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponDef, readySpeed, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponDef, readyMinTime, data_prim_t(f32));
-    data_reg_field_t(g_dataReg, AssetWeaponDef, readyAnim, data_prim_t(String), .flags = DataFlags_NotEmpty | DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetWeaponDef, predictiveAim, data_prim_t(bool), .flags = DataFlags_Opt);
-    data_reg_field_t(g_dataReg, AssetWeaponDef, effects, t_AssetWeaponEffectDef, .container = DataContainer_Array);
+    data_reg_struct_t(reg, AssetWeaponDef);
+    data_reg_field_t(reg, AssetWeaponDef, name, data_prim_t(String), .flags = DataFlags_NotEmpty);
+    data_reg_field_t(reg, AssetWeaponDef, intervalMin, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponDef, intervalMax, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponDef, readySpeed, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponDef, readyMinTime, data_prim_t(f32));
+    data_reg_field_t(reg, AssetWeaponDef, readyAnim, data_prim_t(String), .flags = DataFlags_NotEmpty | DataFlags_Opt);
+    data_reg_field_t(reg, AssetWeaponDef, predictiveAim, data_prim_t(bool), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, AssetWeaponDef, effects, t_AssetWeaponEffectDef, .container = DataContainer_Array);
 
-    data_reg_struct_t(g_dataReg, AssetWeaponMapDef);
-    data_reg_field_t(g_dataReg, AssetWeaponMapDef, weapons, t_AssetWeaponDef, .container = DataContainer_Array);
+    data_reg_struct_t(reg, AssetWeaponMapDef);
+    data_reg_field_t(reg, AssetWeaponMapDef, weapons, t_AssetWeaponDef, .container = DataContainer_Array);
     // clang-format on
 
     g_dataMapDefMeta = data_meta_t(t_AssetWeaponMapDef);
+    g_dataReg        = reg;
   }
   thread_spinlock_unlock(&g_initLock);
 }

--- a/libs/asset/src/manager.c
+++ b/libs/asset/src/manager.c
@@ -146,7 +146,10 @@ static EcsEntityId asset_entity_create(EcsWorld* world, String id) {
 }
 
 static bool asset_manager_load(
-    EcsWorld* world, AssetManagerComp* manager, AssetComp* asset, const EcsEntityId assetEntity) {
+    EcsWorld*               world,
+    const AssetManagerComp* manager,
+    AssetComp*              asset,
+    const EcsEntityId       assetEntity) {
 
   AssetSource* source = asset_repo_source_open(manager->repo, asset->id);
   if (!source) {
@@ -178,12 +181,12 @@ ecs_view_define(DirtyAssetView) {
 
 ecs_view_define(AssetDependencyView) { ecs_access_read(AssetDependencyComp); }
 
-ecs_view_define(GlobalView) { ecs_access_write(AssetManagerComp); }
+ecs_view_define(GlobalView) { ecs_access_read(AssetManagerComp); }
 
-static AssetManagerComp* asset_manager(EcsWorld* world) {
+static const AssetManagerComp* asset_manager_readonly(EcsWorld* world) {
   EcsView*     globalView = ecs_world_view_t(world, GlobalView);
   EcsIterator* globalItr  = ecs_view_maybe_at(globalView, ecs_world_global(world));
-  return globalItr ? ecs_view_write_t(globalItr, AssetManagerComp) : null;
+  return globalItr ? ecs_view_read_t(globalItr, AssetManagerComp) : null;
 }
 
 static void
@@ -212,7 +215,7 @@ static u32 asset_unload_delay(
 }
 
 ecs_system_define(AssetUpdateDirtySys) {
-  AssetManagerComp* manager = asset_manager(world);
+  const AssetManagerComp* manager = asset_manager_readonly(world);
   if (!manager) {
     /**
      * The manager has not been created yet, we delay the processing of asset requests until a
@@ -337,7 +340,7 @@ ecs_system_define(AssetUpdateDirtySys) {
 }
 
 ecs_system_define(AssetPollChangedSys) {
-  AssetManagerComp* manager = asset_manager(world);
+  const AssetManagerComp* manager = asset_manager_readonly(world);
   if (!manager) {
     return;
   }

--- a/libs/asset/src/repo_internal.h
+++ b/libs/asset/src/repo_internal.h
@@ -6,6 +6,10 @@
 typedef struct sAssetRepo   AssetRepo;
 typedef struct sAssetSource AssetSource;
 
+/**
+ * Asset repository.
+ * NOTE: Api is thread-safe.
+ */
 struct sAssetRepo {
   AssetSource* (*open)(AssetRepo*, String id);
   void (*destroy)(AssetRepo*);

--- a/libs/core/include/core_file_monitor.h
+++ b/libs/core/include/core_file_monitor.h
@@ -7,6 +7,7 @@ typedef struct sAllocator Allocator;
 /**
  * File Monitor.
  * Can watch for file modifications.
+ * NOTE: Api is thread-safe.
  */
 typedef struct sFileMonitor FileMonitor;
 

--- a/libs/core/include/core_file_monitor.h
+++ b/libs/core/include/core_file_monitor.h
@@ -11,7 +11,7 @@ typedef struct sAllocator Allocator;
 typedef struct sFileMonitor FileMonitor;
 
 /**
- * Event that significes that the given file was modified.
+ * Event that signifies that the given file was modified.
  */
 typedef struct {
   String path;

--- a/libs/jobs/src/executor.c
+++ b/libs/jobs/src/executor.c
@@ -259,7 +259,7 @@ void executor_init() {
   // Start threads for the other workers.
   for (u16 i = 1; i != g_jobsWorkerCount; ++i) {
     g_workerThreads[i] = thread_start(
-        executor_worker_thread, (void*)(usize)i, fmt_write_scratch("jobs_exec_{}", fmt_int(i)));
+        executor_worker_thread, (void*)(usize)i, fmt_write_scratch("volo_exec_{}", fmt_int(i)));
   }
 }
 


### PR DESCRIPTION
Various startup time wins:
- Execute asset loads in parallel.
- Use a LUT for srgb decoding (instead of 4 pow's).
- Slightly lower amount of iterations for font bezier curve approximation (minimal visual difference).
- Reduce sample count in brdf integration map convolution (minimal visual difference).