### PR TITLE
Improve drawing of small box-select rectangles

### DIFF
--- a/apps/game/src/input.c
+++ b/apps/game/src/input.c
@@ -411,7 +411,7 @@ ecs_system_define(InputDrawUiSys) {
       ui_layout_resize_to(canvas, UiBase_Input, UiAlign_BottomLeft, Ui_XY);
       ui_style_color(canvas, ui_color(255, 255, 255, 16));
       ui_style_outline(canvas, 3);
-      ui_canvas_draw_glyph(canvas, UiShape_Square, 0, UiFlags_None);
+      ui_canvas_draw_glyph(canvas, UiShape_Square, 10, UiFlags_None);
     }
   }
 }

--- a/assets/shaders/ui/canvas.frag
+++ b/assets/shaders/ui/canvas.frag
@@ -109,7 +109,7 @@ void main() {
   }
 
   const f32 smoothingNorm = min(c_smoothingPixels * in_invCanvasScale * in_invBorder, 1.0);
-  const f32 outlineNorm   = min(in_outlineWidth * in_invBorder, c_outlineNormMax - smoothingNorm);
+  const f32 outlineNorm   = in_outlineWidth * in_invBorder;
 
   const f32   distNorm    = get_signed_dist_to_glyph(get_fontcoord()) - in_edgeShiftFrac;
   const f32   outlineFrac = get_outline_frac(distNorm, outlineNorm, smoothingNorm);

--- a/assets/shaders/ui/canvas.frag
+++ b/assets/shaders/ui/canvas.frag
@@ -111,7 +111,16 @@ void main() {
   const f32 smoothingNorm = min(c_smoothingPixels * in_invCanvasScale * in_invBorder, 1.0);
   const f32 outlineNorm   = in_outlineWidth * in_invBorder;
 
-  const f32   distNorm    = get_signed_dist_to_glyph(get_fontcoord()) - in_edgeShiftFrac;
+  /**
+   * When the outlineNorm is bigger then 0.5 it means there is not enough space in the border for
+   * the whole glyph + the outline. In that case we shift the mid-point of the glyph (making it
+   * thinner) to give the outline more space. Reasoning behind this is that inconsistencies in
+   * outline width are more noticeable then inconsistencies in glyph widths.
+   */
+  const f32 outlineShift = max(outlineNorm - 0.5, 0);
+
+  const f32v2 fontCoord   = get_fontcoord();
+  const f32   distNorm    = get_signed_dist_to_glyph(fontCoord) - in_edgeShiftFrac + outlineShift;
   const f32   outlineFrac = get_outline_frac(distNorm, outlineNorm, smoothingNorm);
   const f32v4 color       = mix(in_color, c_outlineColor, outlineFrac);
   const f32   alpha       = get_glyph_alpha(distNorm, outlineNorm, smoothingNorm);

--- a/libs/debug/src/rend.c
+++ b/libs/debug/src/rend.c
@@ -297,7 +297,7 @@ static bool debug_overlay_blocker(UiCanvasComp* canvas) {
     ui_layout_set(canvas, ui_rect(ui_vector(0, 0), ui_vector(1, 1)), UiBase_Canvas); // Fullscreen.
     ui_style_color(canvas, ui_color(0, 0, 0, 225));
     ui_style_layer(canvas, UiLayer_Overlay);
-    ui_canvas_draw_glyph(canvas, UiShape_Square, 0, UiFlags_Interactable);
+    ui_canvas_draw_glyph(canvas, UiShape_Square, 10, UiFlags_Interactable);
   }
   ui_style_pop(canvas);
   ui_layout_pop(canvas);

--- a/libs/debug/src/rend.c
+++ b/libs/debug/src/rend.c
@@ -3,6 +3,7 @@
 #include "core_array.h"
 #include "core_format.h"
 #include "core_math.h"
+#include "ecs_utils.h"
 #include "ecs_world.h"
 #include "rend_draw.h"
 #include "rend_register.h"
@@ -1060,6 +1061,18 @@ ecs_system_define(DebugRendUpdatePanelSys) {
     }
     if (ui_canvas_status(canvas) >= UiStatus_Pressed) {
       ui_canvas_to_front(canvas);
+    }
+  }
+
+  /**
+   * Disable the debug overlay if no render panel is open.
+   * Can happen when a panel is closed external to this module while having an overlay active.
+   */
+  if (!ecs_utils_any(world, PanelUpdateView)) {
+    for (ecs_view_itr_reset(windowItr); ecs_view_walk(windowItr);) {
+      RendSettingsComp* settings    = ecs_view_write_t(windowItr, RendSettingsComp);
+      settings->debugViewerResource = 0;
+      settings->flags &= ~RendFlags_DebugShadow;
     }
   }
 }

--- a/libs/debug/src/stats.c
+++ b/libs/debug/src/stats.c
@@ -234,7 +234,7 @@ static void stats_draw_chart(
     ui_layout_move(canvas, ui_vector(t, 0), UiBase_Current, Ui_X);
     ui_layout_resize(canvas, UiAlign_BottomLeft, ui_vector(frac, 0), UiBase_Current, Ui_X);
     ui_style_color(canvas, entries[i].color);
-    ui_canvas_draw_glyph(canvas, UiShape_Square, 0, UiFlags_None);
+    ui_canvas_draw_glyph(canvas, UiShape_Square, 5, UiFlags_None);
     ui_layout_pop(canvas);
     t += frac;
   }


### PR DESCRIPTION
Improve consistency of box-select outline, mostly tweaking the consistency of glyph outline's on (too) small glyphs. This still requires more work in the future as a zero pixel selection won't draw any outlines at the moment.