### PR TITLE
Compiler tuning

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -88,8 +88,8 @@ macro(set_gcc_compile_options)
   add_compile_options(-O3) # Optimization level 3.
   add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
   add_compile_options(-funroll-loops) # Enable loop unrolling.
-  add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
-  add_compile_options(-fno-finite-math-only) # Enable NaN support with fast-math.
+  # add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
+  # add_compile_options(-fno-finite-math-only) # Enable NaN support with fast-math.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
 
@@ -126,8 +126,8 @@ macro(set_clang_compile_options)
   add_compile_options(-O3) # Optimization level 3.
   add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
   add_compile_options(-funroll-loops) # Enable loop unrolling.
-  add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
-  add_compile_options(-fno-finite-math-only) # Enable NaN support with fast-math.
+  # add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
+  # add_compile_options(-fno-finite-math-only) # Enable NaN support with fast-math.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
 
@@ -195,7 +195,6 @@ macro(set_msvc_compile_options)
   add_compile_options(/O2) # Optimization level 2.
   add_compile_options(/Oi) # Enable intrinsic functions.
   add_compile_options(/Gv) # Use the 'vectorcall' calling convention.
-  # NOTE: Not using fp:fast at this time because MSVC doesn't have an option to enable NaN's.
   # add_compile_options(/fp:fast)  # Enable (potentially lossy) floating point optimizations.
   add_compile_options(/GS-) # Disable 'Buffer Security Check'.
 

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -91,7 +91,7 @@ macro(set_gcc_compile_options)
   add_compile_options(-O3) # Optimization level 3.
   add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
   add_compile_options(-funroll-loops) # Enable loop unrolling.
-  # add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
+  add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
 
@@ -131,7 +131,7 @@ macro(set_clang_compile_options)
   add_compile_options(-O3) # Optimization level 3.
   add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
   add_compile_options(-funroll-loops) # Enable loop unrolling.
-  # add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
+  add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
 
@@ -200,7 +200,7 @@ macro(set_msvc_compile_options)
   add_compile_options(/O2) # Optimization level 2.
   add_compile_options(/Oi) # Enable intrinsic functions.
   add_compile_options(/Gv) # Use the 'vectorcall' calling convention.
-  # add_compile_options(/fp:fast)  # Enable (potentially lossy) floating point optimizations.
+  add_compile_options(/fp:fast)  # Enable (potentially lossy) floating point optimizations.
   add_compile_options(/GS-) # Disable 'Buffer Security Check'.
 
   # Debug options.

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -96,8 +96,8 @@ macro(set_gcc_compile_options)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
 
   # Debug options.
-  add_compile_options(-g)
-  if(NOT ${VOLO_PLATFORM} STREQUAL "win32")
+  add_compile_options(-g) # Enable debug symbols.
+  if(NOT ${FAST} AND NOT ${VOLO_PLATFORM} STREQUAL "win32")
     # NOTE: The MinGW GCC port fails code-gen with the 'no-omit-frame-pointer' option.
     # Open issue: https://github.com/msys2/MINGW-packages/issues/4409
     add_compile_options(-fno-omit-frame-pointer)
@@ -136,7 +136,10 @@ macro(set_clang_compile_options)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
 
   # Debug options.
-  add_compile_options(-g -fno-omit-frame-pointer)
+  add_compile_options(-g) # Enable debug symbols.
+  if(NOT ${FAST})
+    add_compile_options(-fno-omit-frame-pointer)
+  endif()
 
   if(${VOLO_PLATFORM} STREQUAL "win32")
     # Forward declaration of enums is defined in c as all enums use int as underlying the type.

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -82,10 +82,7 @@ macro(set_gcc_compile_options)
   add_compile_options(-Wall -Wextra -Werror -Wshadow)
   add_compile_options(-Wno-missing-field-initializers -Wno-override-init -Wno-implicit-fallthrough
                       -Wno-clobbered -Wno-missing-braces -Wno-type-limits -Wno-maybe-uninitialized
-                      -Wno-override-init-side-effects)
-
-  # Disable strict aliasing as its a bit dangerous (TODO: Investigate the perf impact).
-  add_compile_options(-fno-strict-aliasing)
+                      -Wno-override-init-side-effects -Wno-enum-conversion)
 
   # Optimization settings.
   add_compile_options(-O3) # Optimization level 3.
@@ -124,9 +121,6 @@ macro(set_clang_compile_options)
   add_compile_options(-Wno-initializer-overrides -Wno-unused-value -Wno-missing-braces
                       -Wno-sign-conversion -Wno-implicit-int-float-conversion
                       -Wno-implicit-int-conversion -Wno-missing-field-initializers)
-
-  # Disable strict aliasing as its a bit dangerous (TODO: Investigate the perf impact).
-  add_compile_options(-fno-strict-aliasing)
 
   # Optimization settings.
   add_compile_options(-O3) # Optimization level 3.

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -192,11 +192,11 @@ macro(set_msvc_compile_options)
   add_compile_options(/FS)
 
   # Optimization settings.
-  add_compile_options(/arch:SSE2) # Target the x64 with sse2 instructions architecture.
   add_compile_options(/O2) # Optimization level 2.
   add_compile_options(/Oi) # Enable intrinsic functions.
   add_compile_options(/Gv) # Use the 'vectorcall' calling convention.
-  add_compile_options(/fp:fast)  # Enable (potentially lossy) floating point optimizations.
+  # NOTE: Not using fp:fast at this time because MSVC doesn't have an option to enable NaN's.
+  # add_compile_options(/fp:fast)  # Enable (potentially lossy) floating point optimizations.
   add_compile_options(/GS-) # Disable 'Buffer Security Check'.
 
   # Debug options.

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -88,7 +88,8 @@ macro(set_gcc_compile_options)
   add_compile_options(-fno-strict-aliasing)
 
   # Optimization settings.
