### PR TITLE
script: Support multiple diagnostics

### DIFF
--- a/apps/utilities/lsp.c
+++ b/apps/utilities/lsp.c
@@ -363,6 +363,12 @@ static void lsp_handle_refresh_diagnostics(LspContext* ctx, const String uri, co
     const ScriptPosLineCol rangeStart = script_pos_to_line_col(text, diag->range.start);
     const ScriptPosLineCol rangeEnd   = script_pos_to_line_col(text, diag->range.end);
 
+    /**
+     * TODO: The columns offsets we compute are in unicode codepoints (utf32). However we report to
+     * the LSP client that we are using utf16 offsets. Reason is that some clients (for example
+     * VCCode) only support utf16 offsets. This means the column offsets are incorrect if the line
+     * contains unicode characters outside of the utf16 range.
+     */
     lspDiags[i] = (LspDiagnostic){
         .range.start.line      = rangeStart.line,
         .range.start.character = rangeStart.column,

--- a/libs/script/src/read.c
+++ b/libs/script/src/read.c
@@ -549,12 +549,15 @@ ArgNext:
     goto ArgNext;
   }
 
-ArgEnd:;
+ArgEnd:
+  if (!valid) {
+    return -1;
+  }
   const ScriptToken endToken = read_consume(ctx);
   if (UNLIKELY(endToken.type != ScriptTokenType_ParenClose)) {
     return read_diag_emit(ctx, ScriptError_UnterminatedArgumentList, argsStart), -1;
   }
-  return valid ? count : -1;
+  return count;
 }
 
 static ScriptExpr read_expr_var_declare(ScriptReadContext* ctx, const ScriptPos start) {

--- a/libs/script/src/read.c
+++ b/libs/script/src/read.c
@@ -528,8 +528,8 @@ static bool read_is_args_end(const ScriptTokenType type) {
  * NOTE: Caller is expected to consume the opening parenthesis.
  */
 static i32 read_args(ScriptReadContext* ctx, ScriptExpr out[script_args_max]) {
-  i32  count         = 0;
-  bool anyInvalidArg = false;
+  i32  count = 0;
+  bool valid = true;
 
   ScriptPos argsStart = script_pos_current(ctx);
 
@@ -542,7 +542,7 @@ ArgNext:
     return read_diag_emit(ctx, ScriptError_ArgumentCountExceedsMaximum, argsStart), -1;
   }
   const ScriptExpr arg = read_expr(ctx, OpPrecedence_None);
-  anyInvalidArg |= sentinel_check(arg);
+  valid &= !sentinel_check(arg);
   out[count++] = arg;
 
   if (read_consume_if(ctx, ScriptTokenType_Comma)) {
@@ -554,7 +554,7 @@ ArgEnd:;
   if (UNLIKELY(endToken.type != ScriptTokenType_ParenClose)) {
     return read_diag_emit(ctx, ScriptError_UnterminatedArgumentList, argsStart), -1;
   }
-  return anyInvalidArg ? -1 : count;
+  return valid ? count : -1;
 }
 
 static ScriptExpr read_expr_var_declare(ScriptReadContext* ctx, const ScriptPos start) {

--- a/libs/script/test/test_read.c
+++ b/libs/script/test/test_read.c
@@ -964,7 +964,7 @@ spec(read) {
       ScriptDiagBag diags = {0};
       script_read(doc, binder, g_testData[i].input, &diags);
 
-      check_require(diags.count == 1);
+      check_require(diags.count >= 1);
       const ScriptDiag* diag = &diags.values[0];
       check_msg(
           diag->error == g_testData[i].expected,


### PR DESCRIPTION
At the moment we only report multiple diagnostics for argument lists.