### PR TITLE
scene: Fix hotload adding a skeleton

### DIFF
--- a/assets/graphics/game/structure_factory.graphic
+++ b/assets/graphics/game/structure_factory.graphic
@@ -13,4 +13,5 @@
     { "textureId": "external/factory/factory_2_color_rough.tga", "anisotropy": "x2" },
     { "textureId": "external/factory/factory_2_normal.tga", "anisotropy": "x2" }
   ],
-  "meshId": "external/factory/factory.gltf" }
+  "meshId": "external/factory/factory.gltf"
+}


### PR DESCRIPTION
Fixes the case where an entity did not have a skeleton but then a skeleton was added with an asset hotload.