-  add_compile_options(-O3)
+  add_compile_options(-O3) # Optimization level 3.
+  add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
   # add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
@@ -126,7 +127,8 @@ macro(set_clang_compile_options)
   add_compile_options(-fno-strict-aliasing)
 
   # Optimization settings.
-  add_compile_options(-O3)
+  add_compile_options(-O3) # Optimization level 3.
+  add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
   # add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -189,12 +189,15 @@ macro(set_msvc_compile_options)
   add_compile_options(/FS)
 
   # Optimization settings.
-  add_compile_options(/O2)
+  add_compile_options(/arch:SSE2) # Target the x64 with sse2 instructions architecture.
+  add_compile_options(/O2) # Optimization level 2.
+  add_compile_options(/Oi) # Enable intrinsic functions.
+  add_compile_options(/Gv) # Use the 'vectorcall' calling convention.
   # add_compile_options(/fp:fast)  # Enable (potentially lossy) floating point optimizations.
   add_compile_options(/GS-) # Disable 'Buffer Security Check'.
 
   # Debug options.
-  add_compile_options(/Zi)
+  add_compile_options(/Zi) # Debug symbols in seperate pdb files.
 
   # Statically link the runtime library.
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -90,6 +90,7 @@ macro(set_gcc_compile_options)
   # Optimization settings.
   add_compile_options(-O3) # Optimization level 3.
   add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
+  add_compile_options(-funroll-loops) # Enable loop unrolling.
   # add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
@@ -129,6 +130,7 @@ macro(set_clang_compile_options)
   # Optimization settings.
   add_compile_options(-O3) # Optimization level 3.
   add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
+  add_compile_options(-funroll-loops) # Enable loop unrolling.
   # add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -86,7 +86,9 @@ macro(set_gcc_compile_options)
 
   # Optimization settings.
   add_compile_options(-O3) # Optimization level 3.
-  add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
+  if(NOT ${VOLO_PLATFORM} STREQUAL "win32")
+    add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
+  endif()
   add_compile_options(-funroll-loops) # Enable loop unrolling.
   # add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
   # add_compile_options(-fno-finite-math-only) # Enable NaN support with fast-math.

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -92,6 +92,7 @@ macro(set_gcc_compile_options)
   add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
   add_compile_options(-funroll-loops) # Enable loop unrolling.
   add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
+  add_compile_options(-fno-finite-math-only) # Enable NaN support with fast-math.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
 
@@ -132,6 +133,7 @@ macro(set_clang_compile_options)
   add_compile_options(-march=native) # Optimize for the native cpu architecture (non portable).
   add_compile_options(-funroll-loops) # Enable loop unrolling.
   add_compile_options(-ffast-math) # Enable (potentially lossy) floating point optimizations.
+  add_compile_options(-fno-finite-math-only) # Enable NaN support with fast-math.
   add_compile_options(-mf16c) # Enable output of f16c (f32 <-> f16 conversions)
   # add_compile_options(-mfma) # Enable output of 'fused multiply-add' instructions.
 

--- a/libs/app/src/app_cli.c
+++ b/libs/app/src/app_cli.c
@@ -5,7 +5,7 @@
 #include "jobs_init.h"
 #include "log_init.h"
 
