### PR TITLE
rend: Split instance draw filling

### DIFF
--- a/libs/rend/src/fog.c
+++ b/libs/rend/src/fog.c
@@ -135,5 +135,4 @@ ecs_module_init(rend_fog_module) {
 }
 
 const GeoMatrix* rend_fog_trans(const RendFogComp* fog) { return &fog->transMatrix; }
-
 const GeoMatrix* rend_fog_proj(const RendFogComp* fog) { return &fog->projMatrix; }

--- a/libs/rend/src/instance.c
+++ b/libs/rend/src/instance.c
@@ -77,11 +77,12 @@ ecs_view_define(GlobalView) { ecs_access_read(SceneVisibilityEnvComp); }
 ecs_view_define(RenderableView) {
   ecs_access_read(SceneRenderableComp);
   ecs_access_read(SceneBoundsComp);
-  ecs_access_read(SceneSkeletonComp);
+  ecs_access_with(SceneSkeletonLoadedComp); // Wait until the skeleton is available (if applicable).
 
   ecs_access_maybe_read(SceneScaleComp);
   ecs_access_maybe_read(SceneTagComp);
   ecs_access_maybe_read(SceneTransformComp);
+  ecs_access_maybe_read(SceneSkeletonComp);
   ecs_access_maybe_read(SceneVisibilityComp);
 }
 
