### PR TITLE
rend: Orient octahedron normal encoding along y axis

### DIFF
--- a/assets/shaders/include/math.glsl
+++ b/assets/shaders/include/math.glsl
@@ -21,12 +21,14 @@ f32v2 math_oct_wrap(const f32v2 v) {
 /**
  * Encode a normal using Octahedron normal vector encoding.
  * Source: https://knarkowicz.wordpress.com/2014/04/16/octahedron-normal-vector-encoding/
+ *
+ * The hemispheres are oriented along the positive y axis. The space is continuous in the same
+ * hemisphere but not across hemispheres, this means linear blending can be used as long as the
+ * source and destination points are both on the same hemisphere.
  */
 f32v2 math_normal_encode(f32v3 n) {
   n /= abs(n.x) + abs(n.y) + abs(n.z);
-  n.xy = n.z >= 0.0 ? n.xy : math_oct_wrap(n.xy);
-  n.xy = n.xy * 0.5 + 0.5;
-  return n.xy;
+  return (n.y >= 0.0 ? n.xz : math_oct_wrap(n.xz)) * 0.5 + 0.5;
 }
 
 /**
@@ -35,9 +37,9 @@ f32v2 math_normal_encode(f32v3 n) {
  */
 f32v3 math_normal_decode(f32v2 f) {
   f           = f * 2.0 - 1.0;
-  f32v3     n = f32v3(f.x, f.y, 1.0 - abs(f.x) - abs(f.y));
-  const f32 t = clamp(-n.z, 0, 1);
-  n.xy += f32v2(n.x >= 0.0 ? -t : t, n.y >= 0.0 ? -t : t);
+  f32v3     n = f32v3(f.x, 1.0 - abs(f.x) - abs(f.y), f.y);
+  const f32 t = clamp(-n.y, 0, 1);
+  n.xz += f32v2(n.x >= 0.0 ? -t : t, n.z >= 0.0 ? -t : t);
   return normalize(n);
 }
 

--- a/assets/shaders/vfx/decal.frag
+++ b/assets/shaders/vfx/decal.frag
@@ -39,6 +39,10 @@ bind_internal(8) in flat u32 in_excludeTags;
  * Geometry Data0: color (rgb), emissive (a).
  * Geometry Data1: normal (rg), roughness (b) and tags (a).
  * Alpha blended, w is used to control the blending, outputting emissive / tags is not supported.
+ *
+ * NOTE: Normals can only be blended (without discontinuities) if the source and destination both
+ * have a positive y value or both a negative value. Reason for this is that we use a octahedron
+ * normal encoding.
  */
 bind_internal(0) out f32v4 out_data0;
 bind_internal(1) out f32v4 out_data1;


### PR DESCRIPTION
The octahedron normal encoding we use has discontinuities between the two hemispheres, we used to orient the hemispheres along the z axis causing visual glitches for decals on surfaces perpendicular to the z axis. This PR changes the orientation to be along the y axis greatly reducing the artifacts in practice (as in an RTS most surfaces tend to point upwards). 