### PR TITLE
core: Refactor SIMD enable / disable defines

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -42,21 +42,21 @@ endmacro(set_generic_defines)
 # Set gcc specific defines
 #
 macro(set_gcc_defines)
-  add_definitions(-DVOLO_GCC)
+  add_definitions(-DVOLO_GCC -DVOLO_SIMD)
 endmacro(set_gcc_defines)
 
 #
 # Set clang specific defines
 #
 macro(set_clang_defines)
-  add_definitions(-DVOLO_CLANG)
+  add_definitions(-DVOLO_CLANG -DVOLO_SIMD)
 endmacro(set_clang_defines)
 
 #
 # Set msvc specific defines
 #
 macro(set_msvc_defines)
-  add_definitions(-DVOLO_MSVC)
+  add_definitions(-DVOLO_MSVC -DVOLO_SIMD)
 endmacro(set_msvc_defines)
 
 #

--- a/libs/core/include/core_annotation.h
+++ b/libs/core/include/core_annotation.h
@@ -44,7 +44,7 @@
 #elif defined(VOLO_MSVC)
 #define UNREACHABLE __assume(false);
 #else
-ASSERT(false, "Unsupported compiler");
+#error Unsupported compiler
 #endif
 
 /**
@@ -107,7 +107,7 @@ ASSERT(false, "Unsupported compiler");
 #elif defined(VOLO_MSVC)
 #define COMPILER_BARRIER(void) _ReadWriteBarrier()
 #else
-ASSERT(false, "Unsupported compiler");
+#error Unsupported compiler
 #endif
 
 /**
@@ -119,7 +119,7 @@ ASSERT(false, "Unsupported compiler");
 #elif defined(VOLO_MSVC)
 #define THREAD_LOCAL __declspec(thread)
 #else
-ASSERT(false, "Unsupported compiler");
+#error Unsupported compiler
 #endif
 
 /**
@@ -131,7 +131,7 @@ ASSERT(false, "Unsupported compiler");
 #elif defined(VOLO_MSVC)
 #define PARAM_ARRAY_SIZE(_SIZE_) _SIZE_
 #else
-ASSERT(false, "Unsupported compiler");
+#error Unsupported compiler
 #endif
 
 /**

--- a/libs/core/include/core_simd.h
+++ b/libs/core/include/core_simd.h
@@ -3,6 +3,10 @@
 #include "core_intrinsic.h"
 #include "core_types.h"
 
+#ifndef VOLO_SIMD
+#error SIMD support not enabled
+#endif
+
 /**
  * SIMD vector utilities using SSE, SSE2 and SSE3, SSE4 and SSE4.1 instructions.
  * https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html

--- a/libs/core/src/alloc_page_pal.c
+++ b/libs/core/src/alloc_page_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "alloc_page_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "alloc_page_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/diag_pal.c
+++ b/libs/core/src/diag_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "diag_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "diag_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/dynlib_pal.c
+++ b/libs/core/src/dynlib_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "dynlib_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "dynlib_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/env_pal.c
+++ b/libs/core/src/env_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "env_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "env_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/file_internal.h
+++ b/libs/core/src/file_internal.h
@@ -6,7 +6,7 @@ typedef int FileHandle;
 #elif defined(VOLO_WIN32)
 typedef void* FileHandle;
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif
 
 struct sFile {

--- a/libs/core/src/file_iterator_pal.c
+++ b/libs/core/src/file_iterator_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "file_iterator_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "file_iterator_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/file_monitor_pal.c
+++ b/libs/core/src/file_monitor_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "file_monitor_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "file_monitor_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/file_pal.c
+++ b/libs/core/src/file_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "file_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "file_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/path_pal.c
+++ b/libs/core/src/path_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "path_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "path_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/process_pal.c
+++ b/libs/core/src/process_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "process_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "process_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/signal_pal.c
+++ b/libs/core/src/signal_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "signal_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "signal_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/symbol_pal.c
+++ b/libs/core/src/symbol_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "symbol_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "symbol_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/thread_internal.h
+++ b/libs/core/src/thread_internal.h
@@ -8,7 +8,7 @@
 #elif defined(VOLO_WIN32)
 #define thread_pal_rettype unsigned long
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif
 
 void thread_pal_init(void);

--- a/libs/core/src/thread_pal.c
+++ b/libs/core/src/thread_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "thread_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "thread_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/time_pal.c
+++ b/libs/core/src/time_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "time_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "time_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/src/tty_pal.c
+++ b/libs/core/src/tty_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "tty_pal_linux.c"
 #elif defined(VOLO_WIN32)
 #include "tty_pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/core/test/config.c
+++ b/libs/core/test/config.c
@@ -32,7 +32,6 @@ void app_check_configure(CheckDef* check) {
   register_spec(check, rng);
   register_spec(check, search);
   register_spec(check, shuffle);
-  register_spec(check, simd);
   register_spec(check, sort);
   register_spec(check, string);
   register_spec(check, stringtable);
@@ -42,4 +41,8 @@ void app_check_configure(CheckDef* check) {
   register_spec(check, unicode);
   register_spec(check, utf8);
   register_spec(check, winutils);
+
+#ifdef VOLO_SIMD
+  register_spec(check, simd);
+#endif
 }

--- a/libs/core/test/test_simd.c
+++ b/libs/core/test/test_simd.c
@@ -1,6 +1,8 @@
 #include "check_spec.h"
 #include "core_array.h"
 #include "core_float.h"
+
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 
 spec(simd) {
@@ -38,3 +40,4 @@ spec(simd) {
     }
   }
 }
+#endif

--- a/libs/gap/src/pal.c
+++ b/libs/gap/src/pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "pal_linux_xcb.c"
 #elif defined(VOLO_WIN32)
 #include "pal_win32.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/geo/src/box.c
+++ b/libs/geo/src/box.c
@@ -4,9 +4,7 @@
 #include "geo_box.h"
 #include "geo_sphere.h"
 
-#define geo_box_simd_enable 1
-
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -16,7 +14,7 @@ geo_rotate_around(const GeoVector point, const GeoQuat rot, const GeoVector v) {
 }
 
 GeoVector geo_box_center(const GeoBox* b) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec min  = simd_vec_load(b->min.comps);
   const SimdVec max  = simd_vec_load(b->max.comps);
   const SimdVec half = simd_vec_broadcast(0.5f);
@@ -30,7 +28,7 @@ GeoVector geo_box_center(const GeoBox* b) {
 }
 
 GeoVector geo_box_size(const GeoBox* b) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec min = simd_vec_load(b->min.comps);
   const SimdVec max = simd_vec_load(b->max.comps);
   GeoVector     res;
@@ -42,7 +40,7 @@ GeoVector geo_box_size(const GeoBox* b) {
 }
 
 GeoVector geo_box_closest_point(const GeoBox* b, const GeoVector point) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec min      = simd_vec_load(b->min.comps);
   const SimdVec max      = simd_vec_load(b->max.comps);
   const SimdVec pointVec = simd_vec_load(point.comps);
@@ -58,7 +56,7 @@ GeoVector geo_box_closest_point(const GeoBox* b, const GeoVector point) {
 }
 
 GeoBox geo_box_from_center(const GeoVector center, const GeoVector size) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec centerVec = simd_vec_load(center.comps);
   const SimdVec sizeVec   = simd_vec_load(size.comps);
   const SimdVec halfSize  = simd_vec_mul(sizeVec, simd_vec_broadcast(0.5f));
@@ -91,7 +89,7 @@ GeoBox geo_box_inverted3(void) {
 bool geo_box_is_inverted2(const GeoBox* b) { return b->min.x > b->max.x || b->min.y > b->max.y; }
 
 bool geo_box_is_inverted3(const GeoBox* b) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec min = simd_vec_load(b->min.comps);
   const SimdVec max = simd_vec_load(b->max.comps);
   // NOTE: The non-simd impl doesn't take the w into account, is it worth ignoring it here also?
@@ -115,7 +113,7 @@ GeoBox geo_box_encapsulate2(const GeoBox* b, const GeoVector point) {
 }
 
 GeoBox geo_box_encapsulate(const GeoBox* b, const GeoVector point) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec p   = simd_vec_load(point.comps);
   const SimdVec min = simd_vec_min(simd_vec_load(b->min.comps), p);
   const SimdVec max = simd_vec_max(simd_vec_load(b->max.comps), p);
@@ -133,7 +131,7 @@ GeoBox geo_box_encapsulate(const GeoBox* b, const GeoVector point) {
 }
 
 GeoBox geo_box_dilate(const GeoBox* b, const GeoVector size) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec min     = simd_vec_load(b->min.comps);
   const SimdVec max     = simd_vec_load(b->max.comps);
   const SimdVec sizeVec = simd_vec_load(size.comps);
@@ -163,7 +161,7 @@ void geo_box_corners3(const GeoBox* box, GeoVector corners[PARAM_ARRAY_SIZE(8)])
 
 GeoBox
 geo_box_transform3(const GeoBox* box, const GeoVector pos, const GeoQuat rot, const f32 scale) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   SimdVec       min      = simd_vec_broadcast(f32_max);
   SimdVec       max      = simd_vec_broadcast(f32_min);
   const SimdVec posVec   = simd_vec_load(pos.comps);
@@ -207,7 +205,7 @@ geo_box_transform3(const GeoBox* box, const GeoVector pos, const GeoQuat rot, co
 }
 
 GeoBox geo_box_from_sphere(const GeoVector pos, const f32 radius) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vPos    = simd_vec_load(pos.comps);
   const SimdVec vRadius = simd_vec_clear_w(simd_vec_broadcast(radius));
   GeoBox        newBox;
@@ -223,7 +221,7 @@ GeoBox geo_box_from_sphere(const GeoVector pos, const f32 radius) {
 }
 
 GeoBox geo_box_from_rotated(const GeoBox* box, const GeoQuat rot) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   SimdVec       min     = simd_vec_broadcast(f32_max);
   SimdVec       max     = simd_vec_broadcast(f32_min);
   const SimdVec quatVec = simd_vec_load(rot.comps);
@@ -267,7 +265,7 @@ GeoBox geo_box_from_rotated(const GeoBox* box, const GeoQuat rot) {
 }
 
 GeoBox geo_box_from_capsule(const GeoVector a, const GeoVector b, const f32 radius) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vRadius = simd_vec_clear_w(simd_vec_broadcast(radius));
   const SimdVec vA      = simd_vec_load(a.comps);
   const SimdVec vAMin   = simd_vec_sub(vA, vRadius);
@@ -290,7 +288,7 @@ GeoBox geo_box_from_capsule(const GeoVector a, const GeoVector b, const f32 radi
 }
 
 GeoBox geo_box_from_cylinder(const GeoVector a, const GeoVector b, const f32 radius) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vA        = simd_vec_load(a.comps);
   const SimdVec vB        = simd_vec_load(b.comps);
   const SimdVec toB       = simd_vec_sub(vB, vA);
@@ -319,7 +317,7 @@ GeoBox geo_box_from_cylinder(const GeoVector a, const GeoVector b, const f32 rad
 }
 
 GeoBox geo_box_from_cone(const GeoVector bottom, const GeoVector top, const f32 radius) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vBottom   = simd_vec_load(bottom.comps);
   const SimdVec vTop      = simd_vec_load(top.comps);
   const SimdVec toTop     = simd_vec_sub(vTop, vBottom);
@@ -346,7 +344,7 @@ GeoBox geo_box_from_cone(const GeoVector bottom, const GeoVector top, const f32 
 }
 
 GeoBox geo_box_from_line(const GeoVector from, const GeoVector to) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec fromVec = simd_vec_load(from.comps);
   const SimdVec toVec   = simd_vec_load(to.comps);
 
@@ -364,7 +362,7 @@ GeoBox geo_box_from_line(const GeoVector from, const GeoVector to) {
 
 GeoBox
 geo_box_from_quad(const GeoVector center, const f32 sizeX, const f32 sizeY, const GeoQuat rot) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   SimdVec       min       = simd_vec_broadcast(f32_max);
   SimdVec       max       = simd_vec_broadcast(f32_min);
   const SimdVec centerVec = simd_vec_load(center.comps);
@@ -464,7 +462,7 @@ f32 geo_box_intersect_ray(const GeoBox* box, const GeoRay* ray, GeoVector* outNo
 }
 
 bool geo_box_overlap(const GeoBox* x, const GeoBox* y) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec xMin = simd_vec_load(x->min.comps);
   const SimdVec xMax = simd_vec_load(x->max.comps);
   const SimdVec yMin = simd_vec_load(y->min.comps);
@@ -484,7 +482,7 @@ bool geo_box_overlap_sphere(const GeoBox* box, const GeoSphere* sphere) {
 }
 
 bool geo_box_overlap_frustum4_approx(const GeoBox* box, const GeoPlane frustum[4]) {
-#if geo_box_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec boxMin = simd_vec_load(box->min.comps);
   const SimdVec boxMax = simd_vec_load(box->max.comps);
   if (simd_vec_mask_u32(simd_vec_greater(boxMin, boxMax)) != 0b0000) {

--- a/libs/geo/src/box_rotated.c
+++ b/libs/geo/src/box_rotated.c
@@ -5,9 +5,7 @@
 #include "geo_box_rotated.h"
 #include "geo_sphere.h"
 
-#define geo_box_rotated_simd_enable 1
-
-#if geo_box_rotated_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -71,7 +69,7 @@ static void geo_box_rotated_corners(const GeoBoxRotated* b, GeoVector out[8]) {
 
 GeoBoxRotated
 geo_box_rotated(const GeoBox* box, const GeoVector pos, const GeoQuat rot, const f32 scale) {
-#if geo_box_rotated_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec localMin  = simd_vec_load(box->min.comps);
   const SimdVec localMax  = simd_vec_load(box->max.comps);
   const SimdVec posVec    = simd_vec_load(pos.comps);
@@ -99,7 +97,7 @@ geo_box_rotated(const GeoBox* box, const GeoVector pos, const GeoQuat rot, const
 }
 
 GeoBoxRotated geo_box_rotated_dilate(const GeoBoxRotated* b, const GeoVector size) {
-#if geo_box_rotated_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec localMin = simd_vec_load(b->box.min.comps);
   const SimdVec localMax = simd_vec_load(b->box.max.comps);
   const SimdVec sizeVec  = simd_vec_load(size.comps);
@@ -141,7 +139,7 @@ geo_box_rotated_from_capsule(const GeoVector bottom, const GeoVector top, const 
 
 MAYBE_UNUSED static GeoVector
 geo_box_rotated_world_point(const GeoBoxRotated* box, const GeoVector localPoint) {
-#if geo_box_rotated_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec localPointVec = simd_vec_load(localPoint.comps);
   const SimdVec localMin      = simd_vec_load(box->box.min.comps);
   const SimdVec localMax      = simd_vec_load(box->box.max.comps);
@@ -161,7 +159,7 @@ geo_box_rotated_world_point(const GeoBoxRotated* box, const GeoVector localPoint
 }
 
 static GeoVector geo_box_rotated_local_point(const GeoBoxRotated* box, const GeoVector point) {
-#if geo_box_rotated_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec pointVec    = simd_vec_load(point.comps);
   const SimdVec localMin    = simd_vec_load(box->box.min.comps);
   const SimdVec localMax    = simd_vec_load(box->box.max.comps);
@@ -210,7 +208,7 @@ f32 geo_box_rotated_intersect_ray(
 }
 
 GeoVector geo_box_rotated_closest_point(const GeoBoxRotated* boxRotated, const GeoVector point) {
-#if geo_box_rotated_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec localMin    = simd_vec_load(boxRotated->box.min.comps);
   const SimdVec localMax    = simd_vec_load(boxRotated->box.max.comps);
   const SimdVec half        = simd_vec_broadcast(0.5f);

--- a/libs/geo/src/color.c
+++ b/libs/geo/src/color.c
@@ -6,9 +6,7 @@
 #include "core_math.h"
 #include "geo_color.h"
 
-#define geo_color_simd_enable 1
-
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -32,7 +30,7 @@ bool geo_color_equal(const GeoColor a, const GeoColor b, const f32 threshold) {
 }
 
 GeoColor geo_color_abs(const GeoColor c) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   GeoColor res;
   simd_vec_store(simd_vec_abs(simd_vec_load(c.data)), res.data);
   return res;
@@ -42,7 +40,7 @@ GeoColor geo_color_abs(const GeoColor c) {
 }
 
 GeoColor geo_color_add(const GeoColor a, const GeoColor b) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   GeoColor res;
   simd_vec_store(simd_vec_add(simd_vec_load(a.data), simd_vec_load(b.data)), res.data);
   return res;
@@ -52,7 +50,7 @@ GeoColor geo_color_add(const GeoColor a, const GeoColor b) {
 }
 
 GeoColor geo_color_sub(const GeoColor a, const GeoColor b) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   GeoColor res;
   simd_vec_store(simd_vec_sub(simd_vec_load(a.data), simd_vec_load(b.data)), res.data);
   return res;
@@ -62,7 +60,7 @@ GeoColor geo_color_sub(const GeoColor a, const GeoColor b) {
 }
 
 GeoColor geo_color_mul(const GeoColor c, const f32 scalar) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   GeoColor res;
   simd_vec_store(simd_vec_mul(simd_vec_load(c.data), simd_vec_broadcast(scalar)), res.data);
   return res;
@@ -72,7 +70,7 @@ GeoColor geo_color_mul(const GeoColor c, const f32 scalar) {
 }
 
 GeoColor geo_color_mul_comps(const GeoColor a, const GeoColor b) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   GeoColor res;
   simd_vec_store(simd_vec_mul(simd_vec_load(a.data), simd_vec_load(b.data)), res.data);
   return res;
@@ -82,7 +80,7 @@ GeoColor geo_color_mul_comps(const GeoColor a, const GeoColor b) {
 }
 
 GeoColor geo_color_div(const GeoColor c, const f32 scalar) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   GeoColor res;
   simd_vec_store(simd_vec_div(simd_vec_load(c.data), simd_vec_broadcast(scalar)), res.data);
   return res;
@@ -93,7 +91,7 @@ GeoColor geo_color_div(const GeoColor c, const f32 scalar) {
 }
 
 GeoColor geo_color_div_comps(const GeoColor a, const GeoColor b) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   GeoColor res;
   simd_vec_store(simd_vec_div(simd_vec_load(a.data), simd_vec_load(b.data)), res.data);
   return res;
@@ -103,7 +101,7 @@ GeoColor geo_color_div_comps(const GeoColor a, const GeoColor b) {
 }
 
 f32 geo_color_mag(const GeoColor c) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec tmp = simd_vec_load(c.data);
   const SimdVec dot = simd_vec_dot4(tmp, tmp);
   return simd_vec_x(dot) != 0 ? simd_vec_x(simd_vec_sqrt(dot)) : 0;
@@ -118,7 +116,7 @@ f32 geo_color_mag(const GeoColor c) {
 }
 
 GeoColor geo_color_lerp(const GeoColor x, const GeoColor y, const f32 t) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vX = simd_vec_load(x.data);
   const SimdVec vY = simd_vec_load(y.data);
   const SimdVec vT = simd_vec_broadcast(t);
@@ -141,7 +139,7 @@ GeoColor geo_color_bilerp(
     const GeoColor c4,
     const f32      tX,
     const f32      tY) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vec1  = simd_vec_load(c1.data);
   const SimdVec vec2  = simd_vec_load(c2.data);
   const SimdVec vec3  = simd_vec_load(c3.data);
@@ -159,7 +157,7 @@ GeoColor geo_color_bilerp(
 }
 
 GeoColor geo_color_min(const GeoColor x, const GeoColor y) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   GeoColor res;
   simd_vec_store(simd_vec_min(simd_vec_load(x.data), simd_vec_load(y.data)), res.data);
   return res;
@@ -174,7 +172,7 @@ GeoColor geo_color_min(const GeoColor x, const GeoColor y) {
 }
 
 GeoColor geo_color_max(const GeoColor x, const GeoColor y) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   GeoColor res;
   simd_vec_store(simd_vec_max(simd_vec_load(x.data), simd_vec_load(y.data)), res.data);
   return res;
@@ -200,7 +198,7 @@ GeoColor geo_color_clamp(const GeoColor c, const f32 maxMagnitude) {
 }
 
 GeoColor geo_color_clamp_comps(const GeoColor c, const GeoColor min, const GeoColor max) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   SimdVec vec = simd_vec_load(c.data);
   vec         = simd_vec_max(vec, simd_vec_load(min.data));
   vec         = simd_vec_min(vec, simd_vec_load(max.data));
@@ -226,7 +224,7 @@ GeoColor geo_color_linear_to_srgb(const GeoColor linear) {
  * Linear to srgb curve approximation.
  * Implementation based on: http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
  */
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vecLinear = simd_vec_load(linear.data);
   const SimdVec s1        = simd_vec_sqrt(vecLinear);
   const SimdVec s2        = simd_vec_sqrt(s1);