@@ -121,7 +122,7 @@ ecs_system_define(RendInstanceFillDrawsSys) {
     const SceneScaleComp*     scaleComp     = ecs_view_read_t(itr, SceneScaleComp);
     const SceneBoundsComp*    boundsComp    = ecs_view_read_t(itr, SceneBoundsComp);
     const SceneSkeletonComp*  skeletonComp  = ecs_view_read_t(itr, SceneSkeletonComp);
-    const bool                isSkinned     = skeletonComp->jointCount != 0;
+    const bool                isSkinned     = skeletonComp != null;
 
     SceneTags tags = tagComp ? tagComp->tags : SceneTags_Default;
     if (renderable->color.a < 1.0f) {

--- a/libs/rend/src/instance.c
+++ b/libs/rend/src/instance.c
@@ -47,6 +47,10 @@ typedef struct {
 ASSERT(sizeof(RendInstanceSkinnedData) == 3648, "Size needs to match the size defined in glsl");
 ASSERT(alignof(RendInstanceSkinnedData) == 16, "Alignment needs to match the glsl alignment");
 
+ecs_comp_define(RendInstanceDrawComp);
+
+ecs_view_define(GlobalView) { ecs_access_read(SceneVisibilityEnvComp); }
+
 /**
  * Convert the given 4x4 matrix to a 4x3 matrix (dropping the last row) and then transpose to a 3x4.
  * Reason for transposing is that it avoids needing padding between the columns.
@@ -70,19 +74,28 @@ static u32 rend_color_pack(const GeoColor color) {
   return r | (g << 8) | (b << 16) | (a << 24);
 }
 
-ecs_comp_define(RendInstanceDrawComp);
+static SceneTags rend_tags(const SceneTagComp* tagComp, const SceneRenderableComp* renderable) {
+  SceneTags tags = tagComp ? tagComp->tags : SceneTags_Default;
+  if (renderable->color.a < 1.0f) {
+    tags |= SceneTags_Transparent;
+  }
+  return tags;
+}
 
-ecs_view_define(GlobalView) { ecs_access_read(SceneVisibilityEnvComp); }
+static void rend_draw_init(EcsWorld* w, const SceneRenderableComp* r, const RendDrawFlags flags) {
+  RendDrawComp* draw = rend_draw_create(w, r->graphic, flags);
+  rend_draw_set_resource(draw, RendDrawResource_Graphic, r->graphic);
+}
 
 ecs_view_define(RenderableView) {
   ecs_access_read(SceneRenderableComp);
   ecs_access_read(SceneBoundsComp);
-  ecs_access_with(SceneSkeletonLoadedComp); // Wait until the skeleton is available (if applicable).
+  ecs_access_with(SceneSkeletonLoadedComp); // Wait until we know the entity is not skinned.
+  ecs_access_without(SceneSkeletonComp);
 
   ecs_access_maybe_read(SceneScaleComp);
   ecs_access_maybe_read(SceneTagComp);
   ecs_access_maybe_read(SceneTransformComp);
-  ecs_access_maybe_read(SceneSkeletonComp);
   ecs_access_maybe_read(SceneVisibilityComp);
 }
 
@@ -90,7 +103,6 @@ ecs_view_define(DrawView) {
   ecs_view_flags(EcsViewFlags_Exclusive); // Only access the draw's we create.
 
   ecs_access_write(RendDrawComp);
-  ecs_access_maybe_read(SceneSkeletonTemplComp);
 }
 
 ecs_system_define(RendInstanceFillDrawsSys) {
@@ -121,71 +133,133 @@ ecs_system_define(RendInstanceFillDrawsSys) {
     const SceneTransformComp* transformComp = ecs_view_read_t(itr, SceneTransformComp);
     const SceneScaleComp*     scaleComp     = ecs_view_read_t(itr, SceneScaleComp);
     const SceneBoundsComp*    boundsComp    = ecs_view_read_t(itr, SceneBoundsComp);
-    const SceneSkeletonComp*  skeletonComp  = ecs_view_read_t(itr, SceneSkeletonComp);
-    const bool                isSkinned     = skeletonComp != null;
-
-    SceneTags tags = tagComp ? tagComp->tags : SceneTags_Default;
-    if (renderable->color.a < 1.0f) {
-      tags |= SceneTags_Transparent;
-    }
 
     if (UNLIKELY(!ecs_world_has_t(world, renderable->graphic, RendDrawComp))) {
-      if (++createdDraws > rend_instance_max_draw_create_per_task) {
-        continue; // Limit the amount of new draws to create per frame.
+      if (++createdDraws <= rend_instance_max_draw_create_per_task) { // Limit new draws per frame.
+        rend_draw_init(world, renderable, RendDrawFlags_StandardGeometry);
       }
-      const RendDrawFlags flags = isSkinned ? RendDrawFlags_StandardGeometry | RendDrawFlags_Skinned
-                                            : RendDrawFlags_StandardGeometry;
-      RendDrawComp*       draw  = rend_draw_create(world, renderable->graphic, flags);
-      rend_draw_set_resource(draw, RendDrawResource_Graphic, renderable->graphic);
       continue;
     }
 
     ecs_view_jump(drawItr, renderable->graphic);
     RendDrawComp* draw = ecs_view_write_t(drawItr, RendDrawComp);
 
+    const SceneTags tags     = rend_tags(tagComp, renderable);
     const GeoVector position = transformComp ? transformComp->position : geo_vector(0);
     const GeoQuat   rotation = transformComp ? transformComp->rotation : geo_quat_ident;
     const f32       scale    = scaleComp ? scaleComp->scale : 1.0f;
     const GeoBox    aabb     = scene_bounds_world(boundsComp, transformComp, scaleComp);
 
-    if (isSkinned) {
-      const SceneSkeletonTemplComp* templ = ecs_view_read_t(drawItr, SceneSkeletonTemplComp);
-      if (LIKELY(templ)) {
-        GeoMatrix jointDeltas[scene_skeleton_joints_max];
-        scene_skeleton_delta(skeletonComp, templ, jointDeltas);
+    RendInstanceData* data = rend_draw_add_instance_t(draw, RendInstanceData, tags, aabb);
+    data->posAndScale      = geo_vector(position.x, position.y, position.z, scale);
+    data->rot              = rotation;
+    data->tags             = (u32)tags;
+    data->color            = rend_color_pack(renderable->color);
+    data->emissive         = renderable->emissive;
+  }
+}
 
-        RendInstanceSkinnedData* data =
-            rend_draw_add_instance_t(draw, RendInstanceSkinnedData, tags, aabb);
-        data->posAndScale = geo_vector(position.x, position.y, position.z, scale);
-        data->rot         = rotation;
-        data->tags        = (u32)tags;
-        data->color       = rend_color_pack(renderable->color);
-        data->emissive    = renderable->emissive;
-        for (u32 i = 0; i != skeletonComp->jointCount; ++i) {
-          data->jointDelta[i] = rend_transpose_to_3x4(&jointDeltas[i]);
-        }
+ecs_view_define(RenderableSkinnedView) {
+  ecs_access_read(SceneRenderableComp);
+  ecs_access_read(SceneBoundsComp);
+  ecs_access_read(SceneSkeletonComp);
+  ecs_access_with(SceneSkeletonLoadedComp);
+
+  ecs_access_maybe_read(SceneScaleComp);
+  ecs_access_maybe_read(SceneTagComp);
+  ecs_access_maybe_read(SceneTransformComp);
+  ecs_access_maybe_read(SceneVisibilityComp);
+}
+
+ecs_view_define(DrawSkinnedView) {
+  ecs_view_flags(EcsViewFlags_Exclusive); // Only access the draw's we create.
+
+  ecs_access_write(RendDrawComp);
+  ecs_access_maybe_read(SceneSkeletonTemplComp);
+}
+
+ecs_system_define(RendInstanceSkinnedFillDrawsSys) {
+  EcsView*     globalView = ecs_world_view_t(world, GlobalView);
+  EcsIterator* globalItr  = ecs_view_maybe_at(globalView, ecs_world_global(world));
+  if (!globalItr) {
+    return; // Global dependencies not yet available.
+  }
+  const SceneVisibilityEnvComp* visEnv = ecs_view_read_t(globalItr, SceneVisibilityEnvComp);
+
+  EcsView* renderables = ecs_world_view_t(world, RenderableSkinnedView);
+  EcsView* drawView    = ecs_world_view_t(world, DrawSkinnedView);
+
+  u32 createdDraws = 0;
+
+  EcsIterator* drawItr = ecs_view_itr(drawView);
+  for (EcsIterator* itr = ecs_view_itr(renderables); ecs_view_walk(itr);) {
+    const SceneRenderableComp* renderable = ecs_view_read_t(itr, SceneRenderableComp);
+    if (renderable->color.a <= f32_epsilon) {
+      continue;
+    }
+    const SceneVisibilityComp* visComp = ecs_view_read_t(itr, SceneVisibilityComp);
+    if (visComp && !scene_visible_for_render(visEnv, visComp)) {
+      continue;
+    }
+
+    const SceneTagComp*       tagComp       = ecs_view_read_t(itr, SceneTagComp);
+    const SceneTransformComp* transformComp = ecs_view_read_t(itr, SceneTransformComp);
+    const SceneScaleComp*     scaleComp     = ecs_view_read_t(itr, SceneScaleComp);
+    const SceneBoundsComp*    boundsComp    = ecs_view_read_t(itr, SceneBoundsComp);
+    const SceneSkeletonComp*  skeletonComp  = ecs_view_read_t(itr, SceneSkeletonComp);
+
+    if (UNLIKELY(!ecs_world_has_t(world, renderable->graphic, RendDrawComp))) {
+      if (++createdDraws <= rend_instance_max_draw_create_per_task) { // Limit new draws per frame.
+        rend_draw_init(world, renderable, RendDrawFlags_StandardGeometry | RendDrawFlags_Skinned);
       }
-    } else /* !isSkinned */ {
-      RendInstanceData* data = rend_draw_add_instance_t(draw, RendInstanceData, tags, aabb);
-      data->posAndScale      = geo_vector(position.x, position.y, position.z, scale);
-      data->rot              = rotation;
-      data->tags             = (u32)tags;
-      data->color            = rend_color_pack(renderable->color);
-      data->emissive         = renderable->emissive;
+      continue;
+    }
+
+    ecs_view_jump(drawItr, renderable->graphic);
+    RendDrawComp* draw = ecs_view_write_t(drawItr, RendDrawComp);
+
+    const SceneTags tags     = rend_tags(tagComp, renderable);
+    const GeoVector position = transformComp ? transformComp->position : geo_vector(0);
+    const GeoQuat   rotation = transformComp ? transformComp->rotation : geo_quat_ident;
+    const f32       scale    = scaleComp ? scaleComp->scale : 1.0f;
+    const GeoBox    aabb     = scene_bounds_world(boundsComp, transformComp, scaleComp);
+
+    const SceneSkeletonTemplComp* templ = ecs_view_read_t(drawItr, SceneSkeletonTemplComp);
+    if (UNLIKELY(!templ)) {
+      continue; // Template no longer available; possible when hot-loading the graphic.
+    }
+
+    GeoMatrix jointDeltas[scene_skeleton_joints_max];
+    scene_skeleton_delta(skeletonComp, templ, jointDeltas);
+
+    RendInstanceSkinnedData* data =
+        rend_draw_add_instance_t(draw, RendInstanceSkinnedData, tags, aabb);
+    data->posAndScale = geo_vector(position.x, position.y, position.z, scale);
+    data->rot         = rotation;
+    data->tags        = (u32)tags;
+    data->color       = rend_color_pack(renderable->color);
+    data->emissive    = renderable->emissive;
+    for (u32 i = 0; i != skeletonComp->jointCount; ++i) {
+      data->jointDelta[i] = rend_transpose_to_3x4(&jointDeltas[i]);
     }
   }
 }
 
 ecs_module_init(rend_instance_module) {
   ecs_register_view(GlobalView);
-  ecs_register_view(RenderableView);
-  ecs_register_view(DrawView);
 
   ecs_register_system(
       RendInstanceFillDrawsSys,
       ecs_view_id(GlobalView),
-      ecs_view_id(RenderableView),
-      ecs_view_id(DrawView));
+      ecs_register_view(RenderableView),
+      ecs_register_view(DrawView));
+
+  ecs_register_system(
+      RendInstanceSkinnedFillDrawsSys,
+      ecs_view_id(GlobalView),
+      ecs_register_view(RenderableSkinnedView),
+      ecs_register_view(DrawSkinnedView));
 
   ecs_order(RendInstanceFillDrawsSys, RendOrder_DrawCollect);
+  ecs_order(RendInstanceSkinnedFillDrawsSys, RendOrder_DrawCollect);
 }

--- a/libs/scene/include/scene_skeleton.h
+++ b/libs/scene/include/scene_skeleton.h
@@ -12,7 +12,8 @@ typedef struct {
   u8 jointBits[scene_skeleton_joints_max / 8 + 1];
 } SceneSkeletonMask;
 
-ecs_comp_extern(SceneSkeletonTemplComp);
+ecs_comp_extern(SceneSkeletonTemplComp);  // Skeleton template, present on graphic entities.
+ecs_comp_extern(SceneSkeletonLoadedComp); // Indicates that the skeleton was loaded (if applicable).
 
 ecs_comp_extern_public(SceneSkeletonComp) {
   GeoMatrix* jointTransforms;


### PR DESCRIPTION
Allows skinned and non-skinned entities to be filled in parallel.