### PR TITLE
asset: Remove unneeded asset dependencies

### DIFF
--- a/libs/asset/src/loader_graphic.c
+++ b/libs/asset/src/loader_graphic.c
@@ -177,13 +177,11 @@ ecs_system_define(LoadGraphicAssetSys) {
     // Resolve shader references.
     array_ptr_for_t(graphicComp->shaders, AssetGraphicShader, ptr) {
       ptr->shader = asset_lookup(world, manager, ptr->shaderId);
-      asset_register_dep(world, entity, ptr->shader);
     }
 
     // Resolve texture references.
     array_ptr_for_t(graphicComp->samplers, AssetGraphicSampler, ptr) {
       ptr->texture = asset_lookup(world, manager, ptr->textureId);
-      asset_register_dep(world, entity, ptr->texture);
     }
 
     // Resolve mesh reference.
@@ -193,7 +191,6 @@ ecs_system_define(LoadGraphicAssetSys) {
     }
     if (!string_is_empty(graphicComp->meshId)) {
       graphicComp->mesh = asset_lookup(world, manager, graphicComp->meshId);
-      asset_register_dep(world, entity, graphicComp->mesh);
     }
 
     ecs_world_remove_t(world, entity, AssetGraphicLoadComp);

--- a/libs/asset/src/loader_terrain.c
+++ b/libs/asset/src/loader_terrain.c
@@ -142,8 +142,6 @@ ecs_system_define(LoadTerrainAssetSys) {
     // Resolve asset references.
     terrainComp->graphic   = asset_lookup(world, manager, terrainComp->graphicId);
     terrainComp->heightmap = asset_lookup(world, manager, terrainComp->heightmapId);
-    asset_register_dep(world, entity, terrainComp->graphic);
-    asset_register_dep(world, entity, terrainComp->heightmap);
 
     ecs_world_remove_t(world, entity, AssetTerrainLoadComp);
     ecs_world_add_empty_t(world, entity, AssetLoadedComp);


### PR DESCRIPTION
Asset references that do not contribute to the asset data should not be marked as dependencies.