### PR TITLE
rend: Fix crash during resize

### DIFF
--- a/libs/rend/src/painter.c
+++ b/libs/rend/src/painter.c
@@ -602,16 +602,18 @@ static bool rend_canvas_paint_2d(
   rend_builder_phase_output(b); // Acquire swapchain image.
 
   RvkImage* swapchainImage = rend_builder_img_swapchain(b);
-  rend_builder_img_clear_color(b, swapchainImage, geo_color_black);
+  if (!swapchainImage) {
+    rend_builder_img_clear_color(b, swapchainImage, geo_color_black);
 
-  rend_builder_pass_push(b, platform->passes[AssetGraphicPass_Post]);
-  {
-    const RendView   mainView = painter_view_2d_create(camEntity);
-    RendPaintContext ctx      = painter_context(b, set, time, mainView);
-    rend_builder_attach_color(b, swapchainImage, 0);
-    painter_push_objects_simple(&ctx, objView, resView, AssetGraphicPass_Post);
+    rend_builder_pass_push(b, platform->passes[AssetGraphicPass_Post]);
+    {
+      const RendView   mainView = painter_view_2d_create(camEntity);
+      RendPaintContext ctx      = painter_context(b, set, time, mainView);
+      rend_builder_attach_color(b, swapchainImage, 0);
+      painter_push_objects_simple(&ctx, objView, resView, AssetGraphicPass_Post);
+    }
+    rend_builder_pass_flush(b);
   }
-  rend_builder_pass_flush(b);
 
   rend_builder_canvas_flush(b);
   return true;
@@ -923,8 +925,8 @@ static bool rend_canvas_paint_3d(
   rend_builder_phase_output(b); // Acquire swapchain image.
 
   // Post pass.
-  {
-    RvkImage* swapchainImage = rend_builder_img_swapchain(b);
+  RvkImage* swapchainImage = rend_builder_img_swapchain(b);
+  if (swapchainImage) {
     rend_builder_pass_push(b, platform->passes[AssetGraphicPass_Post]);
 
     RendPaintContext ctx = painter_context(b, set, time, mainView);

--- a/libs/rend/src/rvk/canvas_internal.h
+++ b/libs/rend/src/rvk/canvas_internal.h
@@ -42,7 +42,7 @@ void        rvk_canvas_phase_output(RvkCanvas*);
 
 void      rvk_canvas_swapchain_stats(const RvkCanvas*, RvkSwapchainStats* out);
 RvkSize   rvk_canvas_swapchain_size(const RvkCanvas*);
-RvkImage* rvk_canvas_swapchain_image(RvkCanvas*);
+RvkImage* rvk_canvas_swapchain_image(RvkCanvas*); // NOTE: Can return null if acquire failed.
 
 void rvk_canvas_end(RvkCanvas*);
 

--- a/libs/rend/src/rvk/job.c
+++ b/libs/rend/src/rvk/job.c
@@ -103,7 +103,7 @@ static void rvk_job_submit(
 
   const VkSubmitInfo submitInfo = {
       .sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-      .waitSemaphoreCount   = 1,
+      .waitSemaphoreCount   = waitForTarget ? 1 : 0,
       .pWaitSemaphores      = &waitForTarget,
       .pWaitDstStageMask    = &waitForTargetStageMask,
       .commandBufferCount   = 1,


### PR DESCRIPTION
We didn't support frames without a swapchain so if the swapchain acquire fully failed we ended up crashing.