### PR TITLE
gap: Handle SetCursorPos failing

### DIFF
--- a/libs/gap/src/pal_win32.c
+++ b/libs/gap/src/pal_win32.c
@@ -1251,10 +1251,9 @@ void gap_pal_window_cursor_pos_set(
   };
 
   const GapVector screenPos = pal_client_to_screen(windowId, win32Pos);
-  if (!SetCursorPos(screenPos.x, screenPos.y)) {
-    pal_crash_with_win32_err(string_lit("SetCursorPos"));
+  if (SetCursorPos(screenPos.x, screenPos.y)) {
+    pal_window((GapPal*)pal, windowId)->params[GapParam_CursorPos] = position;
   }
-  pal_window((GapPal*)pal, windowId)->params[GapParam_CursorPos] = position;
 }
 
 void gap_pal_window_clip_copy(GapPal* pal, const GapWindowId windowId, const String value) {

--- a/libs/gap/src/pal_win32.c
+++ b/libs/gap/src/pal_win32.c
@@ -1252,7 +1252,7 @@ void gap_pal_window_cursor_pos_set(
 
   const GapVector screenPos = pal_client_to_screen(windowId, win32Pos);
   if (SetCursorPos(screenPos.x, screenPos.y)) {
-    pal_window((GapPal*)pal, windowId)->params[GapParam_CursorPos] = position;
+    window->params[GapParam_CursorPos] = position;
   }
 }
 


### PR DESCRIPTION
Can happen if the cursor left the window.