### PR TITLE
core: Use same filesystem for atomic write

### DIFF
--- a/libs/core/include/core_file.h
+++ b/libs/core/include/core_file.h
@@ -179,6 +179,7 @@ FileResult file_unmap(File*);
 
 /**
  * Rename the file at the given path.
+ * NOTE: oldPath and newPath need to be on the same filesystem.
  */
 FileResult file_rename(String oldPath, String newPath);
 

--- a/libs/core/src/file.c
+++ b/libs/core/src/file.c
@@ -3,7 +3,6 @@
 #include "core_diag.h"
 #include "core_file.h"
 #include "core_path.h"
-#include "core_rng.h"
 #include "core_thread.h"
 
 #include "file_internal.h"
@@ -119,8 +118,11 @@ ret:
 }
 
 FileResult file_write_to_path_atomic(const String path, const String data) {
-  const String tmpFileName = path_name_random_scratch(g_rng, string_lit("volo"), string_lit("tmp"));
-  const String tmpPath     = path_build_scratch(g_pathTempDir, tmpFileName);
+  /**
+   * NOTE: Its important to use the same directory as the target for the temporary file as we need
+   * to make sure its on the same filesystem (and not on tmpfs for example).
+   */
+  const String tmpPath = fmt_write_scratch("{}.tmp", fmt_text(path));
 
   FileResult res;
   if ((res = file_write_to_path_sync(tmpPath, data))) {


### PR DESCRIPTION
The previous implementation would fail if the temp-file was on tmpfs (as we cannot rename across file-systems).