### PR TITLE
asset: Properly support single channel TGA textures

### DIFF
--- a/assets/CMakeLists.txt
+++ b/assets/CMakeLists.txt
@@ -234,7 +234,7 @@ if(${EXTERNAL_ASSETS})
       tent/tent.gltf
       terrain/terrain_3_height.r16
       terrain/terrain_3_splat.tga
-      tiling/clouds.tga
+      tiling/clouds_2.tga
       tiling/dirt_2_color_rough.tga
       tiling/dirt_2_normal.tga
       tiling/metal_panel_color_rough.tga

--- a/assets/graphics/light/light_directional.graphic
+++ b/assets/graphics/light/light_directional.graphic
@@ -26,7 +26,7 @@
   ],
   "samplers": [
     {
-      "textureId": "external/tiling/clouds.tga",
+      "textureId": "external/tiling/clouds_2.tga",
       "wrap": "Repeat",
       "filter": "Linear"
     }

--- a/assets/textures/ambient_occlusion_rot_noise.proctex
+++ b/assets/textures/ambient_occlusion_rot_noise.proctex
@@ -1,6 +1,6 @@
 {
   "type": "NoiseWhite",
-  "channels": 4,
+  "channels": "Four",
   "mipmaps": false,
   "size": 4,
   "frequency": 1,

--- a/assets/textures/checker.proctex
+++ b/assets/textures/checker.proctex
@@ -1,6 +1,6 @@
 {
   "type": "Checker",
-  "channels": 1,
+  "channels": "One",
   "size": 4,
   "frequency": 2,
   "power": 1,

--- a/assets/textures/checker_white.proctex
+++ b/assets/textures/checker_white.proctex
@@ -1,6 +1,6 @@
 {
   "type": "Checker",
-  "channels": 4,
+  "channels": "Four",
   "size": 4,
   "frequency": 2,
   "power": 1,

--- a/assets/textures/checker_white_32.proctex
+++ b/assets/textures/checker_white_32.proctex
@@ -1,6 +1,6 @@
 {
   "type": "Checker",
-  "channels": 4,
+  "channels": "Four",
   "size": 32,
   "frequency": 16,
   "power": 1,

--- a/assets/textures/checker_white_8.proctex
+++ b/assets/textures/checker_white_8.proctex
@@ -1,6 +1,6 @@
 {
   "type": "Checker",
-  "channels": 4,
+  "channels": "Four",
   "size": 8,
   "frequency": 4,
   "power": 1,

--- a/assets/textures/circle.proctex
+++ b/assets/textures/circle.proctex
@@ -1,6 +1,6 @@
 {
   "type": "Circle",
-  "channels": 1,
+  "channels": "One",
   "size": 64,
   "frequency": 1,
   "power": 1,

--- a/assets/textures/game/env_brdf_integration.proctex
+++ b/assets/textures/game/env_brdf_integration.proctex
@@ -1,7 +1,7 @@
 {
   "type": "BrdfIntegration",
   "pixelType": "F32",
-  "channels": 4,
+  "channels": "Four",
   "size": 128,
   "frequency": 1,
   "power": 1,

--- a/assets/textures/glow.proctex
+++ b/assets/textures/glow.proctex
@@ -1,9 +1,9 @@
 {
   "type": "Circle",
   "pixelType": "F32",
-  "channels": "One",
+  "channels": "Four",
   "size": 128,
   "frequency": 1,
-  "power": 5,
+  "power": 1,
   "seed": 1
 }

--- a/assets/textures/glow.proctex
+++ b/assets/textures/glow.proctex
@@ -1,7 +1,7 @@
 {
   "type": "Circle",
   "pixelType": "F32",
-  "channels": 1,
+  "channels": "One",
   "size": 128,
   "frequency": 1,
   "power": 5,

--- a/assets/textures/missing.proctex
+++ b/assets/textures/missing.proctex
@@ -1,6 +1,6 @@
 {
   "type": "Checker",
-  "channels": 1,
+  "channels": "One",
   "size": 8,
   "frequency": 4,
   "power": 1,

--- a/assets/textures/noise.proctex
+++ b/assets/textures/noise.proctex
@@ -1,6 +1,6 @@
 {
   "type": "NoiseWhiteGauss",
-  "channels": 1,
+  "channels": "One",
   "mipmaps": true,
   "size": 128,
   "frequency": 1,

--- a/assets/textures/one.proctex
+++ b/assets/textures/one.proctex
@@ -1,6 +1,6 @@
 {
   "type": "One",
-  "channels": 1,
+  "channels": "One",
   "size": 1,
   "frequency": 1,
   "power": 1,

--- a/assets/textures/white.proctex
+++ b/assets/textures/white.proctex
@@ -1,6 +1,6 @@
 {
   "type": "One",
-  "channels": 4,
+  "channels": "Four",
   "size": 1,
   "frequency": 1,
   "power": 1,

--- a/assets/textures/zero.proctex
+++ b/assets/textures/zero.proctex
@@ -1,6 +1,6 @@
 {
   "type": "Zero",
-  "channels": 1,
+  "channels": "One",
   "size": 1,
   "frequency": 1,
   "power": 1,

--- a/libs/asset/src/loader_texture.c
+++ b/libs/asset/src/loader_texture.c
@@ -186,6 +186,11 @@ GeoColor asset_texture_at(const AssetTextureComp* tex, const u32 layer, const us
   const usize layerDataSize = pixelCount * asset_texture_pixel_size(tex);
   const void* pixelsMip0    = tex->pixelsRaw + (layerDataSize * layer);
 
+  /**
+   * Follows the same to RGBA conversion rules as the Vulkan spec:
+   * https://registry.khronos.org/vulkan/specs/1.0/html/chap16.html#textures-conversion-to-rgba
+   */
+
   GeoColor res;
   switch (tex->type) {
   // 8 bit unsigned pixels.
@@ -193,14 +198,14 @@ GeoColor asset_texture_at(const AssetTextureComp* tex, const u32 layer, const us
     static const f32 g_u8MaxInv = 1.0f / u8_max;
     switch (tex->channels) {
     case AssetTextureChannels_One:
-      res.r = 1.0f;
-      res.g = 1.0f;
-      res.b = 1.0f;
       if (tex->flags & AssetTextureFlags_Srgb) {
-        res.a = g_textureSrgbToFloat[((AssetTexturePixelB1*)pixelsMip0)[index].r];
+        res.r = g_textureSrgbToFloat[((AssetTexturePixelB1*)pixelsMip0)[index].r];
       } else {
-        res.a = ((AssetTexturePixelB1*)pixelsMip0)[index].r * g_u8MaxInv;
+        res.r = ((AssetTexturePixelB1*)pixelsMip0)[index].r * g_u8MaxInv;
       }
+      res.g = 0.0f;
+      res.b = 0.0f;
+      res.a = 1.0f;
       return res;
     case AssetTextureChannels_Four:
       if (tex->flags & AssetTextureFlags_Srgb) {
@@ -222,10 +227,10 @@ GeoColor asset_texture_at(const AssetTextureComp* tex, const u32 layer, const us
     static const f32 g_u16MaxInv = 1.0f / u16_max;
     switch (tex->channels) {
     case AssetTextureChannels_One:
-      res.r = 1.0f;
-      res.g = 1.0f;
-      res.b = 1.0f;
-      res.a = ((AssetTexturePixelU1*)pixelsMip0)[index].r * g_u16MaxInv;
+      res.r = ((AssetTexturePixelU1*)pixelsMip0)[index].r * g_u16MaxInv;
+      res.g = 0.0f;
+      res.b = 0.0f;
+      res.a = 1.0f;
       return res;
     case AssetTextureChannels_Four:
       res.r = ((AssetTexturePixelU4*)pixelsMip0)[index].r * g_u16MaxInv;
@@ -239,10 +244,10 @@ GeoColor asset_texture_at(const AssetTextureComp* tex, const u32 layer, const us
   case AssetTextureType_F32: {
     switch (tex->channels) {
     case AssetTextureChannels_One:
-      res.r = 1.0f;
-      res.g = 1.0f;
-      res.b = 1.0f;
-      res.a = ((AssetTexturePixelF1*)pixelsMip0)[index].r;
+      res.r = ((AssetTexturePixelF1*)pixelsMip0)[index].r;
+      res.g = 0.0f;
+      res.b = 0.0f;
+      res.a = 1.0f;
       return res;
     case AssetTextureChannels_Four:
       res.r = ((AssetTexturePixelF4*)pixelsMip0)[index].r;

--- a/libs/asset/src/loader_texture_ppm.c
+++ b/libs/asset/src/loader_texture_ppm.c
@@ -141,6 +141,9 @@ static String ppm_read_pixels_binary(
   /**
    * NOTE: PPM images use the top-left as the origin, while the Volo project uses the bottom-left,
    * so we have to remap the y axis.
+   *
+   * NOTE: Follows the same to RGBA conversion rules as the Vulkan spec:
+   * https://registry.khronos.org/vulkan/specs/1.0/html/chap16.html#textures-conversion-to-rgba
    */
 
   u8* data = input.ptr;

--- a/libs/asset/src/loader_texture_tga.c
+++ b/libs/asset/src/loader_texture_tga.c
@@ -198,13 +198,13 @@ static AssetTextureChannels tga_texture_channels(const TgaChannels channels) {
   diag_crash_msg("Unsupported Tga channels value");
 }
 
-static AssetTextureFlags tga_texture_flags(const bool isNormalmap) {
+static AssetTextureFlags tga_texture_flags(const TgaChannels channels, const bool isNormalmap) {
   AssetTextureFlags flags = AssetTextureFlags_GenerateMipMaps;
   if (isNormalmap) {
     // Normal maps are in linear space (and thus not sRGB).
     flags |= AssetTextureFlags_NormalMap;
-  } else {
-    // All other textures are assumed to be sRGB encoded.
+  } else if (channels == TgaChannels_RGB || channels == TgaChannels_RGBA) {
+    // All other (3 or 4 channel) textures are assumed to be sRGB encoded.
     flags |= AssetTextureFlags_Srgb;
   }
   return flags;
@@ -453,7 +453,7 @@ void asset_load_tga(EcsWorld* world, const String id, const EcsEntityId entity, 
       AssetTextureComp,
       .type         = AssetTextureType_U8,
       .channels     = tga_texture_channels(channels),
-      .flags        = tga_texture_flags(isNormalmap),
+      .flags        = tga_texture_flags(channels, isNormalmap),
       .width        = width,
       .height       = height,
       .pixelsRaw    = pixels.ptr,

--- a/libs/asset/src/loader_texture_tga.c
+++ b/libs/asset/src/loader_texture_tga.c
@@ -175,49 +175,114 @@ static bool tga_type_supported(const TgaImageType type) {
   return false;
 }
 
+static void tga_mem_consume_inplace(Mem* mem, const usize amount) {
+  mem->ptr = bits_ptr_offset(mem->ptr, amount);
+  mem->size -= amount;
+}
+
 static u32 tga_index(const u32 x, const u32 y, const u32 width, const u32 height, TgaFlags flags) {
   // Either fill pixels from bottom to top - left to right, or top to bottom - left to right.
   return ((flags & TgaFlags_YFlip) ? (height - 1 - y) * width : y * width) + x;
 }
 
-static void tga_read_pixel_unchecked(u8* data, const TgaChannels chan, AssetTexturePixelB4* out) {
-  switch (chan) {
+static AssetTextureChannels tga_texture_channels(const TgaChannels channels) {
+  switch (channels) {
   case TgaChannels_R:
-    out->r = data[0];
-    out->g = 0;
-    out->b = 0;
-    out->a = 255;
-    break;
+    return AssetTextureChannels_One;
   case TgaChannels_RGB:
-    out->b = data[0];
-    out->g = data[1];
-    out->r = data[2];
-    out->a = 255;
-    break;
   case TgaChannels_RGBA:
-    out->b = data[0];
-    out->g = data[1];
-    out->r = data[2];
-    out->a = data[3];
+    return AssetTextureChannels_Four;
+  case TgaChannels_Invalid:
     break;
+  }
+  diag_crash_msg("Unsupported Tga channels value");
+}
+
+static AssetTextureFlags tga_texture_flags(const bool isNormalmap) {
+  AssetTextureFlags flags = AssetTextureFlags_GenerateMipMaps;
+  if (isNormalmap) {
+    // Normal maps are in linear space (and thus not sRGB).
+    flags |= AssetTextureFlags_NormalMap;
+  } else {
+    // All other textures are assumed to be sRGB encoded.
+    flags |= AssetTextureFlags_Srgb;
+  }
+  return flags;
+}
+
+static Mem tga_pixels_alloc(Allocator* alloc, const TgaChannels ch, const u32 w, const u32 h) {
+  const AssetTextureType     texType   = AssetTextureType_U8;
+  const AssetTextureChannels texChan   = tga_texture_channels(ch);
+  const u32                  texLayers = 1;
+  const u32                  texMips   = 1;
+  const usize size  = asset_texture_req_size(texType, texChan, w, h, texLayers, texMips);
+  const usize align = asset_texture_req_align(texType, texChan);
+  return alloc_alloc(alloc, size, align);
+}
+
+static void tga_pixels_copy_at(
+    const Mem         pixels /* AssetTexturePixelB1* or AssetTexturePixelB4* */,
+    const TgaChannels channels,
+    const usize       dst,
+    const usize       src) {
+  switch (channels) {
+  case TgaChannels_R: {
+    AssetTexturePixelB1* pixelsB1 = (AssetTexturePixelB1*)pixels.ptr;
+    pixelsB1[dst]                 = pixelsB1[src];
+  } break;
+  case TgaChannels_RGB:
+  case TgaChannels_RGBA: {
+    AssetTexturePixelB4* pixelsB4 = (AssetTexturePixelB4*)pixels.ptr;
+    pixelsB4[dst]                 = pixelsB4[src];
+  } break;
   default:
     UNREACHABLE
   }
 }
 
-INLINE_HINT static void tga_mem_consume_inplace(Mem* mem, const usize amount) {
-  mem->ptr = bits_ptr_offset(mem->ptr, amount);
-  mem->size -= amount;
+static void tga_pixels_read_at(
+    const Mem         pixels /* AssetTexturePixelB1* or AssetTexturePixelB4* */,
+    const TgaChannels channels,
+    const u8*         data,
+    const usize       index) {
+
+  /**
+   * Follows the same to RGBA conversion rules as the Vulkan spec:
+   * https://registry.khronos.org/vulkan/specs/1.0/html/chap16.html#textures-conversion-to-rgba
+   */
+
+  switch (channels) {
+  case TgaChannels_R: {
+    AssetTexturePixelB1* outPixelB1 = (AssetTexturePixelB1*)pixels.ptr + index;
+    outPixelB1->r                   = data[0];
+  } break;
+  case TgaChannels_RGB: {
+    AssetTexturePixelB4* outPixelB4 = (AssetTexturePixelB4*)pixels.ptr + index;
+    outPixelB4->b                   = data[0];
+    outPixelB4->g                   = data[1];
+    outPixelB4->r                   = data[2];
+    outPixelB4->a                   = 255;
+  } break;
+  case TgaChannels_RGBA: {
+    AssetTexturePixelB4* outPixelB4 = (AssetTexturePixelB4*)pixels.ptr + index;
+    outPixelB4->b                   = data[0];
+    outPixelB4->g                   = data[1];
+    outPixelB4->r                   = data[2];
+    outPixelB4->a                   = data[3];
+  } break;
+  default:
+    UNREACHABLE
+  }
 }
 
-static Mem tga_read_pixels_uncompressed(
-    Mem                  input,
-    const u32            width,
-    const u32            height,
-    const TgaChannels    channels,
-    const TgaFlags       flags,
-    AssetTexturePixelB4* out,
-    TgaError*            err) {
+static Mem tga_pixels_read_uncompressed(
+    const Mem         pixels /* AssetTexturePixelB1* or AssetTexturePixelB4* */,
+    const TgaChannels channels,
+    const TgaFlags    flags,
+    const u32         width,
+    const u32         height,
+    const Mem         input,
+    TgaError*         err) {
 
   const u32 pixelCount = width * height;
 
@@ -228,7 +293,7 @@ static Mem tga_read_pixels_uncompressed(
   u8* src = mem_begin(input);
   for (u32 y = 0; y != height; ++y) {
     for (u32 x = 0; x != width; ++x) {
-      tga_read_pixel_unchecked(src, channels, &out[tga_index(x, y, width, height, flags)]);
+      tga_pixels_read_at(pixels, channels, src, tga_index(x, y, width, height, flags));
       src += channels;
     }
   }
@@ -236,14 +301,14 @@ static Mem tga_read_pixels_uncompressed(
   return mem_consume(input, pixelCount * channels);
 }
 
-static Mem tga_read_pixels_rle(
-    Mem                  input,
-    const u32            width,
-    const u32            height,
-    const TgaChannels    channels,
-    const TgaFlags       flags,
-    AssetTexturePixelB4* out,
-    TgaError*            err) {
+static Mem tga_pixels_read_rle(
+    const Mem         pixels /* AssetTexturePixelB1* or AssetTexturePixelB4* */,
+    const TgaChannels channels,
+    const TgaFlags    flags,
+    const u32         width,
+    const u32         height,
+    Mem               input,
+    TgaError*         err) {
 
   u32 packetRem      = 0; // How many pixels are left in the current rle packet.
   u32 packetRefPixel = u32_max;
@@ -282,10 +347,10 @@ static Mem tga_read_pixels_rle(
 
       if (packetRefPixel < i) {
         // There is a reference pixel; Use that instead of reading a new one.
-        out[i] = out[packetRefPixel];
+        tga_pixels_copy_at(pixels, channels, i, packetRefPixel);
       } else {
         // No reference pixel; Read a new pixel value.
-        tga_read_pixel_unchecked(mem_begin(input), channels, &out[i]);
+        tga_pixels_read_at(pixels, channels, mem_begin(input), i);
         tga_mem_consume_inplace(&input, channels);
       }
     }
@@ -294,34 +359,24 @@ static Mem tga_read_pixels_rle(
   return input;
 }
 
-static Mem tga_read_pixels(
-    Mem                  input,
-    const u32            width,
-    const u32            height,
-    const TgaChannels    channels,
-    const TgaFlags       flags,
-    AssetTexturePixelB4* out,
-    TgaError*            err) {
+static Mem tga_pixels_read(
+    const Mem         pixels /* AssetTexturePixelB1* or AssetTexturePixelB4* */,
+    const TgaChannels channels,
+    const TgaFlags    flags,
+    const u32         width,
+    const u32         height,
+    const Mem         input,
+    TgaError*         err) {
 
   if (flags & TgaFlags_Rle) {
-    return tga_read_pixels_rle(input, width, height, channels, flags, out, err);
+    return tga_pixels_read_rle(pixels, channels, flags, width, height, input, err);
   }
-  return tga_read_pixels_uncompressed(input, width, height, channels, flags, out, err);
+  return tga_pixels_read_uncompressed(pixels, channels, flags, width, height, input, err);
 }
 
 static void tga_load_fail(EcsWorld* world, const EcsEntityId entity, const TgaError err) {
   log_e("Failed to parse Tga texture", log_param("error", fmt_text(tga_error_str(err))));
   ecs_world_add_empty_t(world, entity, AssetFailedComp);
-}
-
-static AssetTextureFlags tga_texture_flags(const bool isNormalmap) {
-  AssetTextureFlags flags = AssetTextureFlags_GenerateMipMaps;
-  if (isNormalmap) {
-    flags |= AssetTextureFlags_NormalMap;
-  } else {
-    flags |= AssetTextureFlags_Srgb;
-  }
-  return flags;
 }
 
 void asset_load_tga(EcsWorld* world, const String id, const EcsEntityId entity, AssetSource* src) {
@@ -381,13 +436,13 @@ void asset_load_tga(EcsWorld* world, const String id, const EcsEntityId entity, 
   }
   data = mem_consume(data, header.idLength); // Skip over the id field.
 
-  const u32            width  = header.imageSpec.width;
-  const u32            height = header.imageSpec.height;
-  AssetTexturePixelB4* pixels = alloc_array_t(g_alloc_heap, AssetTexturePixelB4, width * height);
-  data                        = tga_read_pixels(data, width, height, channels, flags, pixels, &res);
+  const u32 width  = header.imageSpec.width;
+  const u32 height = header.imageSpec.height;
+  const Mem pixels = tga_pixels_alloc(g_alloc_heap, channels, width, height);
+  data             = tga_pixels_read(pixels, channels, flags, width, height, data, &res);
   if (res) {
     tga_load_fail(world, entity, res);
-    alloc_free_array_t(g_alloc_heap, pixels, width * height);
+    alloc_free(g_alloc_heap, pixels);
     goto Error;
   }
 
@@ -397,11 +452,11 @@ void asset_load_tga(EcsWorld* world, const String id, const EcsEntityId entity, 
       entity,
       AssetTextureComp,
       .type         = AssetTextureType_U8,
-      .channels     = AssetTextureChannels_Four,
+      .channels     = tga_texture_channels(channels),
       .flags        = tga_texture_flags(isNormalmap),
       .width        = width,
       .height       = height,
-      .pixelsB4     = pixels,
+      .pixelsRaw    = pixels.ptr,
       .layers       = 1,
       .srcMipLevels = 1);
   ecs_world_add_empty_t(world, entity, AssetLoadedComp);

--- a/libs/rend/src/rvk/attach.c
+++ b/libs/rend/src/rvk/attach.c
@@ -18,7 +18,8 @@ ASSERT((rvk_attach_max_images % 8) == 0, "Maximum images needs to be a multiple 
  * Capabilities that all attachments will have.
  * TODO: Investigate if these have any (serious) performance impact.
  */
-static const RvkImageCapability g_attachDefaultCapabilities = RvkImageCapability_TransferDest;
+static const RvkImageCapability g_attachDefaultCapabilities =
+    RvkImageCapability_TransferDest | RvkImageCapability_BlitDest;
 
 typedef u32 RvkAttachIndex;
 

--- a/libs/rend/src/rvk/image.c
+++ b/libs/rend/src/rvk/image.c
@@ -551,9 +551,9 @@ void rvk_image_generate_mipmaps(RvkImage* img, VkCommandBuffer vkCmdBuf) {
     return;
   }
 
-  static const RvkImageCapability g_requiredCaps = RvkImageCapability_TransferSource |
-                                                   RvkImageCapability_TransferDest |
-                                                   RvkImageCapability_BlitDest;
+  MAYBE_UNUSED static const RvkImageCapability g_requiredCaps = RvkImageCapability_TransferSource |
+                                                                RvkImageCapability_TransferDest |
+                                                                RvkImageCapability_BlitDest;
 
   diag_assert((g_requiredCaps & img->caps) == g_requiredCaps);
   diag_assert(img->type == RvkImageType_ColorSource || img->type == RvkImageType_ColorSourceCube);
@@ -635,7 +635,7 @@ void rvk_image_clear_color(const RvkImage* img, const GeoColor color, VkCommandB
 
   const VkClearColorValue       clearColor = rvk_rend_clear_color(color);
   const VkImageSubresourceRange ranges[]   = {
-      {
+        {
             .aspectMask     = rvk_image_vkaspect(img->type),
             .baseMipLevel   = 0,
             .levelCount     = img->mipLevels,
@@ -658,7 +658,7 @@ void rvk_image_clear_depth(const RvkImage* img, const f32 depth, VkCommandBuffer
 
   const VkClearDepthStencilValue clearValue = {.depth = depth};
   const VkImageSubresourceRange  ranges[]   = {
-      {
+         {
              .aspectMask     = rvk_image_vkaspect(img->type),
              .baseMipLevel   = 0,
              .levelCount     = img->mipLevels,

--- a/libs/rend/src/rvk/image.c
+++ b/libs/rend/src/rvk/image.c
@@ -178,6 +178,9 @@ static VkFormatFeatureFlags rvk_image_format_features(const RvkImageCapability c
   if (caps & RvkImageCapability_TransferDest) {
     formatFeatures |= VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
   }
+  if (caps & RvkImageCapability_BlitDest) {
+    formatFeatures |= VK_FORMAT_FEATURE_BLIT_DST_BIT;
+  }
   if (caps & RvkImageCapability_Sampled) {
     formatFeatures |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
   }
@@ -322,7 +325,9 @@ static RvkImage rvk_image_create_backed(
 
   const VkFormatFeatureFlags vkFormatFeatures = rvk_image_format_features(caps);
   if (UNLIKELY(!rvk_device_format_supported(dev, vkFormat, vkFormatFeatures))) {
-    diag_crash_msg("Image format {} unsupported", fmt_text(rvk_format_info(vkFormat).name));
+    diag_crash_msg(
+        "Image format {} does not support requested features",
+        fmt_text(rvk_format_info(vkFormat).name));
   }
   if (UNLIKELY(layers > dev->vkProperties.limits.maxImageArrayLayers)) {
     diag_crash_msg("Image layer count {} unsupported", fmt_int(layers));
@@ -364,7 +369,7 @@ RvkImage rvk_image_create_source_color(
     const u8       mipLevels) {
   RvkImageCapability caps = RvkImageCapability_Sampled | RvkImageCapability_TransferDest;
   if (mipLevels > 1) {
-    caps |= RvkImageCapability_TransferSource;
+    caps |= RvkImageCapability_TransferSource | RvkImageCapability_BlitDest;
   }
   return rvk_image_create_backed(
       dev, RvkImageType_ColorSource, caps, vkFormat, size, layers, mipLevels);
@@ -374,7 +379,7 @@ RvkImage rvk_image_create_source_color_cube(
     RvkDevice* dev, const VkFormat vkFormat, const RvkSize size, const u8 mipLevels) {
   RvkImageCapability caps = RvkImageCapability_Sampled | RvkImageCapability_TransferDest;
   if (mipLevels > 1) {
-    caps |= RvkImageCapability_TransferSource;
+    caps |= RvkImageCapability_TransferSource | RvkImageCapability_BlitDest;
   }
   const u8 layers = 6;
   return rvk_image_create_backed(
@@ -420,6 +425,7 @@ rvk_image_create_swapchain(RvkDevice* dev, VkImage vkImage, VkFormat vkFormat, c
    */
   capabilities |= RvkImageCapability_AttachmentColor;
   capabilities |= RvkImageCapability_TransferDest;
+  capabilities |= RvkImageCapability_BlitDest;
 
   const u8 layers    = 1;
   const u8 mipLevels = 1;
@@ -545,8 +551,11 @@ void rvk_image_generate_mipmaps(RvkImage* img, VkCommandBuffer vkCmdBuf) {
     return;
   }
 
-  diag_assert(img->caps & RvkImagePhase_TransferSource);
-  diag_assert(img->caps & RvkImagePhase_TransferDest);
+  static const RvkImageCapability g_requiredCaps = RvkImageCapability_TransferSource |
+                                                   RvkImageCapability_TransferDest |
+                                                   RvkImageCapability_BlitDest;
+
+  diag_assert((g_requiredCaps & img->caps) == g_requiredCaps);
   diag_assert(img->type == RvkImageType_ColorSource || img->type == RvkImageType_ColorSourceCube);
 
   /**
@@ -700,6 +709,7 @@ void rvk_image_blit(const RvkImage* src, RvkImage* dest, VkCommandBuffer vkCmdBu
   rvk_image_assert_phase(src, RvkImagePhase_TransferSource);
   rvk_image_assert_phase(dest, RvkImagePhase_TransferDest);
   diag_assert_msg(src->layers == dest->layers, "Image blit requires matching layer counts");
+  diag_assert_msg(dest->caps & RvkImageCapability_BlitDest, "Dest image does not support blitting");
 
   const VkImageBlit regions[] = {
       {

--- a/libs/rend/src/rvk/image_internal.h
+++ b/libs/rend/src/rvk/image_internal.h
@@ -35,10 +35,11 @@ typedef enum eRvkImageCapability {
   RvkImageCapability_None            = 0,
   RvkImageCapability_TransferSource  = 1 << 0,
   RvkImageCapability_TransferDest    = 1 << 1,
-  RvkImageCapability_Sampled         = 1 << 2,
-  RvkImageCapability_AttachmentColor = 1 << 3,
-  RvkImageCapability_AttachmentDepth = 1 << 4,
-  RvkImageCapability_Present         = 1 << 5,
+  RvkImageCapability_BlitDest        = 1 << 2,
+  RvkImageCapability_Sampled         = 1 << 3,
+  RvkImageCapability_AttachmentColor = 1 << 4,
+  RvkImageCapability_AttachmentDepth = 1 << 5,
+  RvkImageCapability_Present         = 1 << 6,
 } RvkImageCapability;
 
 typedef struct sRvkImage {


### PR DESCRIPTION
Now actually passed to the gpu as single-channel instead of widening to 4 channel.