### PR TITLE
script: Tweak truthy logic

### DIFF
--- a/libs/script/src/val.c
+++ b/libs/script/src/val.c
@@ -101,27 +101,18 @@ bool script_truthy(const ScriptVal value) {
   switch (val_type(value)) {
   case ScriptType_Null:
     return false;
-  case ScriptType_Num:
-    return val_as_num(value) != 0;
   case ScriptType_Bool:
     return val_as_bool(value);
+  case ScriptType_Num:
   case ScriptType_Vec3:
   case ScriptType_Quat:
   case ScriptType_Color:
-    /**
-     * NOTE: At the moment vectors, quaternions and colors are always considered to be truthy. This
-     * is arguably inconsistent with numbers where we treat 0 as falsy. However its unclear what
-     * good truthy semantics are for these types, for example is a unit-quaternion truthy or not?
-     */
-    return true;
   case ScriptType_Entity:
-    return true; // Only valid entities can be stored in values.
   case ScriptType_Str:
-    return val_as_str(value) != 0;
+    return true;
   case ScriptType_Count:
     break;
   }
-  diag_assert_fail("Invalid script value");
   UNREACHABLE
 }
 

--- a/libs/script/test/test_eval.c
+++ b/libs/script/test/test_eval.c
@@ -341,7 +341,7 @@ spec(eval) {
     const ScriptExpr expr = script_read(
         doc,
         binder,
-        string_lit("test_increase_counter(); assert(0); test_increase_counter()"),
+        string_lit("test_increase_counter(); assert(false); test_increase_counter()"),
         stringtableNull,
         diagsNull,
         symsNull);

--- a/libs/script/test/test_val.c
+++ b/libs/script/test/test_val.c
@@ -135,12 +135,12 @@ spec(val) {
   it("can test if a value is truthy") {
     check(!script_truthy(script_null()));
 
-    check(!script_truthy(script_num(0)));
-    check(!script_truthy(script_num(-0.0)));
-    check(script_truthy(script_num(42)));
-
     check(!script_truthy(script_bool(false)));
     check(script_truthy(script_bool(true)));
+
+    check(script_truthy(script_num(0)));
+    check(script_truthy(script_num(-0.0)));
+    check(script_truthy(script_num(42)));
 
     check(script_truthy(script_vec3_lit(0, 0, 0)));
     check(script_truthy(script_vec3_lit(1, 2, 0)));
@@ -152,18 +152,17 @@ spec(val) {
 
     check(script_truthy(script_entity(dummyEntity1)));
 
-    check(!script_truthy(script_str(0)));
+    check(script_truthy(script_str(0)));
     check(script_truthy(script_str(string_hash_lit("Hello World"))));
   }
 
   it("can test if a value is falsy") {
     check(script_falsy(script_null()));
-
-    check(script_falsy(script_num(0)));
-    check(!script_falsy(script_num(42)));
-
     check(script_falsy(script_bool(false)));
     check(!script_falsy(script_bool(true)));
+
+    check(!script_falsy(script_num(0)));
+    check(!script_falsy(script_num(42)));
 
     check(!script_falsy(script_vec3_lit(0, 0, 0)));
     check(!script_falsy(script_vec3_lit(1, 2, 0)));
@@ -175,7 +174,7 @@ spec(val) {
 
     check(!script_falsy(script_entity(dummyEntity1)));
 
-    check(script_falsy(script_str(0)));
+    check(!script_falsy(script_str(0)));
     check(!script_falsy(script_str(string_hash_lit("Hello World"))));
   }
 


### PR DESCRIPTION
Now only null and false are falsy, everything else is truthy. Makes nullable values more use-able. 