### PR TITLE
Update Light attenuation api

### DIFF
--- a/assets/shaders/include/pbr.glsl
+++ b/assets/shaders/include/pbr.glsl
@@ -87,14 +87,14 @@ f32v3 pbr_surf_reflectance(const PbrSurface surf) {
   return mix(f32v3(0.04), surf.color, surf.metallicness);
 }
 
-f32 pbr_attenuation_resolve(const f32 dist, const f32 radius) {
+f32 pbr_attenuation_resolve(const f32 dist, const f32 radiusInv) {
   /**
    * Compute the light attenuation using the inverse square falloff with an artificial radius to
    * force the attenuation to reach 0. Based on the falloff under 'Lighting Model' from 'Real
    * Shading in Unreal Engine 4':
    * https://www.gamedevs.org/uploads/real-shading-in-unreal-engine-4.pdf
    */
-  const f32 edgeFrac       = dist / radius;
+  const f32 edgeFrac       = dist * radiusInv;
   const f32 edgeFracQuad   = edgeFrac * edgeFrac * edgeFrac * edgeFrac;
   const f32 centerFracQuad = clamp(1.0 - edgeFracQuad, 0.0, 1.0);
   return centerFracQuad * centerFracQuad / (dist * dist + 1.0);
@@ -136,14 +136,14 @@ f32v3 pbr_light_dir(
 
 f32v3 pbr_light_point(
     const f32v3      radiance,
-    const f32        radius,
+    const f32        radiusInv,
     const f32v3      pos,
     const f32v3      viewDir,
     const PbrSurface surf) {
 
   const f32v3 lightDir          = normalize(surf.position - pos);
   const f32   dist              = length(surf.position - pos);
-  const f32v3 effectiveRadiance = radiance * pbr_attenuation_resolve(dist, radius);
+  const f32v3 effectiveRadiance = radiance * pbr_attenuation_resolve(dist, radiusInv);
   return pbr_light_dir(effectiveRadiance, lightDir, viewDir, surf);
 }
 

--- a/assets/shaders/include/pbr.glsl
+++ b/assets/shaders/include/pbr.glsl
@@ -90,8 +90,8 @@ f32v3 pbr_surf_reflectance(const PbrSurface surf) {
 f32 pbr_attenuation_resolve(const f32 dist, const f32 radiusInv) {
   /**
    * Compute the light attenuation using the inverse square falloff with an artificial radius to
-   * force the attenuation to reach 0. Based on the falloff under 'Lighting Model' from 'Real
-   * Shading in Unreal Engine 4':
+   * force the attenuation to reach 0.
+   * Based on the falloff under 'Lighting Model' from 'Real Shading in Unreal Engine 4':
    * https://www.gamedevs.org/uploads/real-shading-in-unreal-engine-4.pdf
    */
   const f32 edgeFrac       = dist * radiusInv;

--- a/assets/shaders/light/light_point.frag
+++ b/assets/shaders/light/light_point.frag
@@ -12,7 +12,7 @@ bind_global(2) uniform sampler2D u_texGeoNormalTags;
 bind_global(3) uniform sampler2D u_texGeoDepth;
 
 bind_internal(0) in flat f32v3 in_position;
-bind_internal(1) in flat f32v4 in_radianceAndRadius;
+bind_internal(1) in flat f32v4 in_radianceAndRadiusInv;
 
 bind_internal(0) out f32v3 out_color;
 
@@ -27,11 +27,11 @@ void main() {
   const f32v4 normalTags = texture(u_texGeoNormalTags, texcoord);
   const f32   depth      = texture(u_texGeoDepth, texcoord).r;
 
-  const f32v3 clipPos  = f32v3(texcoord * 2.0 - 1.0, depth);
-  const f32v3 worldPos = clip_to_world(clipPos);
-  const f32v3 viewDir  = normalize(u_global.camPosition.xyz - worldPos);
-  const f32v3 radiance = in_radianceAndRadius.rgb;
-  const f32   radius   = in_radianceAndRadius.a;
+  const f32v3 clipPos   = f32v3(texcoord * 2.0 - 1.0, depth);
+  const f32v3 worldPos  = clip_to_world(clipPos);
+  const f32v3 viewDir   = normalize(u_global.camPosition.xyz - worldPos);
+  const f32v3 radiance  = in_radianceAndRadiusInv.rgb;
+  const f32   radiusInv = in_radianceAndRadiusInv.a;
 
   PbrSurface surf;
   surf.position     = worldPos;
@@ -40,5 +40,5 @@ void main() {
   surf.roughness    = colorRough.a;
   surf.metallicness = 0.0; // TODO: Support metals.
 
-  out_color = pbr_light_point(radiance, radius, in_position, viewDir, surf);
+  out_color = pbr_light_point(radiance, radiusInv, in_position, viewDir, surf);
 }

--- a/assets/shaders/light/light_point.frag
+++ b/assets/shaders/light/light_point.frag
@@ -12,8 +12,7 @@ bind_global(2) uniform sampler2D u_texGeoNormalTags;
 bind_global(3) uniform sampler2D u_texGeoDepth;
 
 bind_internal(0) in flat f32v3 in_position;
-bind_internal(1) in flat f32v3 in_radiance;
-bind_internal(2) in flat f32v3 in_attenuation;
+bind_internal(1) in flat f32v4 in_radianceAndRadius;
 
 bind_internal(0) out f32v3 out_color;
 
@@ -31,6 +30,8 @@ void main() {
   const f32v3 clipPos  = f32v3(texcoord * 2.0 - 1.0, depth);
   const f32v3 worldPos = clip_to_world(clipPos);
   const f32v3 viewDir  = normalize(u_global.camPosition.xyz - worldPos);
+  const f32v3 radiance = in_radianceAndRadius.rgb;
+  const f32   radius   = in_radianceAndRadius.a;
 
   PbrSurface surf;
   surf.position     = worldPos;
@@ -39,5 +40,5 @@ void main() {
   surf.roughness    = colorRough.a;
   surf.metallicness = 0.0; // TODO: Support metals.
 
-  out_color = pbr_light_point(in_radiance, in_position, in_attenuation, viewDir, surf);
+  out_color = pbr_light_point(radiance, radius, in_position, viewDir, surf);
 }

--- a/assets/shaders/light/light_point.vert
+++ b/assets/shaders/light/light_point.vert
@@ -7,9 +7,8 @@
 #include "vertex.glsl"
 
 struct LightPointData {
-  f32v4 posScale;    // x, y, z: position, w: scale
-  f32v4 radiance;    // x, y, z: radiance, w: unused
-  f32v3 attenuation; // x: constant term, y: linear term, z: quadratic term, w: unused
+  f32v4 posScale;          // x, y, z: position, w: scale
+  f32v4 radianceAndRadius; // x, y, z: radiance, w: radius
 };
 
 bind_global_data(0) readonly uniform Global { GlobalData u_global; };
@@ -17,21 +16,18 @@ bind_graphic_data(0) readonly buffer Mesh { VertexPacked[] u_vertices; };
 bind_instance_data(0) readonly uniform Instance { LightPointData[c_maxInstances] u_instances; };
 
 bind_internal(0) out flat f32v3 out_position;
-bind_internal(1) out flat f32v3 out_radiance;
-bind_internal(2) out flat f32v3 out_attenuation;
+bind_internal(1) out flat f32v4 out_radianceAndRadius;
 
 void main() {
   const Vertex vert = vert_unpack(u_vertices[in_vertexIndex]);
 
-  const f32v3 instancePos         = u_instances[in_instanceIndex].posScale.xyz;
-  const f32   instanceScale       = u_instances[in_instanceIndex].posScale.w;
-  const f32v3 instanceRadiance    = u_instances[in_instanceIndex].radiance.rgb;
-  const f32v3 instanceAttenuation = u_instances[in_instanceIndex].attenuation.rgb;
+  const f32v3 instancePos               = u_instances[in_instanceIndex].posScale.xyz;
+  const f32   instanceScale             = u_instances[in_instanceIndex].posScale.w;
+  const f32v4 instanceRadianceAndRadius = u_instances[in_instanceIndex].radianceAndRadius;
 
   const f32v3 worldPos = vert.position * instanceScale + instancePos;
 
-  out_vertexPosition = u_global.viewProj * f32v4(worldPos, 1);
-  out_position       = instancePos.xyz;
-  out_radiance       = instanceRadiance;
-  out_attenuation    = instanceAttenuation;
+  out_vertexPosition    = u_global.viewProj * f32v4(worldPos, 1);
+  out_position          = instancePos.xyz;
+  out_radianceAndRadius = instanceRadianceAndRadius;
 }

--- a/assets/shaders/light/light_point.vert
+++ b/assets/shaders/light/light_point.vert
@@ -7,8 +7,8 @@
 #include "vertex.glsl"
 
 struct LightPointData {
-  f32v4 posScale;          // x, y, z: position, w: scale
-  f32v4 radianceAndRadius; // x, y, z: radiance, w: radius
+  f32v4 posScale;             // x, y, z: position, w: scale
+  f32v4 radianceAndRadiusInv; // x, y, z: radiance, w: inverse radius (1.0 / radius)
 };
 
 bind_global_data(0) readonly uniform Global { GlobalData u_global; };
@@ -16,18 +16,18 @@ bind_graphic_data(0) readonly buffer Mesh { VertexPacked[] u_vertices; };
 bind_instance_data(0) readonly uniform Instance { LightPointData[c_maxInstances] u_instances; };
 
 bind_internal(0) out flat f32v3 out_position;
-bind_internal(1) out flat f32v4 out_radianceAndRadius;
+bind_internal(1) out flat f32v4 out_radianceAndRadiusInv;
 
 void main() {
   const Vertex vert = vert_unpack(u_vertices[in_vertexIndex]);
 
-  const f32v3 instancePos               = u_instances[in_instanceIndex].posScale.xyz;
-  const f32   instanceScale             = u_instances[in_instanceIndex].posScale.w;
-  const f32v4 instanceRadianceAndRadius = u_instances[in_instanceIndex].radianceAndRadius;
+  const f32v3 instancePos                  = u_instances[in_instanceIndex].posScale.xyz;
+  const f32   instanceScale                = u_instances[in_instanceIndex].posScale.w;
+  const f32v4 instanceRadianceAndRadiusInv = u_instances[in_instanceIndex].radianceAndRadiusInv;
 
   const f32v3 worldPos = vert.position * instanceScale + instancePos;
 
-  out_vertexPosition    = u_global.viewProj * f32v4(worldPos, 1);
-  out_position          = instancePos.xyz;
-  out_radianceAndRadius = instanceRadianceAndRadius;
+  out_vertexPosition       = u_global.viewProj * f32v4(worldPos, 1);
+  out_position             = instancePos.xyz;
+  out_radianceAndRadiusInv = instanceRadianceAndRadiusInv;
 }

--- a/assets/shaders/light/light_point_debug.frag
+++ b/assets/shaders/light/light_point_debug.frag
@@ -10,8 +10,7 @@ bind_global_data(0) readonly uniform Global { GlobalData u_global; };
 bind_global(3) uniform sampler2D u_texGeoDepth;
 
 bind_internal(0) in flat f32v3 in_position;
-bind_internal(1) in flat f32v3 in_radiance;
-bind_internal(2) in flat f32v3 in_attenuation;
+bind_internal(1) in flat f32v4 in_radianceAndRadius;
 
 bind_internal(0) out f32v4 out_color;
 
@@ -27,7 +26,9 @@ void main() {
   const f32v3 clipPos  = f32v3(texcoord * 2.0 - 1.0, depth);
   const f32v3 worldPos = clip_to_world(clipPos);
   const f32   dist     = length(worldPos - in_position);
+  const f32v3 radiance = in_radianceAndRadius.rgb;
+  const f32   radius   = in_radianceAndRadius.a;
 
-  const f32 frac = pbr_attenuation_resolve(in_attenuation, dist);
-  out_color      = mix(f32v4(0, 0, 0, 1), f32v4(normalize(in_radiance), 1), frac);
+  const f32 frac = pbr_attenuation_resolve(dist, radius);
+  out_color      = mix(f32v4(0, 0, 0, 1), f32v4(normalize(radiance), 1), frac);
 }

--- a/assets/shaders/light/light_point_debug.frag
+++ b/assets/shaders/light/light_point_debug.frag
@@ -10,7 +10,7 @@ bind_global_data(0) readonly uniform Global { GlobalData u_global; };
 bind_global(3) uniform sampler2D u_texGeoDepth;
 
 bind_internal(0) in flat f32v3 in_position;
-bind_internal(1) in flat f32v4 in_radianceAndRadius;
+bind_internal(1) in flat f32v4 in_radianceAndRadiusInv;
 
 bind_internal(0) out f32v4 out_color;
 
@@ -23,12 +23,12 @@ void main() {
   const f32v2 texcoord = in_fragCoord.xy / u_global.resolution.xy;
   const f32   depth    = texture(u_texGeoDepth, texcoord).r;
 
-  const f32v3 clipPos  = f32v3(texcoord * 2.0 - 1.0, depth);
-  const f32v3 worldPos = clip_to_world(clipPos);
-  const f32   dist     = length(worldPos - in_position);
-  const f32v3 radiance = in_radianceAndRadius.rgb;
-  const f32   radius   = in_radianceAndRadius.a;
+  const f32v3 clipPos   = f32v3(texcoord * 2.0 - 1.0, depth);
+  const f32v3 worldPos  = clip_to_world(clipPos);
+  const f32   dist      = length(worldPos - in_position);
+  const f32v3 radiance  = in_radianceAndRadiusInv.rgb;
+  const f32   radiusInv = in_radianceAndRadiusInv.a;
 
-  const f32 frac = pbr_attenuation_resolve(dist, radius);
+  const f32 frac = pbr_attenuation_resolve(dist, radiusInv);
   out_color      = mix(f32v4(0, 0, 0, 1), f32v4(normalize(radiance), 1), frac);
 }

--- a/assets/vfx/sandbox/explosion.vfx
+++ b/assets/vfx/sandbox/explosion.vfx
@@ -83,10 +83,9 @@
           "r": 1,
           "g": 0.5,
           "b": 0.2,
-          "a": 200
+          "a": 50
         },
-        "attenuationLinear": 0.5,
-        "attenuationQuad": 4,
+        "radius": 10,
         "fadeInTime": 0.1,
         "fadeOutTime": 0.45
       },

--- a/assets/vfx/sandbox/fire_barrel.vfx
+++ b/assets/vfx/sandbox/fire_barrel.vfx
@@ -118,10 +118,9 @@
           "r": 1,
           "g": 0.5,
           "b": 0.2,
-          "a": 100
+          "a": 7.5
         },
-        "attenuationLinear": 0.7,
-        "attenuationQuad": 20,
+        "radius": 7.5,
         "turbulenceFrequency": 5
       }
     }

--- a/assets/vfx/sandbox/launch.vfx
+++ b/assets/vfx/sandbox/launch.vfx
@@ -113,10 +113,9 @@
           "r": 1,
           "g": 0.5,
           "b": 0.2,
-          "a": 100
+          "a": 10
         },
-        "attenuationLinear": 0.5,
-        "attenuationQuad": 10,
+        "radius": 7.5,
         "fadeInTime": 0.1,
         "fadeOutTime": 0.3
       },

