### PR TITLE
geo: Increase nav region update queue size

### DIFF
--- a/libs/geo/src/nav.c
+++ b/libs/geo/src/nav.c
@@ -59,7 +59,7 @@ typedef enum {
 
 typedef struct {
   BitSet                   markedCells; // Marked cells already have their island updated.
-  GeoNavCell               queue[512];
+  GeoNavCell               queue[1024];
   u32                      queueStart;
   u32                      queueEnd;
   GeoNavIslandUpdaterFlags flags : 8;

--- a/libs/geo/src/nav.c
+++ b/libs/geo/src/nav.c
@@ -1061,7 +1061,7 @@ static NavIslandUpdateResult nav_island_update_tick(GeoNavGrid* grid) {
         continue;
       }
       if (u->currentIsland == geo_nav_island_max) {
-        log_e("Navigation island limit reached", log_param("limit", fmt_int(geo_nav_island_max)));
+        log_w("Navigation island limit reached", log_param("limit", fmt_int(geo_nav_island_max)));
         return NavIslandUpdate_Done;
       }
       const GeoNavCell cell = {.x = x, .y = u->currentRegionY};


### PR DESCRIPTION
512 was not enough for all situations.
Also change island limit reached to a warning as it can happen we deleting many blockers while the middle of updating the islands.