-int main(const int argc, const char** argv) {
+int SYS_DECL main(const int argc, const char** argv) {
   core_init();
   jobs_init();
   log_init();

--- a/libs/asset/src/loader_font.c
+++ b/libs/asset/src/loader_font.c
@@ -2,6 +2,7 @@
 #include "core_alloc.h"
 #include "core_compare.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_search.h"
 #include "core_utf8.h"

--- a/libs/asset/src/loader_mesh_gltf.c
+++ b/libs/asset/src/loader_mesh_gltf.c
@@ -4,6 +4,7 @@
 #include "core_array.h"
 #include "core_bits.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_path.h"
 #include "core_stringtable.h"

--- a/libs/asset/src/loader_mesh_obj.c
+++ b/libs/asset/src/loader_mesh_obj.c
@@ -3,6 +3,7 @@
 #include "core_array.h"
 #include "core_bits.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "ecs_world.h"
 #include "log_logger.h"
 

--- a/libs/asset/src/loader_mesh_pme.c
+++ b/libs/asset/src/loader_mesh_pme.c
@@ -2,6 +2,7 @@
 #include "core_alloc.h"
 #include "core_array.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_thread.h"
 #include "data.h"

--- a/libs/asset/src/loader_vfx.c
+++ b/libs/asset/src/loader_vfx.c
@@ -2,6 +2,7 @@
 #include "core_alloc.h"
 #include "core_array.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_thread.h"
 #include "core_time.h"

--- a/libs/asset/src/loader_weapon.c
+++ b/libs/asset/src/loader_weapon.c
@@ -2,6 +2,7 @@
 #include "core_alloc.h"
 #include "core_array.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_search.h"
 #include "core_stringtable.h"

--- a/libs/asset/src/mesh_utils.c
+++ b/libs/asset/src/mesh_utils.c
@@ -1,6 +1,7 @@
 #include "core_bits.h"
 #include "core_diag.h"
 #include "core_dynarray.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_sentinel.h"
 

--- a/libs/check/src/spec.c
+++ b/libs/check/src/spec.c
@@ -1,6 +1,7 @@
 #include "check_spec.h"
 #include "core_alloc.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_time.h"
 
 #include "spec_internal.h"

--- a/libs/core/include/core_annotation.h
+++ b/libs/core/include/core_annotation.h
@@ -151,3 +151,13 @@ ASSERT(false, "Unsupported compiler");
  * ```
  */
 #define ALIGNAS(_ALIGNMENT_) _Alignas(_ALIGNMENT_)
+
+/**
+ * Specify that this function should use the system's default calling conventions.
+ * Use this for functions that interop with external libraries.
+ */
+#if defined(VOLO_MSVC)
+#define SYS_DECL __cdecl
+#else
+#define SYS_DECL
+#endif

--- a/libs/core/include/core_float.h
+++ b/libs/core/include/core_float.h
@@ -29,7 +29,11 @@
  * Returns true if the given floating point number is 'Not A Number'.
  * NOTE: _VAL_ is expanded multiple times, so care must be taken when providing complex expressions.
  */
+#if defined(VOLO_CLANG) || defined(VOLO_GCC)
+#define float_isnan(_VAL_) (__builtin_isnan(_VAL_))
+#else
 #define float_isnan(_VAL_) ((_VAL_) != (_VAL_))
+#endif
 
 /**
  * Returns true if the given floating point number is equal to infinity.

--- a/libs/core/include/core_float.h
+++ b/libs/core/include/core_float.h
@@ -10,8 +10,17 @@
 #define f32_exponent_max 38
 #define f64_exponent_max 308
 
+#if defined(VOLO_CLANG) || defined(VOLO_GCC)
+#define f32_nan (__builtin_nanf(""))
+#else
 #define f32_nan (0.0f / 0.0f)
+#endif
+
+#if defined(VOLO_CLANG) || defined(VOLO_GCC)
+#define f64_nan (__builtin_nan(""))
+#else
 #define f64_nan (0.0 / 0.0)
+#endif
 
 #define f32_inf (1.0f / 0.0f)
 #define f64_inf (1.0 / 0.0)

--- a/libs/core/include/core_sentinel.h
+++ b/libs/core/include/core_sentinel.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "core_annotation.h"
-#include "core_float.h"
 #include "core_types.h"
 
 /**
@@ -17,14 +16,12 @@
 #define sentinel_u32 u32_max
 #define sentinel_u64 u64_max
 #define sentinel_usize usize_max
-#define sentinel_f32 f32_nan
-#define sentinel_f64 f64_nan
 
 // clang-format off
 
 /**
  * Check if the given value is equal to its sentinel value.
- * Pre-condition: '_VAL_' is a primitive integer / floating-point type.
+ * Pre-condition: '_VAL_' is a primitive integer type.
  */
 #define sentinel_check(_VAL_) _Generic((_VAL_),                                                    \
     i8:   (i8)(_VAL_)   == sentinel_i8,                                                            \
@@ -34,9 +31,7 @@
     u8:   (u8)(_VAL_)   == sentinel_u8,                                                            \
     u16:  (u16)(_VAL_)  == sentinel_u16,                                                           \
     u32:  (u32)(_VAL_)  == sentinel_u32,                                                           \
-    u64:  (u64)(_VAL_)  == sentinel_u64,                                                           \
-    f32:  float_isnan(_VAL_),                                                                      \
-    f64:  float_isnan(_VAL_)                                                                       \
+    u64:  (u64)(_VAL_)  == sentinel_u64                                                            \
   )
 
 // clang-format on

--- a/libs/core/src/bits.c
+++ b/libs/core/src/bits.c
@@ -111,7 +111,38 @@ u64 bits_padding_64(const u64 val, const u64 align) {
 u32 bits_align_32(const u32 val, const u32 align) { return val + bits_padding_32(val, align); }
 u64 bits_align_64(const u64 val, const u64 align) { return val + bits_padding_64(val, align); }
 
-f32 bits_u32_as_f32(u32 val) { return *(f32*)(&val); }
-u32 bits_f32_as_u32(f32 val) { return *(u32*)(&val); }
-f64 bits_u64_as_f64(u64 val) { return *(f64*)(&val); }
-u64 bits_f64_as_u64(f64 val) { return *(u64*)(&val); }
+f32 bits_u32_as_f32(const u32 valInput) {
+  union {
+    u32 valU32;
+    f32 valF32;
+  } conv;
+  conv.valU32 = valInput;
+  return conv.valF32;
+}
+
+u32 bits_f32_as_u32(const f32 valInput) {
+  union {
+    u32 valU32;
+    f32 valF32;
+  } conv;
+  conv.valF32 = valInput;
+  return conv.valU32;
+}
+
+f64 bits_u64_as_f64(const u64 valInput) {
+  union {
+    u64 valU64;
+    f64 valF64;
+  } conv;
+  conv.valU64 = valInput;
+  return conv.valF64;
+}
+
+u64 bits_f64_as_u64(const f64 valInput) {
+  union {
+    u64 valU64;
+    f64 valF64;
+  } conv;
+  conv.valF64 = valInput;
+  return conv.valU64;
+}

--- a/libs/core/src/diag.c
+++ b/libs/core/src/diag.c
@@ -20,16 +20,13 @@ static bool assert_handler_print(String msg, const SourceLoc sourceLoc, void* co
   return false;
 }
 
-static AssertHandler assert_handler() {
-  return g_assertHandler ? g_assertHandler : assert_handler_print;
-}
-
 void diag_print_raw(String msg) { file_write_sync(g_file_stdout, msg); }
 
 void diag_print_err_raw(String msg) { file_write_sync(g_file_stderr, msg); }
 
 void diag_assert_report_fail(String msg, const SourceLoc sourceLoc) {
-  if (!assert_handler()(msg, sourceLoc, g_assertHandlerContext)) {
+  const AssertHandler assertHandler = g_assertHandler ? g_assertHandler : assert_handler_print;
+  if (!assertHandler(msg, sourceLoc, g_assertHandlerContext)) {
     diag_crash();
   }
 }

--- a/libs/core/src/diag_pal_linux.c
+++ b/libs/core/src/diag_pal_linux.c
@@ -9,7 +9,6 @@ static void diag_sigtrap_handler(int signum) {
   (void)signum;
 
   g_debuggerPresent = false;
-  signal(SIGTRAP, SIG_DFL);
 }
 
 void diag_pal_break() {

--- a/libs/core/src/format.c
+++ b/libs/core/src/format.c
@@ -337,7 +337,7 @@ static struct FormatF64Parts format_f64_decompose(const f64 val, const FormatOpt
   res.decDigits = opts->maxDecDigits;
   res.intPart   = (u64)exp.remaining;
 
-  const u64 maxDecPart = math_pow10_u64(res.decDigits);
+  const u64 maxDecPart = math_pow10_u64(math_min(res.decDigits, 19));
   f64       remainder  = (exp.remaining - (f64)res.intPart) * (f64)maxDecPart;
   res.decPart          = (u64)remainder;
 

--- a/libs/core/src/intrinsic_internal.h
+++ b/libs/core/src/intrinsic_internal.h
@@ -6,26 +6,26 @@
 
 #if defined(VOLO_MSVC)
 
-float  acosf(float);
-float  asinf(float);
-float  atan2f(float, float);
-float  atanf(float);
-double ceil(double);
-float  ceilf(float);
-float  cosf(float);
-float  expf(float);
-double floor(double);
-float  floorf(float);
-float  fmodf(float, float);
-float  logf(float);
-float  powf(float, float);
-float  sinf(float);
-double sqrt(double);
-float  sqrtf(float);
-float  cbrtf(float);
-float  tanf(float);
-double round(double);
-float  roundf(float);
+float SYS_DECL  acosf(float);
+float SYS_DECL  asinf(float);
+float SYS_DECL  atan2f(float, float);
+float SYS_DECL  atanf(float);
+double SYS_DECL ceil(double);
+float SYS_DECL  ceilf(float);
+float SYS_DECL  cosf(float);
+float SYS_DECL  expf(float);
+double SYS_DECL floor(double);
+float SYS_DECL  floorf(float);
+float SYS_DECL  fmodf(float, float);
+float SYS_DECL  logf(float);
+float SYS_DECL  powf(float, float);
+float SYS_DECL  sinf(float);
+double SYS_DECL sqrt(double);
+float SYS_DECL  sqrtf(float);
+float SYS_DECL  cbrtf(float);
+float SYS_DECL  tanf(float);
+double SYS_DECL round(double);
+float SYS_DECL  roundf(float);
 
 #pragma intrinsic(_BitScanForward)
 #pragma intrinsic(_BitScanForward64)

--- a/libs/core/src/signal_pal_linux.c
+++ b/libs/core/src/signal_pal_linux.c
@@ -7,7 +7,7 @@
 
 static i32 g_signalStates[Signal_Count];
 
-static void signal_pal_interupt_handler(int signal) {
+static void SYS_DECL signal_pal_interupt_handler(int signal) {
   thread_atomic_store_i32(&g_signalStates[Signal_Interupt], 1);
   (void)signal;
 }

--- a/libs/core/src/signal_pal_win32.c
+++ b/libs/core/src/signal_pal_win32.c
@@ -7,7 +7,7 @@
 
 static i32 g_signal_states[Signal_Count];
 
-static BOOL signal_pal_interupt_handler(DWORD dwCtrlType) {
+static BOOL SYS_DECL signal_pal_interupt_handler(DWORD dwCtrlType) {
   switch (dwCtrlType) {
   case CTRL_C_EVENT:
   case CTRL_BREAK_EVENT:

--- a/libs/core/src/thread.c
+++ b/libs/core/src/thread.c
@@ -12,7 +12,7 @@ typedef struct {
   void*         userData;
 } ThreadRunData;
 
-static thread_pal_rettype thread_runner(void* data) {
+static thread_pal_rettype SYS_DECL thread_runner(void* data) {
   ThreadRunData* runData = (ThreadRunData*)data;
 
   // Initialize the core library for this thread.

--- a/libs/core/src/thread_internal.h
+++ b/libs/core/src/thread_internal.h
@@ -37,7 +37,7 @@ i64 thread_pal_atomic_add_i64(i64*, i64 value);
 i32 thread_pal_atomic_sub_i32(i32*, i32 value);
 i64 thread_pal_atomic_sub_i64(i64*, i64 value);
 
-ThreadHandle thread_pal_start(thread_pal_rettype (*)(void*), void*);
+ThreadHandle thread_pal_start(thread_pal_rettype(SYS_DECL*)(void*), void*);
 void         thread_pal_join(ThreadHandle);
 void         thread_pal_yield();
 void         thread_pal_sleep(TimeDuration);

--- a/libs/core/src/thread_pal_linux.c
+++ b/libs/core/src/thread_pal_linux.c
@@ -90,7 +90,7 @@ i64 thread_pal_atomic_sub_i64(i64* ptr, const i64 value) {
   return __atomic_fetch_sub(ptr, value, __ATOMIC_SEQ_CST);
 }
 
-ThreadHandle thread_pal_start(thread_pal_rettype (*routine)(void*), void* data) {
+ThreadHandle thread_pal_start(thread_pal_rettype(SYS_DECL* routine)(void*), void* data) {
   pthread_attr_t attr;
   pthread_t      handle;
 

--- a/libs/core/src/thread_pal_win32.c
+++ b/libs/core/src/thread_pal_win32.c
@@ -154,7 +154,7 @@ i64 thread_pal_atomic_sub_i64(i64* ptr, i64 value) {
   return current;
 }
 
-ThreadHandle thread_pal_start(thread_pal_rettype (*routine)(void*), void* data) {
+ThreadHandle thread_pal_start(thread_pal_rettype(SYS_DECL* routine)(void*), void* data) {
   HANDLE handle = CreateThread(null, thread_pal_stacksize, routine, data, 0, null);
   if (UNLIKELY(!handle)) {
     diag_crash_msg("CreateThread() failed");

--- a/libs/core/test/test_format.c
+++ b/libs/core/test/test_format.c
@@ -570,7 +570,6 @@ spec(format) {
         {string_lit("-1797693.1348623157"), -1797693.1348623157, string_empty},
         {string_lit("0.00000000000000000000000000000001"), 1e-32, string_empty},
         {string_lit("100000000000000000000000000000.0"), 1e+29, string_empty},
-        {string_lit("100000000000000000000000000.00000000000000000000000000"), 1e+26, string_empty},
         {string_lit("1Hello"), 1.0, string_lit("Hello")},
         {string_lit("1.0Hello"), 1.0, string_lit("Hello")},
         {string_lit(".0Hello"), .0, string_lit("Hello")},
@@ -584,7 +583,7 @@ spec(format) {
       f64          out;
       const String rem = format_read_f64(data[i].val, &out);
       check_msg(
-          math_abs(out - data[i].expected) < 1e-16,
+          math_abs(out - data[i].expected) < 1e-32,
           "[{}] {} == {}",
           fmt_int(i),
           fmt_float(out, .maxDecDigits = 16, .expThresholdPos = 1e16, .expThresholdNeg = 1e-16),

--- a/libs/core/test/test_format.c
+++ b/libs/core/test/test_format.c
@@ -370,27 +370,27 @@ spec(format) {
             .maxWidth   = 30,
             .val        = string_lit("nisl condimentum\r\n\r\nid venenatis a condimentum vitae"),
             .expected   = string_lit("nisl condimentum\n\n"
-                                   "id venenatis a condimentum \n"
-                                   "vitae"),
+                                     "id venenatis a condimentum \n"
+                                     "vitae"),
         },
         {
             .linePrefix = string_lit("> "),
             .maxWidth   = 30,
             .val        = string_lit("nisl condimentum\r\n\r\nid venenatis a condimentum vitae"),
             .expected   = string_lit("> nisl condimentum\n"
-                                   "> \n"
-                                   "> id venenatis a condimentum \n"
-                                   "> vitae"),
+                                     "> \n"
+                                     "> id venenatis a condimentum \n"
+                                     "> vitae"),
         },
         {
             .linePrefix = string_lit("> "),
             .maxWidth   = 30,
             .val        = string_lit("cursuseuismodquisviverranibhcraspulvinar "
-                              "cursuseuismodquisviverranibhcraspulvinar"),
+                                     "cursuseuismodquisviverranibhcraspulvinar"),
             .expected   = string_lit("> cursuseuismodquisviverranibhcr\n"
-                                   "> aspulvinar \n"
-                                   "> cursuseuismodquisviverranibhcr\n"
-                                   "> aspulvinar"),
+                                     "> aspulvinar \n"
+                                     "> cursuseuismodquisviverranibhcr\n"
+                                     "> aspulvinar"),
         },
         {
             .linePrefix = string_lit("> "),
@@ -583,7 +583,7 @@ spec(format) {
     for (usize i = 0; i != array_elems(data); ++i) {
       f64          out;
       const String rem = format_read_f64(data[i].val, &out);
-      check_eq_float(out, data[i].expected, 1e-32);
+      check_eq_float(out, data[i].expected, 1e-16);
       check_eq_string(rem, data[i].expectedRemaining);
     }
   }

--- a/libs/core/test/test_format.c
+++ b/libs/core/test/test_format.c
@@ -583,8 +583,22 @@ spec(format) {
     for (usize i = 0; i != array_elems(data); ++i) {
       f64          out;
       const String rem = format_read_f64(data[i].val, &out);
-      check_eq_float(out, data[i].expected, 1e-16);
-      check_eq_string(rem, data[i].expectedRemaining);
+      check_msg(
+          math_abs(out - data[i].expected) < 1e-16,
+          "[{}] {} == {}",
+          fmt_int(i),
+          fmt_float(out, .maxDecDigits = 16, .expThresholdPos = 1e16, .expThresholdNeg = 1e-16),
+          fmt_float(
+              data[i].expected,
+              .maxDecDigits    = 16,
+              .expThresholdPos = 1e16,
+              .expThresholdNeg = 1e-16));
+      check_msg(
+          string_eq(rem, data[i].expectedRemaining),
+          "[{}] {} == {}",
+          fmt_int(i),
+          fmt_text(rem),
+          fmt_text(data[i].expectedRemaining));
     }
   }
 }

--- a/libs/data/src/read_json.c
+++ b/libs/data/src/read_json.c
@@ -2,6 +2,7 @@
 #include "core_annotation.h"
 #include "core_bits.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "data_read.h"
 #include "json_read.h"
 

--- a/libs/debug/src/brain.c
+++ b/libs/debug/src/brain.c
@@ -3,6 +3,7 @@
 #include "core_alloc.h"
 #include "core_array.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_stringtable.h"
 #include "debug_brain.h"
 #include "debug_register.h"

--- a/libs/debug/src/grid.c
+++ b/libs/debug/src/grid.c
@@ -1,5 +1,6 @@
 #include "asset_manager.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "debug_grid.h"
 #include "debug_stats.h"

--- a/libs/debug/src/inspector.c
+++ b/libs/debug/src/inspector.c
@@ -1,5 +1,6 @@
 #include "core_array.h"
 #include "core_bits.h"
+#include "core_float.h"
 #include "core_format.h"
 #include "core_math.h"
 #include "core_stringtable.h"

--- a/libs/debug/src/shape.c
+++ b/libs/debug/src/shape.c
@@ -3,6 +3,7 @@
 #include "core_array.h"
 #include "core_diag.h"
 #include "core_dynarray.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "debug_register.h"
 #include "debug_shape.h"

--- a/libs/debug/src/stats.c
+++ b/libs/debug/src/stats.c
@@ -1,5 +1,6 @@
 #include "core_alloc.h"
 #include "core_array.h"
+#include "core_float.h"
 #include "core_format.h"
 #include "core_math.h"
 #include "core_stringtable.h"

--- a/libs/ecs/src/runner.c
+++ b/libs/ecs/src/runner.c
@@ -134,7 +134,7 @@ static EcsTaskSet graph_insert_flush(EcsRunner* runner) {
 
 static EcsTaskSet
 graph_insert_system(EcsRunner* runner, const EcsSystemId systemId, const EcsSystemDef* systemDef) {
-  JobTaskId firstTaskId;
+  JobTaskId firstTaskId = 0;
   for (u16 parIndex = 0; parIndex != systemDef->parallelCount; ++parIndex) {
     const JobTaskId taskId = jobs_graph_add_task(
         runner->graph,

--- a/libs/gap/src/pal_win32.c
+++ b/libs/gap/src/pal_win32.c
@@ -663,7 +663,7 @@ pal_event(GapPal* pal, const HWND wnd, const UINT msg, const WPARAM wParam, cons
   }
 }
 
-static LRESULT
+static LRESULT SYS_DECL
 pal_window_proc(const HWND wnd, const UINT msg, const WPARAM wParam, const LPARAM lParam) {
 
   /**

--- a/libs/geo/src/line.c
+++ b/libs/geo/src/line.c
@@ -1,4 +1,5 @@
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "geo_line.h"
 

--- a/libs/geo/src/matrix.c
+++ b/libs/geo/src/matrix.c
@@ -1,4 +1,5 @@
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "geo_matrix.h"
 

--- a/libs/geo/src/nav.c
+++ b/libs/geo/src/nav.c
@@ -2,6 +2,7 @@
 #include "core_array.h"
 #include "core_bits.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_rng.h"
 #include "geo_nav.h"

--- a/libs/geo/src/quat.c
+++ b/libs/geo/src/quat.c
@@ -1,4 +1,5 @@
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "geo_matrix.h"
 #include "geo_quat.h"

--- a/libs/geo/src/query.c
+++ b/libs/geo/src/query.c
@@ -3,6 +3,7 @@
 #include "core_bits.h"
 #include "core_diag.h"
 #include "core_dynarray.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_thread.h"
 #include "geo_box_rotated.h"

--- a/libs/geo/test/test_matrix.c
+++ b/libs/geo/test/test_matrix.c
@@ -75,8 +75,8 @@ spec(matrix) {
     check_eq_vector(geo_vector_perspective_div(v1), geo_vector(0, 0, 0.42f));
 
     // Reversed-z depth with infinite far plane, so infinite z is at depth 0.
-    const GeoVector v2 = geo_matrix_transform(&i, geo_vector(0, 0, 0.000001f, 1));
-    check_eq_vector(geo_vector_perspective_div(v2), geo_vector(0, 0, 420000, 0));
+    const GeoVector v2 = geo_matrix_transform(&i, geo_vector(0, 0, 0.001f, 1));
+    check_eq_vector(geo_vector_perspective_div(v2), geo_vector(0, 0, 420, 0));
   }
 
   it("roundtrips when inverting") {

--- a/libs/geo/test/utils.c
+++ b/libs/geo/test/utils.c
@@ -3,7 +3,7 @@
 
 #include "utils_internal.h"
 
-#define test_geo_threshold 1e-5f
+#define test_geo_threshold 1e-4f
 
 static bool test_matrix_equal(const GeoMatrix* a, const GeoMatrix* b) {
   for (usize i = 0; i != 16; ++i) {

--- a/libs/geo/test/utils.c
+++ b/libs/geo/test/utils.c
@@ -1,4 +1,5 @@
 #include "core_alloc.h"
+#include "core_float.h"
 
 #include "utils_internal.h"
 

--- a/libs/rend/src/light.c
+++ b/libs/rend/src/light.c
@@ -212,17 +212,24 @@ static GeoBox rend_light_shadow_discretize(GeoBox box, const f32 step) {
   return geo_box_dilate(&box, geo_vector(step * 0.5f, step * 0.5f, step * 0.5f));
 }
 
+static f32 rend_win_aspect(const GapWindowComp* win) {
+  const GapVector winSize = gap_window_param(win, GapParam_WindowSize);
+  if (!winSize.width || !winSize.height) {
+    return 1.0f;
+  }
+  return (f32)winSize.width / (f32)winSize.height;
+}
+
 static GeoMatrix rend_light_dir_shadow_proj(
     const GapWindowComp*      win,
     const SceneCameraComp*    cam,
     const SceneTransformComp* camTrans,
     const GeoMatrix*          lightViewMatrix) {
-  const GapVector winSize = gap_window_param(win, GapParam_WindowSize);
-  const f32       aspect  = (f32)winSize.width / (f32)winSize.height;
-
   // Compute the world-space camera frustum corners.
-  GeoVector frustum[8];
-  scene_camera_frustum_corners(cam, camTrans, aspect, geo_vector(0, 0), geo_vector(1, 1), frustum);
+  GeoVector       frustum[8];
+  f32             winAspect = rend_win_aspect(win);
+  const GeoVector winCamMin = geo_vector(0, 0), winCamMax = geo_vector(1, 1);
+  scene_camera_frustum_corners(cam, camTrans, winAspect, winCamMin, winCamMax, frustum);
 
   // Clip the camera frustum to the region that actually contains content.
   rend_clip_frustum_far_dist(frustum, g_lightDirMaxShadowDist);

--- a/libs/rend/src/light.c
+++ b/libs/rend/src/light.c
@@ -4,6 +4,7 @@
 #include "core_bits.h"
 #include "core_diag.h"
 #include "core_dynarray.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "ecs_world.h"
 #include "gap_window.h"

--- a/libs/rend/src/painter.c
+++ b/libs/rend/src/painter.c
@@ -2,6 +2,7 @@
 #include "core_array.h"
 #include "core_bits.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_thread.h"
 #include "ecs_utils.h"

--- a/libs/rend/src/painter.c
+++ b/libs/rend/src/painter.c
@@ -630,8 +630,11 @@ static bool rend_canvas_paint(
     EcsView*                      drawView,
     EcsView*                      graphicView,
     EcsView*                      resourceView) {
-  const RvkSize winSize   = painter_win_size(win);
-  const f32     winAspect = (f32)winSize.width / (f32)winSize.height;
+  const RvkSize winSize = painter_win_size(win);
+  if (!winSize.width || !winSize.height) {
+    return false; // Window is zero sized; no need to render.
+  }
+  const f32 winAspect = (f32)winSize.width / (f32)winSize.height;
 
   const GeoMatrix      camMat   = trans ? scene_transform_matrix(trans) : geo_matrix_ident();
   const GeoMatrix      projMat  = cam ? scene_camera_proj(cam, winAspect)

--- a/libs/rend/src/rvk/debug.c
+++ b/libs/rend/src/rvk/debug.c
@@ -83,7 +83,7 @@ static LogLevel rvk_msg_log_level(const VkDebugUtilsMessageSeverityFlagBitsEXT m
   return LogLevel_Debug;
 }
 
-static VkBool32 rvk_message_func(
+static VkBool32 SYS_DECL rvk_message_func(
     VkDebugUtilsMessageSeverityFlagBitsEXT      msgSeverity,
     VkDebugUtilsMessageTypeFlagsEXT             msgType,
     const VkDebugUtilsMessengerCallbackDataEXT* callbackData,
@@ -128,14 +128,14 @@ RvkDebug* rvk_debug_create(
 
   RvkDebug* debug = alloc_alloc_t(g_alloc_heap, RvkDebug);
   *debug          = (RvkDebug){
-      .flags            = flags,
-      .logger           = g_logger,
-      .vkInst           = vkInst,
-      .vkDev            = vkDev,
-      .vkAlloc          = vkAlloc,
-      .vkObjectNameFunc = rvk_func_load_instance(vkInst, vkSetDebugUtilsObjectNameEXT),
-      .vkLabelBeginFunc = rvk_func_load_instance(vkInst, vkCmdBeginDebugUtilsLabelEXT),
-      .vkLabelEndFunc   = rvk_func_load_instance(vkInst, vkCmdEndDebugUtilsLabelEXT),
+               .flags            = flags,
+               .logger           = g_logger,
+               .vkInst           = vkInst,
+               .vkDev            = vkDev,
+               .vkAlloc          = vkAlloc,
+               .vkObjectNameFunc = rvk_func_load_instance(vkInst, vkSetDebugUtilsObjectNameEXT),
+               .vkLabelBeginFunc = rvk_func_load_instance(vkInst, vkCmdBeginDebugUtilsLabelEXT),
+               .vkLabelEndFunc   = rvk_func_load_instance(vkInst, vkCmdEndDebugUtilsLabelEXT),
   };
   rvk_messenger_create(debug);
 

--- a/libs/rend/src/rvk/image.c
+++ b/libs/rend/src/rvk/image.c
@@ -15,6 +15,12 @@ MAYBE_UNUSED static const RvkImageCapability g_allowedExtraCaps =
     RvkImageCapability_Sampled;
 // clang-format on
 
+static VkClearColorValue rvk_rend_clear_color(const GeoColor color) {
+  VkClearColorValue result;
+  mem_cpy(mem_var(result), mem_var(color));
+  return result;
+}
+
 MAYBE_UNUSED static bool
 rvk_image_phase_supported(const RvkImageCapability caps, const RvkImagePhase phase) {
   switch (phase) {
@@ -614,7 +620,7 @@ void rvk_image_clear_color(const RvkImage* img, const GeoColor color, VkCommandB
   rvk_image_assert_phase(img, RvkImagePhase_TransferDest);
   diag_assert(img->type != RvkImageType_DepthAttachment);
 
-  const VkClearColorValue       clearColor = *(VkClearColorValue*)&color;
+  const VkClearColorValue       clearColor = rvk_rend_clear_color(color);
   const VkImageSubresourceRange ranges[]   = {
       {
           .aspectMask     = rvk_image_vkaspect(img->type),

--- a/libs/rend/src/rvk/mem_alloc.c
+++ b/libs/rend/src/rvk/mem_alloc.c
@@ -67,14 +67,14 @@ static RvkAllocInfo rvk_alloc_internal(
   };
 }
 
-static void* rvk_alloc_func(
+static void* SYS_DECL rvk_alloc_func(
     void* userData, const usize size, const usize align, const VkSystemAllocationScope scope) {
 
   Allocator* alloc = userData;
   return rvk_alloc_internal(alloc, size, align, scope).payloadPtr;
 }
 
-static void* rvk_realloc_func(
+static void* SYS_DECL rvk_realloc_func(
     void*                         userData,
     void*                         original,
     const usize                   size,
@@ -106,7 +106,7 @@ static void* rvk_realloc_func(
   return newAlloc.payloadPtr;
 }
 
-static void rvk_free_func(void* userData, void* memory) {
+static void SYS_DECL rvk_free_func(void* userData, void* memory) {
   if (UNLIKELY(memory == null)) {
     return;
   }

--- a/libs/rend/src/rvk/pass.c
+++ b/libs/rend/src/rvk/pass.c
@@ -65,6 +65,12 @@ static RvkPassStage* rvk_pass_stage() {
   return &g_stage;
 }
 
+static VkClearColorValue rvk_rend_clear_color(const GeoColor color) {
+  VkClearColorValue result;
+  mem_cpy(mem_var(result), mem_var(color));
+  return result;
+}
+
 struct sRvkPass {
   RvkDevice*       dev;
   VkFormat         swapchainFormat;
@@ -381,7 +387,7 @@ static void rvk_pass_vkrenderpass_begin(RvkPass* pass, RvkPassInvoc* invoc, RvkP
 
   if (pass->flags & RvkPassFlags_NeedsClear) {
     for (u32 i = 0; i != rvk_pass_attach_color_count(&pass->config); ++i) {
-      clearValues[clearValueCount++].color = *(VkClearColorValue*)&stage->clearColor;
+      clearValues[clearValueCount++].color = rvk_rend_clear_color(stage->clearColor);
     }
     if (pass->config.attachDepth) {
       // Init depth to zero for a reversed-z depth-buffer.

--- a/libs/scene/src/collision.c
+++ b/libs/scene/src/collision.c
@@ -2,6 +2,7 @@
 #include "core_array.h"
 #include "core_bits.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "ecs_world.h"
 #include "geo_query.h"
 #include "scene_collision.h"

--- a/libs/scene/src/locomotion.c
+++ b/libs/scene/src/locomotion.c
@@ -1,4 +1,5 @@
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "ecs_world.h"
 #include "scene_locomotion.h"

--- a/libs/scene/src/projectile.c
+++ b/libs/scene/src/projectile.c
@@ -1,4 +1,5 @@
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "ecs_world.h"
 #include "scene_collision.h"

--- a/libs/script/include/script_val.h
+++ b/libs/script/include/script_val.h
@@ -19,8 +19,12 @@ typedef enum {
 /**
  * Type-erased script value.
  */
-typedef struct {
+typedef union {
   ALIGNAS(16) u32 data[4];
+  f64         unsafeNumber;
+  bool        unsafeBool;
+  GeoVector   unsafeVector;
+  EcsEntityId unsafeEntity;
 } ScriptVal;
 
 ASSERT(sizeof(ScriptVal) == 16, "Expected ScriptVal's size to be 128 bits");

--- a/libs/script/src/val.c
+++ b/libs/script/src/val.c
@@ -22,12 +22,12 @@
  * NOTE: Assumes little-endian byte order.
  */
 
-INLINE_HINT static f64 val_as_number(const ScriptVal value) { return *((f64*)&value.data); }
+INLINE_HINT static f64 val_as_number(const ScriptVal value) { return value.unsafeNumber; }
 
-INLINE_HINT static bool val_as_bool(const ScriptVal value) { return *((bool*)&value.data); }
+INLINE_HINT static bool val_as_bool(const ScriptVal value) { return value.unsafeBool; }
 
 INLINE_HINT static GeoVector val_as_vector3_dirty_w(const ScriptVal value) {
-  return *((GeoVector*)&value.data);
+  return value.unsafeVector;
 }
 
 INLINE_HINT static GeoVector val_as_vector3(const ScriptVal value) {
@@ -36,9 +36,7 @@ INLINE_HINT static GeoVector val_as_vector3(const ScriptVal value) {
   return result;
 }
 
-INLINE_HINT static EcsEntityId val_as_entity(const ScriptVal value) {
-  return *((EcsEntityId*)&value.data);
-}
+INLINE_HINT static EcsEntityId val_as_entity(const ScriptVal value) { return value.unsafeEntity; }
 
 ScriptType script_type(const ScriptVal value) { return (ScriptType)value.data[3]; }
 
@@ -49,38 +47,36 @@ ScriptVal script_null() {
 
 ScriptVal script_number(const f64 value) {
   ScriptVal result;
-  *((f64*)&result.data) = value;
-  result.data[3]        = ScriptType_Number;
+  result.unsafeNumber = value;
+  result.data[3]      = ScriptType_Number;
   return result;
 }
 
 ScriptVal script_bool(const bool value) {
   ScriptVal result;
-  *((bool*)&result.data) = value;
-  result.data[3]         = ScriptType_Bool;
+  result.unsafeBool = value;
+  result.data[3]    = ScriptType_Bool;
   return result;
 }
 
 ScriptVal script_vector3(const GeoVector value) {
   ScriptVal result;
-  *((GeoVector*)&result.data) = value;
-  result.data[3]              = ScriptType_Vector3;
+  result.unsafeVector = value;
+  result.data[3]      = ScriptType_Vector3;
   return result;
 }
 
 ScriptVal script_vector3_lit(const f32 x, const f32 y, const f32 z) {
   ScriptVal result;
-  ((f32*)&result.data)[0] = x;
-  ((f32*)&result.data)[1] = y;
-  ((f32*)&result.data)[2] = z;
-  result.data[3]          = ScriptType_Vector3;
+  result.unsafeVector = geo_vector(x, y, z);
+  result.data[3]      = ScriptType_Vector3;
   return result;
 }
 
 ScriptVal script_entity(const EcsEntityId value) {
   ScriptVal result;
-  *((EcsEntityId*)&result.data) = value;
-  result.data[3]                = ScriptType_Entity;
+  result.unsafeEntity = value;
+  result.data[3]      = ScriptType_Entity;
   return result;
 }
 

--- a/libs/ui/src/builder.c
+++ b/libs/ui/src/builder.c
@@ -1,4 +1,5 @@
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "ui_canvas.h"
 #include "ui_shape.h"

--- a/libs/ui/src/widget.c
+++ b/libs/ui/src/widget.c
@@ -1,4 +1,5 @@
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "ui_canvas.h"
 #include "ui_layout.h"

--- a/libs/vfx/src/particle.c
+++ b/libs/vfx/src/particle.c
@@ -1,6 +1,7 @@
 #include "asset_atlas.h"
 #include "asset_manager.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "ecs_world.h"
 #include "log_logger.h"

--- a/libs/vfx/src/system.c
+++ b/libs/vfx/src/system.c
@@ -3,6 +3,7 @@
 #include "asset_vfx.h"
 #include "core_alloc.h"
 #include "core_diag.h"
+#include "core_float.h"
 #include "core_math.h"
 #include "core_noise.h"
 #include "core_rng.h"


### PR DESCRIPTION
Tune various compiler options:
- Use vectorcall calling convention on windows.
- Enable strict-aliasing rules on GCC / Clang.
- Target native architecture on GCC / Clang.
- Omit frame pointers in FAST builds on GCC / Clang.
- Enable loop unrolling on GCC / Clang.