### PR TITLE
Debug colliders

### DIFF
--- a/apps/game/src/input.c
+++ b/apps/game/src/input.c
@@ -267,9 +267,9 @@ static void update_camera_movement_debug(
 static SceneQueryFilter select_filter(InputManagerComp* input) {
   if (input_layer_active(input, string_hash_lit("Debug"))) {
     /**
-     * Allow selecting all objects in debug mode.
+     * Allow selecting all objects (including debug shapes) in debug mode.
      */
-    return (SceneQueryFilter){.layerMask = SceneLayer_All};
+    return (SceneQueryFilter){.layerMask = SceneLayer_AllIncludingDebug};
   }
   /**
    * Only allow selecting your own units.

--- a/libs/debug/src/camera.c
+++ b/libs/debug/src/camera.c
@@ -267,7 +267,7 @@ static void debug_camera_draw_input_ray(
   debug_line(shape, start, end, geo_color_fuchsia);
 
   SceneRayHit            hit;
-  const SceneQueryFilter filter  = {.layerMask = SceneLayer_All};
+  const SceneQueryFilter filter  = {.layerMask = SceneLayer_AllNonDebug};
   const f32              maxDist = 1e5f;
   if (scene_query_ray(collisionEnv, &ray, maxDist, &filter, &hit)) {
     debug_sphere(shape, hit.position, 0.04f, geo_color_lime, DebugShape_Overlay);

--- a/libs/geo/include/geo_box.h
+++ b/libs/geo/include/geo_box.h
@@ -61,7 +61,7 @@ GeoBox geo_box_dilate(const GeoBox*, GeoVector size);
 /**
  * Retrieve the 8 corners of the 3d box.
  */
-void geo_box_corners3(const GeoBox*, GeoVector corners[8]);
+void geo_box_corners3(const GeoBox*, GeoVector corners[PARAM_ARRAY_SIZE(8)]);
 
 /**
  * Construct a transformed 3d box.

--- a/libs/geo/include/geo_sphere.h
+++ b/libs/geo/include/geo_sphere.h
@@ -29,3 +29,4 @@ f32 geo_sphere_intersect_ray(const GeoSphere*, const GeoRay*);
  */
 bool geo_sphere_overlap(const GeoSphere*, const GeoSphere*);
 bool geo_sphere_overlap_box(const GeoSphere*, const GeoBox*);
+bool geo_sphere_overlap_frustum(const GeoSphere*, const GeoVector[PARAM_ARRAY_SIZE(8)]);

--- a/libs/geo/src/box.c
+++ b/libs/geo/src/box.c
@@ -150,7 +150,7 @@ GeoBox geo_box_dilate(const GeoBox* b, const GeoVector size) {
 #endif
 }
 
-void geo_box_corners3(const GeoBox* box, GeoVector corners[8]) {
+void geo_box_corners3(const GeoBox* box, GeoVector corners[PARAM_ARRAY_SIZE(8)]) {
   corners[0] = geo_vector(box->min.x, box->min.y, box->min.z);
   corners[1] = geo_vector(box->min.x, box->min.y, box->max.z);
   corners[2] = geo_vector(box->max.x, box->min.y, box->min.z);

--- a/libs/geo/src/query.c
+++ b/libs/geo/src/query.c
@@ -190,12 +190,7 @@ static bool geo_prim_overlap_frustum(
   switch (prim->type) {
   case GeoQueryPrim_Sphere: {
     const GeoSphere* sphere = &((const GeoSphere*)prim->shapes)[entryIdx];
-    // TODO: Implement sphere <-> frustum overlap instead of converting spheres to boxes.
-    const GeoBoxRotated box = {
-        .box      = geo_box_from_sphere(sphere->point, sphere->radius),
-        .rotation = geo_quat_ident,
-    };
-    return geo_box_rotated_overlap_frustum(&box, frustum);
+    return geo_sphere_overlap_frustum(sphere, frustum);
   }
   case GeoQueryPrim_Capsule: {
     const GeoCapsule* cap = &((const GeoCapsule*)prim->shapes)[entryIdx];

--- a/libs/geo/src/sphere.c
+++ b/libs/geo/src/sphere.c
@@ -1,3 +1,4 @@
+#include "core_array.h"
 #include "core_float.h"
 #include "core_intrinsic.h"
 #include "core_math.h"
@@ -44,4 +45,22 @@ bool geo_sphere_overlap_box(const GeoSphere* sphere, const GeoBox* box) {
   const GeoVector closest = geo_box_closest_point(box, sphere->point);
   const f32       distSqr = geo_vector_mag_sqr(geo_vector_sub(closest, sphere->point));
   return distSqr <= (sphere->radius * sphere->radius);
+}
+
+bool geo_sphere_overlap_frustum(
+    const GeoSphere* sphere, const GeoVector frustum[PARAM_ARRAY_SIZE(8)]) {
+  const GeoPlane frustumPlanes[] = {
+      geo_plane_at_triangle(frustum[3], frustum[6], frustum[2]), // Right.
+      geo_plane_at_triangle(frustum[1], frustum[4], frustum[0]), // Left.
+      geo_plane_at_triangle(frustum[2], frustum[5], frustum[1]), // Up.
+      geo_plane_at_triangle(frustum[4], frustum[7], frustum[0]), // Down.
+      geo_plane_at_triangle(frustum[4], frustum[5], frustum[6]), // Back.
+      geo_plane_at_triangle(frustum[2], frustum[1], frustum[0]), // Front.
+  };
+  array_for_t(frustumPlanes, GeoPlane, plane) {
+    if ((geo_vector_dot(sphere->point, plane->normal) - plane->distance) < -sphere->radius) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/libs/scene/include/scene_collision.h
+++ b/libs/scene/include/scene_collision.h
@@ -121,6 +121,12 @@ String scene_layer_name(SceneLayer);
 String scene_collision_type_name(SceneCollisionType);
 
 /**
+ * Set a mask to ignore colliders on specific layers globally.
+ */
+SceneLayer scene_collision_ignore_mask(const SceneCollisionEnvComp*);
+void       scene_collision_ignore_mask_set(SceneCollisionEnvComp*, SceneLayer);
+
+/**
  * Add a collision shape to the given entity.
  */
 

--- a/libs/scene/include/scene_collision.h
+++ b/libs/scene/include/scene_collision.h
@@ -46,9 +46,10 @@ typedef enum {
   SceneLayer_UnitFactionC = SceneLayer_InfantryFactionC | SceneLayer_StructureFactionC,
   SceneLayer_UnitFactionD = SceneLayer_InfantryFactionD | SceneLayer_StructureFactionD,
 
-  SceneLayer_Count = 13,
-  SceneLayer_None  = 0,
-  SceneLayer_All   = ~0,
+  SceneLayer_Count             = 13,
+  SceneLayer_None              = 0,
+  SceneLayer_AllIncludingDebug = ~0,
+  SceneLayer_AllNonDebug       = ~SceneLayer_Debug,
 } SceneLayer;
 
 /**

--- a/libs/scene/src/collision.c
+++ b/libs/scene/src/collision.c
@@ -24,11 +24,13 @@ static void ecs_destruct_collision_env_comp(void* data) {
 
 ecs_view_define(UpdateGlobalView) { ecs_access_write(SceneCollisionEnvComp); }
 
-ecs_view_define(CollisionEntityView) {
+ecs_view_define(CollisionView) {
   ecs_access_read(SceneCollisionComp);
   ecs_access_read(SceneTransformComp);
   ecs_access_maybe_read(SceneScaleComp);
 }
+
+ecs_view_define(TransformView) { ecs_access_read(SceneTransformComp); }
 
 static void collision_env_create(EcsWorld* world) {
   GeoQueryEnv* queryEnv = geo_query_env_create(g_alloc_heap);
@@ -58,11 +60,16 @@ ecs_system_define(SceneCollisionUpdateSys) {
     return;
   }
 
+  EcsView* collisionView = ecs_world_view_t(world, CollisionView);
+  EcsView* transformView = ecs_world_view_t(world, TransformView);
+
   SceneCollisionEnvComp* env = ecs_view_write_t(globalItr, SceneCollisionEnvComp);
   geo_query_env_clear(env->queryEnv);
 
-  EcsView* collisionEntities = ecs_world_view_t(world, CollisionEntityView);
-  for (EcsIterator* itr = ecs_view_itr(collisionEntities); ecs_view_walk(itr);) {
+  /**
+   * Insert geo shapes for all colliders.
+   */
+  for (EcsIterator* itr = ecs_view_itr(collisionView); ecs_view_walk(itr);) {
     const SceneCollisionComp* collision = ecs_view_read_t(itr, SceneCollisionComp);
     const SceneTransformComp* trans     = ecs_view_read_t(itr, SceneTransformComp);
     const SceneScaleComp*     scale     = ecs_view_read_t(itr, SceneScaleComp);
@@ -94,6 +101,17 @@ ecs_system_define(SceneCollisionUpdateSys) {
       diag_crash();
     }
   }
+
+  /**
+   * Insert a debug sphere shape for all entities with a transform.
+   * The debug shapes are useful to be able to select entities without a collider.
+   */
+  for (EcsIterator* itr = ecs_view_itr(transformView); ecs_view_walk(itr);) {
+    const SceneTransformComp* trans  = ecs_view_read_t(itr, SceneTransformComp);
+    const GeoSphere           sphere = {.point = trans->position, .radius = 0.25f};
+    const u64                 id     = (u64)ecs_view_entity(itr);
+    geo_query_insert_sphere(env->queryEnv, sphere, id, (GeoQueryLayer)SceneLayer_Debug);
+  }
 }
 
 ecs_view_define(UpdateStatsGlobalView) {
@@ -119,10 +137,14 @@ ecs_module_init(scene_collision_module) {
   ecs_register_comp(SceneCollisionComp);
 
   ecs_register_view(UpdateGlobalView);
-  ecs_register_view(CollisionEntityView);
+  ecs_register_view(CollisionView);
+  ecs_register_view(TransformView);
 
   ecs_register_system(
-      SceneCollisionUpdateSys, ecs_view_id(UpdateGlobalView), ecs_view_id(CollisionEntityView));
+      SceneCollisionUpdateSys,
+      ecs_view_id(UpdateGlobalView),
+      ecs_view_id(CollisionView),
+      ecs_view_id(TransformView));
 
   ecs_order(SceneCollisionUpdateSys, SceneOrder_CollisionUpdate);
 

--- a/libs/scene/src/collision.c
+++ b/libs/scene/src/collision.c
@@ -26,7 +26,7 @@ ecs_view_define(UpdateGlobalView) { ecs_access_write(SceneCollisionEnvComp); }
 
 ecs_view_define(CollisionEntityView) {
   ecs_access_read(SceneCollisionComp);
-  ecs_access_maybe_read(SceneTransformComp);
+  ecs_access_read(SceneTransformComp);
   ecs_access_maybe_read(SceneScaleComp);
 }
 


### PR DESCRIPTION
Add 'debug' colliders to entities that have no collider, this allows us to select those entities in debug mode.