### PR TITLE
core: Support finding symbols in DynLib dependencies on Windows

### DIFF
--- a/libs/core/src/dynlib_internal.h
+++ b/libs/core/src/dynlib_internal.h
@@ -2,6 +2,7 @@
 #include "core_dynlib.h"
 
 void         dynlib_pal_init(void);
+void         dynlib_pal_teardown(void);
 DynLibResult dynlib_pal_load(Allocator*, String name, DynLib** out);
 void         dynlib_pal_destroy(DynLib*);
 String       dynlib_pal_path(const DynLib*);

--- a/libs/core/src/dynlib_pal_linux.c
+++ b/libs/core/src/dynlib_pal_linux.c
@@ -11,6 +11,7 @@
 #define dynlib_crash_on_error false
 
 void dynlib_pal_init(void) {}
+void dynlib_pal_teardown(void) {}
 
 struct sDynLib {
   void*      handle;

--- a/libs/core/src/dynlib_pal_win32.c
+++ b/libs/core/src/dynlib_pal_win32.c
@@ -1,5 +1,6 @@
 #include "core_alloc.h"
 #include "core_diag.h"
+#include "core_thread.h"
 #include "core_winutils.h"
 
 #include "dynlib_internal.h"
@@ -8,14 +9,18 @@
 
 #define dynlib_max_symbol_name 128
 
+static ThreadMutex g_dynlibLoadMutex;
+
 void dynlib_pal_init(void) {
   /**
    * Disable Windows ui error popups that could be shown as a result of calling 'LoadLibrary'.
    */
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX | SEM_NOGPFAULTERRORBOX);
+
+  g_dynlibLoadMutex = thread_mutex_create(g_allocHeap);
 }
 
-void dynlib_pal_teardown(void) {}
+void dynlib_pal_teardown(void) { thread_mutex_destroy(g_dynlibLoadMutex); }
 
 struct sDynLib {
   HMODULE    handle;

--- a/libs/core/src/dynlib_pal_win32.c
+++ b/libs/core/src/dynlib_pal_win32.c
@@ -15,6 +15,8 @@ void dynlib_pal_init(void) {
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX | SEM_NOGPFAULTERRORBOX);
 }
 
+void dynlib_pal_teardown(void) {}
+
 struct sDynLib {
   HMODULE    handle;
   String     path;

--- a/libs/core/src/init.c
+++ b/libs/core/src/init.c
@@ -58,6 +58,7 @@ void core_teardown(void) {
     thread_teardown();
 
     dynlib_leak_detect(); // Leak-detect late as the thread module owns some dynamic-libraries.
+    dynlib_teardown();
 
     symbol_teardown();
     alloc_teardown();

--- a/libs/core/src/init_internal.h
+++ b/libs/core/src/init_internal.h
@@ -41,8 +41,9 @@ void file_leak_detect(void);
  * Fired once when the core library is torn down.
  */
 void alloc_teardown(void);
+void dynlib_teardown(void);
 void stringtable_teardown(void);
-void symbol_teardown();
+void symbol_teardown(void);
 void thread_teardown(void);
 void tty_teardown(void);
 


### PR DESCRIPTION
This emulates the unix dlopen/dlsym behavior on Windows and makes the behavior (more) consistent.