@@ -302,7 +300,7 @@ GeoColor geo_color_from_hsv(const f32 hue, const f32 saturation, const f32 value
 }
 
 void geo_color_pack_f16(const GeoColor color, f16 out[PARAM_ARRAY_SIZE(4)]) {
-#if geo_color_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vecF32 = simd_vec_load(color.data);
   SimdVec       vecF16;
   if (g_f16cSupport) {

--- a/libs/geo/src/matrix.c
+++ b/libs/geo/src/matrix.c
@@ -4,9 +4,7 @@
 #include "core_math.h"
 #include "geo_matrix.h"
 
-#define geo_matrix_simd_enable 1
-
-#if geo_matrix_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -55,7 +53,7 @@ GeoVector geo_matrix_row(const GeoMatrix* m, const usize index) {
 }
 
 GeoMatrix geo_matrix_mul(const GeoMatrix* a, const GeoMatrix* b) {
-#if geo_matrix_simd_enable
+#ifdef VOLO_SIMD
   GeoMatrix res;
 
   const SimdVec aCol0 = simd_vec_load(a->columns[0].comps);
@@ -137,7 +135,7 @@ GeoVector geo_matrix_transform3_point(const GeoMatrix* m, const GeoVector vec) {
 }
 
 GeoMatrix geo_matrix_transpose(const GeoMatrix* m) {
-#if geo_matrix_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec col0 = simd_vec_load(m->columns[0].comps);
   const SimdVec col1 = simd_vec_load(m->columns[1].comps);
   const SimdVec col2 = simd_vec_load(m->columns[2].comps);
@@ -353,7 +351,7 @@ GeoMatrix geo_matrix_rotate(const GeoVector right, const GeoVector up, const Geo
 }
 
 GeoMatrix geo_matrix_rotate_look(const GeoVector forward, const GeoVector upRef) {
-#if geo_matrix_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vForward       = simd_vec_load(forward.comps);
   const SimdVec vForwardSqrMag = simd_vec_dot3(vForward, vForward);
   if (UNLIKELY(simd_vec_x(vForwardSqrMag) <= f32_epsilon)) {
@@ -408,7 +406,7 @@ GeoMatrix geo_matrix_from_quat(const GeoQuat quat) {
  * [ 2xz + 2wy,       2yz - 2wx,      1 - 2x² - 2y², 0 ]
  * [ 0,               0,              0,             1 ]
  */
-#if geo_matrix_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec q  = simd_vec_load(quat.comps);
   const SimdVec q0 = simd_vec_add(q, q);
   SimdVec       q1 = simd_vec_mul(q, q0);
@@ -524,7 +522,7 @@ GeoQuat geo_matrix_to_quat(const GeoMatrix* m) {
 }
 
 GeoMatrix geo_matrix_trs(const GeoVector t, const GeoQuat r, const GeoVector s) {
-#if geo_matrix_simd_enable
+#ifdef VOLO_SIMD
   /**
    * Inlined geo_matrix_from_quat() with added scaling and translation.
    */

--- a/libs/geo/src/plane.c
+++ b/libs/geo/src/plane.c
@@ -2,9 +2,7 @@
 #include "core_math.h"
 #include "geo_plane.h"
 
-#define geo_plane_simd_enable 1
-
-#if geo_plane_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -19,7 +17,7 @@ GeoPlane geo_plane_at(const GeoVector normal, const GeoVector position) {
 }
 
 GeoPlane geo_plane_at_triangle(const GeoVector a, const GeoVector b, const GeoVector c) {
-#if geo_plane_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec aVec     = simd_vec_load(a.comps);
   const SimdVec bVec     = simd_vec_load(b.comps);
   const SimdVec cVec     = simd_vec_load(c.comps);

--- a/libs/geo/src/quat.c
+++ b/libs/geo/src/quat.c
@@ -6,9 +6,7 @@
 #include "geo_quat.h"
 #include "geo_vector.h"
 
-#define geo_quat_simd_enable 1
-
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -22,7 +20,7 @@ GeoQuat geo_quat_angle_axis(const f32 angle, const GeoVector axis) {
   assert_normalized(axis);
 #endif
 
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec angleVec     = simd_vec_broadcast(angle);
   const SimdVec angleHalfVec = simd_vec_mul(angleVec, simd_vec_broadcast(0.5f));
 
@@ -46,7 +44,7 @@ GeoQuat geo_quat_from_to(const GeoQuat from, const GeoQuat to) {
 }
 
 GeoQuat geo_quat_mul(const GeoQuat a, const GeoQuat b) {
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   GeoQuat res;
   simd_vec_store(simd_quat_mul(simd_vec_load(a.comps), simd_vec_load(b.comps)), res.comps);
   return res;
@@ -61,7 +59,7 @@ GeoQuat geo_quat_mul(const GeoQuat a, const GeoQuat b) {
 }
 
 GeoQuat geo_quat_mul_comps(const GeoQuat a, const GeoVector b) {
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   GeoQuat res;
   simd_vec_store(simd_vec_mul(simd_vec_load(a.comps), simd_vec_load(b.comps)), res.comps);
   return res;
@@ -76,7 +74,7 @@ GeoQuat geo_quat_mul_comps(const GeoQuat a, const GeoVector b) {
 }
 
 GeoVector geo_quat_rotate(const GeoQuat q, const GeoVector v) {
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_quat_rotate(simd_vec_load(q.comps), simd_vec_load(v.comps)), res.comps);
   return res;
@@ -93,7 +91,7 @@ GeoVector geo_quat_rotate(const GeoQuat q, const GeoVector v) {
 
 GeoQuat geo_quat_inverse(const GeoQuat q) {
   // Compute the conjugate ('transposing').
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   GeoQuat res;
   simd_vec_store(simd_quat_conjugate(simd_vec_load(q.comps)), res.comps);
   return res;
@@ -103,7 +101,7 @@ GeoQuat geo_quat_inverse(const GeoQuat q) {
 }
 
 GeoQuat geo_quat_flip(const GeoQuat q) {
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   GeoQuat res;
   simd_vec_store(simd_vec_mul(simd_vec_load(q.comps), simd_vec_broadcast(-1.0f)), res.comps);
   return res;
@@ -118,7 +116,7 @@ GeoQuat geo_quat_flip(const GeoQuat q) {
 }
 
 GeoQuat geo_quat_norm(const GeoQuat q) {
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   GeoQuat res;
   simd_vec_store(simd_quat_norm(simd_vec_load(q.comps)), res.comps);
   return res;
@@ -130,7 +128,7 @@ GeoQuat geo_quat_norm(const GeoQuat q) {
 }
 
 GeoQuat geo_quat_norm_or_ident(const GeoQuat q) {
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec qVec   = simd_vec_load(q.comps);
   const SimdVec magSqr = simd_vec_dot4(qVec, qVec);
   if (simd_vec_x(magSqr) < f32_epsilon) {
@@ -151,7 +149,7 @@ GeoQuat geo_quat_norm_or_ident(const GeoQuat q) {
 }
 
 f32 geo_quat_dot(const GeoQuat a, const GeoQuat b) {
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   return simd_vec_x(simd_vec_dot4(simd_vec_load(a.comps), simd_vec_load(b.comps)));
 #else
   f32 res = 0;
@@ -177,7 +175,7 @@ GeoQuat geo_quat_slerp(const GeoQuat a, const GeoQuat b, const f32 t) {
    * https://zeux.io/2016/05/05/optimizing-slerp/
    */
 
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   // Implementation of Zeux's onlerp.
   const SimdVec l          = simd_vec_load(a.comps);
   const SimdVec r          = simd_vec_load(b.comps);
@@ -373,7 +371,7 @@ bool geo_quat_clamp(GeoQuat* q, const f32 maxAngle) {
 }
 
 void geo_quat_pack_f16(const GeoQuat quat, f16 out[PARAM_ARRAY_SIZE(4)]) {
-#if geo_quat_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vecF32 = simd_vec_load(quat.comps);
   SimdVec       vecF16;
   if (g_f16cSupport) {

--- a/libs/geo/src/vector.c
+++ b/libs/geo/src/vector.c
@@ -6,9 +6,7 @@
 #include "core_rng.h"
 #include "geo_vector.h"
 
-#define geo_vec_simd_enable 1
-
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -23,7 +21,7 @@ bool geo_vector_equal3(const GeoVector a, const GeoVector b, const f32 threshold
 }
 
 GeoVector geo_vector_abs(const GeoVector vec) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_abs(simd_vec_load(vec.comps)), res.comps);
   return res;
@@ -33,7 +31,7 @@ GeoVector geo_vector_abs(const GeoVector vec) {
 }
 
 GeoVector geo_vector_add(const GeoVector a, const GeoVector b) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_add(simd_vec_load(a.comps), simd_vec_load(b.comps)), res.comps);
   return res;
@@ -43,7 +41,7 @@ GeoVector geo_vector_add(const GeoVector a, const GeoVector b) {
 }
 
 GeoVector geo_vector_sub(const GeoVector a, const GeoVector b) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_sub(simd_vec_load(a.comps), simd_vec_load(b.comps)), res.comps);
   return res;
@@ -53,7 +51,7 @@ GeoVector geo_vector_sub(const GeoVector a, const GeoVector b) {
 }
 
 GeoVector geo_vector_mul(const GeoVector v, const f32 scalar) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_mul(simd_vec_load(v.comps), simd_vec_broadcast(scalar)), res.comps);
   return res;
@@ -63,7 +61,7 @@ GeoVector geo_vector_mul(const GeoVector v, const f32 scalar) {
 }
 
 GeoVector geo_vector_mul_comps(const GeoVector a, const GeoVector b) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_mul(simd_vec_load(a.comps), simd_vec_load(b.comps)), res.comps);
   return res;
@@ -74,7 +72,7 @@ GeoVector geo_vector_mul_comps(const GeoVector a, const GeoVector b) {
 
 GeoVector geo_vector_div(const GeoVector v, const f32 scalar) {
   diag_assert(scalar != 0);
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_div(simd_vec_load(v.comps), simd_vec_broadcast(scalar)), res.comps);
   return res;
@@ -84,7 +82,7 @@ GeoVector geo_vector_div(const GeoVector v, const f32 scalar) {
 }
 
 GeoVector geo_vector_div_comps(const GeoVector a, const GeoVector b) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_div(simd_vec_load(a.comps), simd_vec_load(b.comps)), res.comps);
   return res;
@@ -94,7 +92,7 @@ GeoVector geo_vector_div_comps(const GeoVector a, const GeoVector b) {
 }
 
 f32 geo_vector_mag_sqr(const GeoVector v) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vec = simd_vec_load(v.comps);
   return simd_vec_x(simd_vec_dot4(vec, vec));
 #else
@@ -103,7 +101,7 @@ f32 geo_vector_mag_sqr(const GeoVector v) {
 }
 
 f32 geo_vector_mag(const GeoVector v) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vec = simd_vec_load(v.comps);
   const SimdVec dot = simd_vec_dot4(vec, vec);
   return simd_vec_x(dot) != 0 ? simd_vec_x(simd_vec_sqrt(dot)) : 0;
@@ -114,7 +112,7 @@ f32 geo_vector_mag(const GeoVector v) {
 }
 
 GeoVector geo_vector_norm(const GeoVector v) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vec    = simd_vec_load(v.comps);
   const SimdVec sqrMag = simd_vec_dot4(vec, vec);
 
@@ -136,7 +134,7 @@ GeoVector geo_vector_norm_or(const GeoVector v, const GeoVector fallback) {
 }
 
 f32 geo_vector_dot(const GeoVector a, const GeoVector b) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   return simd_vec_x(simd_vec_dot4(simd_vec_load(a.comps), simd_vec_load(b.comps)));
 #else
   f32 res = 0;
@@ -149,7 +147,7 @@ f32 geo_vector_dot(const GeoVector a, const GeoVector b) {
 }
 
 GeoVector geo_vector_cross3(const GeoVector a, const GeoVector b) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_cross3(simd_vec_load(a.comps), simd_vec_load(b.comps)), res.comps);
   return res;
@@ -184,7 +182,7 @@ GeoVector geo_vector_reflect(const GeoVector v, const GeoVector nrm) {
 }
 
 GeoVector geo_vector_lerp(const GeoVector x, const GeoVector y, const f32 t) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vX = simd_vec_load(x.comps);
   const SimdVec vY = simd_vec_load(y.comps);
   const SimdVec vT = simd_vec_broadcast(t);
@@ -208,7 +206,7 @@ GeoVector geo_vector_bilerp(
     const GeoVector v4,
     const f32       tX,
     const f32       tY) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vec1  = simd_vec_load(v1.comps);
   const SimdVec vec2  = simd_vec_load(v2.comps);
   const SimdVec vec3  = simd_vec_load(v3.comps);
@@ -226,7 +224,7 @@ GeoVector geo_vector_bilerp(
 }
 
 GeoVector geo_vector_min(const GeoVector x, const GeoVector y) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_min(simd_vec_load(x.comps), simd_vec_load(y.comps)), res.comps);
   return res;
@@ -241,7 +239,7 @@ GeoVector geo_vector_min(const GeoVector x, const GeoVector y) {
 }
 
 GeoVector geo_vector_max(const GeoVector x, const GeoVector y) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_max(simd_vec_load(x.comps), simd_vec_load(y.comps)), res.comps);
   return res;
@@ -259,7 +257,7 @@ GeoVector geo_vector_xyz(const GeoVector v) { return geo_vector(v.x, v.y, v.z, 0
 GeoVector geo_vector_xz(const GeoVector v) { return geo_vector(v.x, 0, v.z, 0); }
 
 GeoVector geo_vector_sqrt(const GeoVector v) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_sqrt(simd_vec_load(v.comps)), res.comps);
   return res;
@@ -284,7 +282,7 @@ GeoVector geo_vector_clamp(const GeoVector v, const f32 maxMagnitude) {
 }
 
 GeoVector geo_vector_clamp_comps(const GeoVector v, const GeoVector min, const GeoVector max) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   SimdVec vec = simd_vec_load(v.comps);
   vec         = simd_vec_max(vec, simd_vec_load(min.comps));
   vec         = simd_vec_min(vec, simd_vec_load(max.comps));
@@ -302,7 +300,7 @@ GeoVector geo_vector_clamp_comps(const GeoVector v, const GeoVector min, const G
 }
 
 GeoVector geo_vector_round_nearest(const GeoVector v) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_round_nearest(simd_vec_load(v.comps)), res.comps);
   return res;
@@ -317,7 +315,7 @@ GeoVector geo_vector_round_nearest(const GeoVector v) {
 }
 
 GeoVector geo_vector_round_down(const GeoVector v) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_round_down(simd_vec_load(v.comps)), res.comps);
   return res;
@@ -332,7 +330,7 @@ GeoVector geo_vector_round_down(const GeoVector v) {
 }
 
 GeoVector geo_vector_round_up(const GeoVector v) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   GeoVector res;
   simd_vec_store(simd_vec_round_up(simd_vec_load(v.comps)), res.comps);
   return res;
@@ -368,7 +366,7 @@ GeoVector geo_vector_quantize3(const GeoVector v, const u8 maxMantissaBits) {
 }
 
 void geo_vector_pack_f16(const GeoVector v, f16 out[PARAM_ARRAY_SIZE(4)]) {
-#if geo_vec_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec vecF32 = simd_vec_load(v.comps);
   SimdVec       vecF16;
   if (g_f16cSupport) {

--- a/libs/rend/src/draw.c
+++ b/libs/rend/src/draw.c
@@ -13,9 +13,7 @@
 #include "resource_internal.h"
 #include "rvk/texture_internal.h"
 
-#define rend_draw_simd_enable 1
-
-#if rend_draw_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -51,7 +49,7 @@ ecs_comp_define(RendDrawComp) {
  * Pre-condition: bits_is_aligned(size, 16)
  */
 INLINE_HINT static void rend_draw_memcpy(u8* dst, const u8* src, const usize size) {
-#if rend_draw_simd_enable
+#ifdef VOLO_SIMD
   const void* end = bits_ptr_offset(src, size);
   for (; src != end; src += 16, dst += 16) {
     simd_copy_128(dst, src);

--- a/libs/rend/src/rvk/swapchain.c
+++ b/libs/rend/src/rvk/swapchain.c
@@ -21,7 +21,7 @@
 #elif defined(VOLO_WIN32)
 #include <vulkan/vulkan_win32.h>
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif
 
 #define swapchain_images_max 5

--- a/libs/scene/src/set.c
+++ b/libs/scene/src/set.c
@@ -12,13 +12,11 @@
 #include "scene_set.h"
 #include "scene_tag.h"
 
-#define scene_set_simd_enable 1
-#define scene_set_wellknown_names 1
-
-#if scene_set_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
+#define scene_set_wellknown_names 1
 #define scene_set_max 64
 
 typedef struct {
@@ -42,7 +40,7 @@ static void set_storage_destroy(SetStorage* s) {
 }
 
 static u32 set_storage_index(const SetStorage* s, const StringHash set) {
-#if scene_set_simd_enable
+#ifdef VOLO_SIMD
   ASSERT((scene_set_max % 8) == 0, "Only multiple of 8 set counts are supported");
 
   const SimdVec setVec = simd_vec_broadcast_u32(set);
@@ -67,7 +65,7 @@ static u32 set_storage_index(const SetStorage* s, const StringHash set) {
 }
 
 static u32 set_storage_index_free(const SetStorage* s) {
-#if scene_set_simd_enable
+#ifdef VOLO_SIMD
   ASSERT((scene_set_max % 8) == 0, "Only multiple of 8 set counts are supported");
 
   for (u32 setIdx = 0; setIdx != scene_set_max; setIdx += 8) {
@@ -282,7 +280,7 @@ static void ecs_destruct_set_env_comp(void* data) {
 }
 
 static bool set_member_contains(const SceneSetMemberComp* member, const StringHash set) {
-#if scene_set_simd_enable
+#ifdef VOLO_SIMD
   ASSERT(scene_set_member_max_sets == 8, "set_member_contains only supports 8 elems at the moment")
 
   const SimdVec setVec = simd_vec_broadcast_u32(set);
@@ -302,7 +300,7 @@ static bool set_member_contains(const SceneSetMemberComp* member, const StringHa
 }
 
 static bool set_member_add(SceneSetMemberComp* member, const StringHash set) {
-#if scene_set_simd_enable
+#ifdef VOLO_SIMD
   ASSERT(scene_set_member_max_sets == 8, "set_member_add only supports 8 elems at the moment")
 
   const SimdVec setVec      = simd_vec_broadcast_u32(set);
@@ -343,7 +341,7 @@ static bool set_member_add(SceneSetMemberComp* member, const StringHash set) {
 }
 
 static bool set_member_remove(SceneSetMemberComp* member, const StringHash set) {
-#if scene_set_simd_enable
+#ifdef VOLO_SIMD
   ASSERT(scene_set_member_max_sets == 8, "set_member_contains only supports 8 elems at the moment")
 
   const SimdVec setVec = simd_vec_broadcast_u32(set);

--- a/libs/scene/src/visibility.c
+++ b/libs/scene/src/visibility.c
@@ -7,9 +7,8 @@
 #include "scene_visibility.h"
 
 #define scene_vision_areas_max 2048
-#define scene_vision_simd_enable 1
 
-#if scene_vision_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -60,7 +59,7 @@ visibility_env_insert(SceneVisibilityEnvComp* env, const GeoVector pos, const f3
 
 static bool visiblity_env_visible(const SceneVisibilityEnvComp* env, const GeoVector pos) {
   // TODO: This could use some kind of acceleration structure.
-#if scene_vision_simd_enable
+#ifdef VOLO_SIMD
   const SimdVec posVec = simd_vec_load(pos.comps);
   for (u32 i = 0; i != env->visionCount; ++i) {
     const SimdVec delta        = simd_vec_sub(posVec, simd_vec_load(env->visionPositions[i].comps));

--- a/libs/snd/src/device_pal.c
+++ b/libs/snd/src/device_pal.c
@@ -1,9 +1,7 @@
-#include "core_annotation.h"
-
 #if defined(VOLO_LINUX)
 #include "device_pal_linux_alsa.c"
 #elif defined(VOLO_WIN32)
 #include "device_pal_win32_mme.c"
 #else
-ASSERT(false, "Unsupported platform");
+#error Unsupported platform
 #endif

--- a/libs/snd/src/mixer.c
+++ b/libs/snd/src/mixer.c
@@ -7,7 +7,6 @@
 #include "core_float.h"
 #include "core_math.h"
 #include "core_rng.h"
-#include "core_simd.h"
 #include "ecs_utils.h"
 #include "ecs_world.h"
 #include "log_logger.h"
@@ -17,6 +16,12 @@
 
 #include "constants_internal.h"
 #include "device_internal.h"
+
+#ifdef VOLO_SIMD
+#include "core_simd.h"
+#else
+#error Sound Mixer requires SIMD support
+#endif
 
 #define snd_mixer_objects_max 512
 ASSERT(snd_mixer_objects_max < u16_max, "Sound objects need to indexable with a 16 bit integer");

--- a/libs/trace/src/sink_store.c
+++ b/libs/trace/src/sink_store.c
@@ -10,6 +10,10 @@
 
 #include "tracer_internal.h"
 
+#ifdef VOLO_SIMD
+#include "core_simd.h"
+#endif
+
 /**
  * Trace sink implementation that stores events in in-memory buffers to be queried later.
  */
@@ -18,15 +22,10 @@
 #define trace_store_max_threads 8
 #define trace_store_buffer_events 1024
 #define trace_store_buffer_max_depth 8
-#define trace_store_simd_enable 1
 
 ASSERT(trace_store_max_ids < u8_max, "Trace id has to be representable by a u8")
 ASSERT((trace_store_buffer_events & (trace_store_buffer_events - 1u)) == 0, "Has to be a pow2");
 ASSERT(trace_store_buffer_events < u16_max, "Events have to be representable with a u16")
-
-#if trace_store_simd_enable
-#include "core_simd.h"
-#endif
 
 static THREAD_LOCAL bool g_traceStoreIsVisiting;
 
@@ -59,7 +58,7 @@ typedef struct {
 } TraceSinkStore;
 
 static u8 trace_id_find(TraceSinkStore* s, const StringHash hash) {
-#if trace_store_simd_enable
+#ifdef VOLO_SIMD
   ASSERT((trace_store_max_ids % 8) == 0, "Only multiple of 8 id counts are supported");
 
   const SimdVec hashVec = simd_vec_broadcast_u32(hash);

--- a/libs/vfx/src/decal.c
+++ b/libs/vfx/src/decal.c
@@ -24,9 +24,7 @@
 #include "atlas_internal.h"
 #include "draw_internal.h"
 
-#define vfx_decal_simd_enable 1
-
-#if vfx_decal_simd_enable
+#ifdef VOLO_SIMD
 #include "core_simd.h"
 #endif
 
@@ -448,7 +446,7 @@ static void vfx_decal_draw_output(RendDrawComp* draw, const VfxDecalParams* para
   geo_vector_pack_f16(
       geo_vector(warpScale.x, warpScale.y, params->texOffsetY, params->texScaleY), out->data5);
 
-#if vfx_decal_simd_enable
+#ifdef VOLO_SIMD
   /**
    * Warp-points are represented by 8 floats, pack them to 16 bits in two steps.
    */


### PR DESCRIPTION
Now uses a shared VOLO_SIMD define, most of the project still compiles without SIMD support (the only exception is the sound-mixer but this can be added if needed). Reason for keeping the non-simd paths is that it might help speed-up porting to other architectures (perhaps ARM).