--- a/assets/vfx/sandbox/muzzleflash.vfx
+++ b/assets/vfx/sandbox/muzzleflash.vfx
@@ -30,10 +30,9 @@
           "r": 1,
           "g": 0.5,
           "b": 0.2,
-          "a": 50
+          "a": 5
         },
-        "attenuationLinear": 0.5,
-        "attenuationQuad": 10,
+        "radius": 4,
         "fadeInTime": 0.05,
         "fadeOutTime": 0.05
       },

--- a/assets/vfx/sandbox/projectile_missile.vfx
+++ b/assets/vfx/sandbox/projectile_missile.vfx
@@ -25,10 +25,9 @@
           "r": 1,
           "g": 0.5,
           "b": 0.2,
-          "a": 30
+          "a": 6
         },
-        "attenuationLinear": 0.7,
-        "attenuationQuad": 5,
+        "radius": 7.5,
         "fadeInTime": 0.05,
         "fadeOutTime": 0.75
       }

--- a/libs/asset/include/asset_vfx.h
+++ b/libs/asset/include/asset_vfx.h
@@ -39,8 +39,8 @@ typedef struct {
 
 typedef struct {
   GeoColor     radiance;
-  f32          attenuationLinear, attenuationQuad;
   TimeDuration fadeInTime, fadeOutTime;
+  f32          radius;
   f32          turbulenceFrequency; // Optional random scale turbulence.
 } AssetVfxLight;
 

--- a/libs/asset/src/loader_vfx.c
+++ b/libs/asset/src/loader_vfx.c
@@ -67,8 +67,8 @@ typedef struct {
 
 typedef struct {
   VfxColorDef radiance;
-  f32         attenuationLinear, attenuationQuad;
   f32         fadeInTime, fadeOutTime;
+  f32         radius;
   f32         turbulenceFrequency;
 } VfxLightDef;
 
@@ -173,10 +173,9 @@ static void vfx_datareg_init() {
 
     data_reg_struct_t(reg, VfxLightDef);
     data_reg_field_t(reg, VfxLightDef, radiance, t_VfxColorDef, .flags = DataFlags_Opt);
-    data_reg_field_t(reg, VfxLightDef, attenuationLinear, data_prim_t(f32), .flags = DataFlags_Opt);
-    data_reg_field_t(reg, VfxLightDef, attenuationQuad, data_prim_t(f32), .flags = DataFlags_Opt);
     data_reg_field_t(reg, VfxLightDef, fadeInTime, data_prim_t(f32), .flags = DataFlags_Opt);
     data_reg_field_t(reg, VfxLightDef, fadeOutTime, data_prim_t(f32), .flags = DataFlags_Opt);
+    data_reg_field_t(reg, VfxLightDef, radius, data_prim_t(f32), .flags = DataFlags_Opt);
     data_reg_field_t(reg, VfxLightDef, turbulenceFrequency, data_prim_t(f32), .flags = DataFlags_Opt);
 
     data_reg_struct_t(reg, VfxEmitterDef);
@@ -313,10 +312,9 @@ static void vfx_build_light(const VfxLightDef* def, AssetVfxLight* out) {
     return; // Lights are optional.
   }
   out->radiance            = vfx_build_color(&def->radiance);
-  out->attenuationLinear   = def->attenuationLinear > f32_epsilon ? def->attenuationLinear : 0.7f;
-  out->attenuationQuad     = def->attenuationQuad > f32_epsilon ? def->attenuationQuad : 1.8f;
   out->fadeInTime          = (TimeDuration)time_seconds(def->fadeInTime);
   out->fadeOutTime         = (TimeDuration)time_seconds(def->fadeOutTime);
+  out->radius              = def->radius > f32_epsilon ? def->radius : 10.0f;
   out->turbulenceFrequency = def->turbulenceFrequency;
 }
 

--- a/libs/rend/include/rend_light.h
+++ b/libs/rend/include/rend_light.h
@@ -17,15 +17,8 @@ ecs_comp_extern(RendLightComp);
  */
 RendLightComp* rend_light_create(EcsWorld*, EcsEntityId entity);
 
-// clang-format off
-
 /**
  * Light primitives.
- *
- * Useful starting points for the attenuation values:
- * - https://wiki.ogre3d.org/tiki-index.php?page=-Point+Light+Attenuation
  */
 void rend_light_directional(RendLightComp*, GeoQuat rot, GeoColor radiance, RendLightFlags);
-void rend_light_point(RendLightComp*, GeoVector pos, GeoColor radiance, f32 attenuationLinear, f32 attenuationQuadratic, RendLightFlags);
-
-// clang-format on
+void rend_light_point(RendLightComp*, GeoVector pos, GeoColor radiance, f32 radius, RendLightFlags);

--- a/libs/rend/src/light.c
+++ b/libs/rend/src/light.c
@@ -50,7 +50,7 @@ typedef struct {
 typedef struct {
   GeoVector      pos;
   GeoColor       radiance;
-  f32            attenuationLinear, attenuationQuadratic;
+  f32            radius;
   RendLightFlags flags;
 } RendLightPoint;
 
@@ -148,16 +148,6 @@ static GeoColor rend_radiance_resolve(const GeoColor radiance) {
 
 static f32 rend_light_brightness(const GeoColor radiance) {
   return math_max(math_max(radiance.r, radiance.g), radiance.b);
-}
-
-static f32 rend_light_point_radius(const RendLightPoint* point) {
-  const GeoColor radiance   = rend_radiance_resolve(point->radiance);
-  const f32      brightness = rend_light_brightness(radiance);
-  const f32      c          = 1.0f;                        // Constant term.
-  const f32      l          = point->attenuationLinear;    // Linear term.
-  const f32      q          = point->attenuationQuadratic; // Quadratic term.
-  const f32      threshold  = 256.0f / 10.0f;
-  return (-l + math_sqrt_f32(l * l - 4.0f * q * (c - threshold * brightness))) / (2.0f * q);
 }
 
 ecs_system_define(RendLightSunSys) {
@@ -299,11 +289,10 @@ ecs_system_define(RendLightRenderSys) {
 
       typedef struct {
         ALIGNAS(16)
-        GeoVector posScale;    // x, y, z: position, w: scale.
-        GeoColor  radiance;    // r, g, b: radiance, a: unused.
-        GeoVector attenuation; // x: constant term, y: linear term, z: quadratic term, w: unused.
+        GeoVector posScale;          // x, y, z: position, w: scale.
+        GeoColor  radianceAndRadius; // r, g, b: radiance, a: radius.
       } LightPointData;
-      ASSERT(sizeof(LightPointData) == 48, "Size needs to match the size defined in glsl");
+      ASSERT(sizeof(LightPointData) == 32, "Size needs to match the size defined in glsl");
       ASSERT(alignof(LightPointData) == 16, "Alignment needs to match the glsl alignment");
 
       switch (entry->type) {
@@ -346,20 +335,22 @@ ecs_system_define(RendLightRenderSys) {
         if (entry->data_point.flags & RendLightFlags_Shadow) {
           log_e("Point-light shadows are unsupported");
         }
-        const f32 radius = rend_light_point_radius(&entry->data_point);
-        if (UNLIKELY(radius < f32_epsilon)) {
+        const GeoVector pos      = entry->data_point.pos;
+        const GeoColor  radiance = rend_radiance_resolve(entry->data_directional.radiance);
+        const f32       radius   = entry->data_point.radius;
+        if (UNLIKELY(rend_light_brightness(radiance) < 0.01f || radius < f32_epsilon)) {
           continue;
         }
-        const GeoBox bounds = geo_box_from_sphere(entry->data_point.pos, radius);
+        const GeoBox bounds = geo_box_from_sphere(pos, radius);
         *rend_draw_add_instance_t(draw, LightPointData, tags, bounds) = (LightPointData){
-            .posScale.x    = entry->data_point.pos.x,
-            .posScale.y    = entry->data_point.pos.y,
-            .posScale.z    = entry->data_point.pos.z,
-            .posScale.w    = radius,
-            .radiance      = rend_radiance_resolve(entry->data_point.radiance),
-            .attenuation.x = 1.0f, // Constant term.
-            .attenuation.y = entry->data_point.attenuationLinear,
-            .attenuation.z = entry->data_point.attenuationQuadratic,
+            .posScale.x          = pos.x,
+            .posScale.y          = pos.y,
+            .posScale.z          = pos.z,
+            .posScale.w          = radius,
+            .radianceAndRadius.r = radiance.r,
+            .radianceAndRadius.g = radiance.g,
+            .radianceAndRadius.b = radiance.b,
+            .radianceAndRadius.a = radius,
         };
         break;
       }
@@ -419,8 +410,7 @@ void rend_light_point(
     RendLightComp*       comp,
     const GeoVector      pos,
     const GeoColor       radiance,
-    const f32            attenuationLinear,
-    const f32            attenuationQuadratic,
+    const f32            radius,
     const RendLightFlags flags) {
   rend_light_add(
       comp,
@@ -428,11 +418,10 @@ void rend_light_point(
           .type = RendLightType_Point,
           .data_point =
               {
-                  .pos                  = pos,
-                  .radiance             = radiance,
-                  .attenuationLinear    = attenuationLinear,
-                  .attenuationQuadratic = attenuationQuadratic,
-                  .flags                = flags,
+                  .pos      = pos,
+                  .radiance = radiance,
+                  .radius   = radius,
+                  .flags    = flags,
               },
       });
 }

--- a/libs/rend/src/light.c
+++ b/libs/rend/src/light.c
@@ -289,8 +289,8 @@ ecs_system_define(RendLightRenderSys) {
 
       typedef struct {
         ALIGNAS(16)
-        GeoVector posScale;          // x, y, z: position, w: scale.
-        GeoColor  radianceAndRadius; // r, g, b: radiance, a: radius.
+        GeoVector posScale;             // x, y, z: position, w: scale.
+        GeoColor  radianceAndRadiusInv; // r, g, b: radiance, a: inverse radius (1.0 / radius).
       } LightPointData;
       ASSERT(sizeof(LightPointData) == 32, "Size needs to match the size defined in glsl");
       ASSERT(alignof(LightPointData) == 16, "Alignment needs to match the glsl alignment");
@@ -343,14 +343,14 @@ ecs_system_define(RendLightRenderSys) {
         }
         const GeoBox bounds = geo_box_from_sphere(pos, radius);
         *rend_draw_add_instance_t(draw, LightPointData, tags, bounds) = (LightPointData){
-            .posScale.x          = pos.x,
-            .posScale.y          = pos.y,
-            .posScale.z          = pos.z,
-            .posScale.w          = radius,
-            .radianceAndRadius.r = radiance.r,
-            .radianceAndRadius.g = radiance.g,
-            .radianceAndRadius.b = radiance.b,
-            .radianceAndRadius.a = radius,
+            .posScale.x             = pos.x,
+            .posScale.y             = pos.y,
+            .posScale.z             = pos.z,
+            .posScale.w             = radius,
+            .radianceAndRadiusInv.r = radiance.r,
+            .radianceAndRadiusInv.g = radiance.g,
+            .radianceAndRadiusInv.b = radiance.b,
+            .radianceAndRadiusInv.a = 1.0f / radius,
         };
         break;
       }

--- a/libs/vfx/src/system.c
+++ b/libs/vfx/src/system.c
@@ -415,14 +415,7 @@ static void vfx_instance_output_light(
     // TODO: Implement a 1d perlin noise as an optimization.
     radiance.a *= 1.0f - noise_perlin3(instance->ageSec * light->turbulenceFrequency, 0, 0);
   }
-
-  rend_light_point(
-      lightOutput,
-      pos,
-      radiance,
-      light->attenuationLinear,
-      light->attenuationQuad,
-      RendLightFlags_None);
+  rend_light_point(lightOutput, pos, radiance, light->radius * scale, RendLightFlags_None);
 }
 
 ecs_system_define(VfxSystemUpdateSys) {


### PR DESCRIPTION
Compute light attenuation as a inverse square falloff with an artificial radius limiter.

Based on the falloff under 'Lighting Model' from 'Real Shading in Unreal Engine 4':
https://www.gamedevs.org/uploads/real-shading-in-unreal-engine-4.pdf