### PR TITLE
script: Support missing expr in arg as an semantic error

### DIFF
--- a/apps/utilities/repl.c
+++ b/apps/utilities/repl.c
@@ -318,7 +318,8 @@ static void repl_exec(ScriptMem* mem, const ReplFlags flags, const String input,
     if (flags & ReplFlags_OutputStats) {
       repl_output_stats(script, expr);
     }
-    if (!(flags & ReplFlags_NoEval)) {
+    const bool noErrors = script_diag_count(diags, ScriptDiagFilter_Error) == 0;
+    if (noErrors && !(flags & ReplFlags_NoEval)) {
       const ScriptEvalResult evalRes = script_eval(script, mem, expr, repl_bind_init(), null);
       if (script_panic_valid(&evalRes.panic)) {
         repl_output_panic(input, &evalRes.panic, id);

--- a/libs/asset/src/loader_behavior.c
+++ b/libs/asset/src/loader_behavior.c
@@ -223,7 +223,7 @@ static AssetAiNodeCondition build_node_condition(BuildContext* ctx, const AssetA
 
   script_diag_bag_destroy(diags);
 
-  if (UNLIKELY(sentinel_check(expr))) {
+  if (UNLIKELY(sentinel_check(expr) || diagCount > 0)) {
     ctx->error = BehaviorError_ScriptInvalid;
     return (AssetAiNodeCondition){.scriptExpr = sentinel_u32};
   }
@@ -253,7 +253,7 @@ static AssetAiNodeExecute build_node_execute(BuildContext* ctx, const AssetAiNod
 
   script_diag_bag_destroy(diags);
 
-  if (UNLIKELY(sentinel_check(expr))) {
+  if (UNLIKELY(sentinel_check(expr) || diagCount > 0)) {
     ctx->error = BehaviorError_ScriptInvalid;
     return (AssetAiNodeExecute){.scriptExpr = sentinel_u32};
   }

--- a/libs/asset/src/loader_script.c
+++ b/libs/asset/src/loader_script.c
@@ -110,7 +110,7 @@ void asset_load_script(
 
   script_diag_bag_destroy(diags);
 
-  if (UNLIKELY(sentinel_check(expr))) {
+  if (UNLIKELY(sentinel_check(expr) || diagCount > 0)) {
     goto Error;
   }
 

--- a/libs/core/src/signal_pal_linux.c
+++ b/libs/core/src/signal_pal_linux.c
@@ -13,7 +13,7 @@ static void SYS_DECL signal_pal_interrupt_handler(int signal) {
 }
 
 static void signal_pal_setup_interrupt_handler() {
-  struct sigaction action = (struct sigaction){
+  struct sigaction action = {
       .sa_handler = signal_pal_interrupt_handler,
       .sa_flags   = SA_RESTART,
   };

--- a/libs/script/src/read.c
+++ b/libs/script/src/read.c
@@ -773,12 +773,6 @@ ArgNext:;
     };
     return read_emit_err(ctx, ScriptDiag_ArgumentCountExceedsMaximum, wholeArgsRange), -1;
   }
-  if (UNLIKELY(read_consume_if(ctx, ScriptTokenType_ParenClose))) {
-    diag_assert(count != 0); // Only happens after reading at least 1 argument.
-    // TODO: Ideality we would report the range of the last separator token.
-    const ScriptRange lastArgRange = script_expr_range(ctx->doc, outExprs[count - 1]);
-    return read_emit_err(ctx, ScriptDiag_MissingPrimaryExpr, lastArgRange), -1;
-  }
   const ScriptSection prevSection = read_section_add(ctx, ScriptSection_InsideArg);
   const ScriptExpr    arg         = read_expr(ctx, OpPrecedence_None);
   ctx->section                    = prevSection;

--- a/libs/script/src/read.c
+++ b/libs/script/src/read.c
@@ -1604,5 +1604,14 @@ ScriptExpr script_read(
     diag_assert_msg(fail || !hasErrDiag, "Error diagnostic was produced for a successful read");
   }
 #endif
-  return fail ? script_expr_sentinel : expr;
+
+  /**
+   * NOTE: Currently we assume that if the caller provides a diagnostic bag it will check if the bag
+   * has any errors to determine if the program is valid instead of just checking the output
+   * expression. This is useful for tools that want to inspect the program even if it is invalid.
+   * TODO: This should probably be an input flag instead.
+   */
+  const bool allowInvalidProgram = diags != null;
+
+  return (fail && !allowInvalidProgram) ? script_expr_sentinel : expr;
 }

--- a/libs/script/test/test_read.c
+++ b/libs/script/test/test_read.c
@@ -1088,6 +1088,9 @@ spec(read) {
         {string_static("hello()"), ScriptDiag_NoFuncFoundForId},
         {string_static("type(1 +)"), ScriptDiag_MissingPrimaryExpr},
         {string_static("type(, 1)"), ScriptDiag_MissingPrimaryExpr},
+        {string_static("type(,)"), ScriptDiag_MissingPrimaryExpr},
+        {string_static("type(1,)"), ScriptDiag_MissingPrimaryExpr},
+        {string_static("type(1 +,)"), ScriptDiag_MissingPrimaryExpr},
     };
 
     for (u32 i = 0; i != array_elems(g_testData); ++i) {

--- a/libs/script/test/test_read.c
+++ b/libs/script/test/test_read.c
@@ -964,7 +964,7 @@ spec(read) {
         {string_static("1 ? 1 : 1 2"), ScriptDiag_MissingSemicolon},
         {string_static("distance"), ScriptDiag_NoVarFoundForId},
         {string_static("distance("), ScriptDiag_UnterminatedArgumentList},
-        {string_static("distance(,"), ScriptDiag_InvalidPrimaryExpr},
+        {string_static("distance(,"), ScriptDiag_MissingPrimaryExpr},
         {string_static("distance(1 2"), ScriptDiag_UnterminatedArgumentList},
         {string_static("distance(1,"), ScriptDiag_MissingPrimaryExpr},
         {string_static("distance(1,2,3)"), ScriptDiag_IncorrectArgCountForBuiltinFunc},
@@ -1077,6 +1077,32 @@ spec(read) {
           fmt_int(diag->type),
           fmt_int(g_testData[i].expected),
           fmt_text(g_testData[i].input));
+    }
+  }
+
+  it("can return programs with semantic errors") {
+    static const struct {
+      String         input;
+      ScriptDiagType expected;
+    } g_testData[] = {
+        {string_static("hello()"), ScriptDiag_NoFuncFoundForId},
+        {string_static("type(1 +)"), ScriptDiag_MissingPrimaryExpr},
+        {string_static("type(, 1)"), ScriptDiag_MissingPrimaryExpr},
+    };
+
+    for (u32 i = 0; i != array_elems(g_testData); ++i) {
+      // NOTE: Invalid programs are only returned when providing a diagnostic-bag as otherwise there
+      // would be no way to determine if the output program was valid.
+      script_diag_clear(diags);
+      const ScriptExpr expr = script_read(doc, binder, g_testData[i].input, diags, symsNull);
+
+      check_msg(!sentinel_check(expr), "valid expression [{}]", fmt_text(g_testData[i].input));
+
+      const u32 errorCount = script_diag_count(diags, ScriptDiagFilter_Error);
+      check_require_msg(errorCount >= 1, "errorCount >= 1 [{}]", fmt_text(g_testData[i].input));
+
+      const ScriptDiag* diag = script_diag_first(diags, ScriptDiagFilter_Error);
+      check(diag->type == g_testData[i].expected);
     }
   }
 


### PR DESCRIPTION
As opposed to a structural error, which means we can keep parsing the rest of the script.