### PR TITLE
core: Malloc wrapper

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(lib_core STATIC
   src/alloc_pagecache.c
   src/alloc_persist.c
   src/alloc_scratch.c
+  src/alloc_stdlib.c
   src/alloc_tracker.c
   src/alloc.c
   src/ascii.c

--- a/libs/core/src/alloc_stdlib.c
+++ b/libs/core/src/alloc_stdlib.c
@@ -25,7 +25,7 @@ typedef struct {
   usize size, padding;
 } AllocStdHeader;
 
-static void* stdlib_alloc(usize size, usize align) {
+INLINE_HINT static void* stdlib_alloc(usize size, usize align) {
   if (!size) {
     return null;
   }
@@ -47,7 +47,7 @@ static void* stdlib_alloc(usize size, usize align) {
   return bits_ptr_offset(hdr, sizeof(AllocStdHeader));
 }
 
-static void stdlib_free(void* ptr) {
+INLINE_HINT static void stdlib_free(void* ptr) {
   if (!ptr) {
     return;
   }

--- a/libs/core/src/alloc_stdlib.c
+++ b/libs/core/src/alloc_stdlib.c
@@ -1,0 +1,129 @@
+#include "core_bits.h"
+#include "core_math.h"
+
+#include "alloc_internal.h"
+
+#include <errno.h>
+#include <stdlib.h>
+
+/**
+ * Implement the standard library malloc to use our heap-allocator.
+ * This allows us to use our memory tracking for allocations from external libraries.
+ *
+ * Our allocators require the caller to track allocation sizes, to support this for the standard
+ * malloc api we add a header to the beginning of the allocations.
+ *
+ * Allocation memory layout:
+ * - [PADDING] (padding to satisfy the requested alignment)
+ * - AllocStdHeader (16 bytes)
+ * - [PAYLOAD]
+ */
+
+#define alloc_std_default_align 16
+
+typedef struct {
+  usize size, padding;
+} AllocStdHeader;
+
+static void* stdlib_alloc(usize size, usize align) {
+  if (!size) {
+    return null;
+  }
+  align = math_max(align, alignof(AllocStdHeader));
+  size  = bits_align(size, align);
+
+  const usize padding   = bits_padding(sizeof(AllocStdHeader), align);
+  const usize totalSize = padding + sizeof(AllocStdHeader) + size;
+
+  Mem mem = alloc_alloc(g_allocHeap, totalSize, align);
+  if (UNLIKELY(!mem_valid(mem))) {
+    return null;
+  }
+
+  AllocStdHeader* hdr = bits_ptr_offset(mem.ptr, padding);
+  hdr->size           = size;
+  hdr->padding        = padding;
+
+  return bits_ptr_offset(hdr, sizeof(AllocStdHeader));
+}
+
+static void stdlib_free(void* ptr) {
+  if (!ptr) {
+    return;
+  }
+  AllocStdHeader* hdr = bits_ptr_offset(ptr, -(iptr)sizeof(AllocStdHeader));
+
+  const usize totalSize = hdr->padding + sizeof(AllocStdHeader) + hdr->size;
+  const Mem   mem       = mem_create(bits_ptr_offset(hdr, -(iptr)hdr->padding), totalSize);
+
+  alloc_free(g_allocHeap, mem);
+}
+
+static Mem stdlib_payload(void* ptr) {
+  if (!ptr) {
+    return mem_empty;
+  }
+  AllocStdHeader* hdr = bits_ptr_offset(ptr, -(iptr)sizeof(AllocStdHeader));
+  return mem_create(ptr, hdr->size);
+}
+
+void* SYS_DECL malloc(const usize size) { return stdlib_alloc(size, alloc_std_default_align); }
+
+void* SYS_DECL calloc(const usize num, const usize size) {
+  const usize sizeTotal = num * size;
+  void*       res       = stdlib_alloc(sizeTotal, alloc_std_default_align);
+  if (LIKELY(res)) {
+    mem_set(mem_create(res, sizeTotal), 0);
+  }
+  return res;
+}
+
+void SYS_DECL free(void* ptr) {
+  const int errnoPrev = errno; // Preserve errno to match the GNU-C library behavior.
+  stdlib_free(ptr);
+  errno = errnoPrev;
+}
+
+void SYS_DECL cfree(void* ptr) { free(ptr); }
+
+void* SYS_DECL realloc(void* ptr, const usize newSize) {
+  void* newPtr = stdlib_alloc(newSize, alloc_std_default_align);
+  if (UNLIKELY(!newPtr && !ptr)) {
+    return null;
+  }
+
+  if (ptr) {
+    if (newPtr) {
+      const Mem   orgPayload  = stdlib_payload(ptr);
+      const usize bytesToCopy = math_min(orgPayload.size, newSize);
+      mem_cpy(mem_create(newPtr, bytesToCopy), mem_create(orgPayload.ptr, bytesToCopy));
+    }
+    stdlib_free(ptr);
+  }
+
+  return newPtr;
+}
+
+int SYS_DECL posix_memalign(void** outPtr, const usize align, const usize size) {
+  if (!bits_aligned(align, sizeof(usize)) || !bits_ispow2(align)) {
+    return EINVAL;
+  }
+  void* res = stdlib_alloc(size, align);
+  if (res) {
+    *outPtr = res;
+    return 0;
+  }
+  return ENOMEM;
+}
+
+void* SYS_DECL aligned_alloc(const usize align, const usize size) {
+  return stdlib_alloc(size, align);
+}
+
+void* SYS_DECL valloc(const usize size) { return stdlib_alloc(size, alloc_page_size()); }
+
+void* SYS_DECL memalign(const usize align, const usize size) { return stdlib_alloc(size, align); }
+
+void* SYS_DECL pvalloc(const usize size) { return stdlib_alloc(size, alloc_page_size()); }
+
+usize SYS_DECL malloc_usable_size(void* ptr) { return stdlib_payload(ptr).size; }

--- a/libs/core/src/alloc_stdlib.c
+++ b/libs/core/src/alloc_stdlib.c
@@ -127,3 +127,14 @@ void* SYS_DECL memalign(const usize align, const usize size) { return stdlib_all
 void* SYS_DECL pvalloc(const usize size) { return stdlib_alloc(size, alloc_page_size()); }
 
 usize SYS_DECL malloc_usable_size(void* ptr) { return stdlib_payload(ptr).size; }
+
+void SYS_DECL free_sized(void* ptr, const usize size) {
+  (void)size;
+  free(ptr);
+}
+
+void SYS_DECL free_aligned_sized(void* ptr, const usize align, const usize size) {
+  (void)align;
+  (void)size;
+  free(ptr);
+}

--- a/libs/core/src/alloc_stdlib.c
+++ b/libs/core/src/alloc_stdlib.c
@@ -1,3 +1,20 @@
+#ifdef VOLO_WIN32
+/**
+ * DISABLED: Overriding malloc on Win32 can't be done (as far as i know) directly from the
+ * executable as dynamic libraries won't link to symbols from the executable.
+ */
+#define alloc_std_malloc_override 0
+#else
+/**
+ * DISABLED: Our memory allocators do leak detection at shutdown, however allot of third party
+ * dependencies don't free all their allocations. To avoid allot of false positives we need to
+ * support suppressing leak detection for external allocations.
+ */
+#define alloc_std_malloc_override 0
+#endif
+
+#if alloc_std_malloc_override
+
 #include "core_bits.h"
 #include "core_math.h"
 
@@ -158,3 +175,5 @@ void SYS_DECL free_aligned_sized(void* ptr, const usize align, const usize size)
   (void)size;
   stdlib_free(ptr);
 }
+
+#endif

--- a/libs/core/src/init.c
+++ b/libs/core/src/init.c
@@ -20,6 +20,7 @@ void core_init(void) {
   }
   if (!g_initializedThread) {
     alloc_init_thread();
+    thread_init_thread_late();
   }
   if (!g_initalized) {
     bits_init();

--- a/libs/core/src/init_internal.h
+++ b/libs/core/src/init_internal.h
@@ -27,6 +27,7 @@ void alloc_init_thread(void);
 void float_init_thread(void);
 void rng_init_thread(void);
 void thread_init_thread(void);
+void thread_init_thread_late(void);
 
 /**
  * Global leak-detect routines.

--- a/libs/core/src/thread.c
+++ b/libs/core/src/thread.c
@@ -58,7 +58,7 @@ u16                   g_threadCoreCount;
 
 void thread_init(void) {
   /**
-   * Early thread initialization.
+   * Early main-thread initialization.
    * NOTE: Returns before memory allocators have been setup so cannot allocate any memory.
    */
   thread_pal_init();
@@ -71,7 +71,7 @@ void thread_init(void) {
 
 void thread_init_late(void) {
   /**
-   * Late thread initialization.
+   * Late main-thread initialization.
    * NOTE: Memory can now be allocated.
    */
   thread_pal_init_late();
@@ -83,9 +83,17 @@ void thread_teardown(void) { thread_pal_teardown(); }
 
 void thread_init_thread(void) {
   /**
+   * Early thread initialization (not just the main-thread like 'thread_init()').
    * NOTE: Called during early startup so cannot allocate memory.
    */
-  g_threadTid      = thread_pal_tid();
+  g_threadTid = thread_pal_tid();
+}
+
+void thread_init_thread_late(void) {
+  /**
+   * Late thread initialization (not just the main-thread like 'thread_init_late()').
+   * NOTE: Memory can now be allocated.
+   */
   g_threadStackTop = thread_pal_stack_top();
 }
 

--- a/libs/core/src/thread_pal_linux.c
+++ b/libs/core/src/thread_pal_linux.c
@@ -76,20 +76,17 @@ u16 thread_pal_core_count(void) {
 }
 
 uptr thread_pal_stack_top(void) {
-  /**
-   * NOTE: Called during early startup so cannot allocate memory.
-   */
   pthread_attr_t attr;
   if (pthread_getattr_np(pthread_self(), &attr)) {
-    thread_crash_early_init(string_lit("pthread_getattr_np() failed\n"));
+    diag_crash_msg("pthread_getattr_np() failed");
   }
   void*  stackPtr;
   size_t stackSize;
   if (pthread_attr_getstack(&attr, &stackPtr, &stackSize)) {
-    thread_crash_early_init(string_lit("pthread_attr_getstack() failed\n"));
+    diag_crash_msg("pthread_attr_getstack() failed");
   }
   if (pthread_attr_destroy(&attr)) {
-    thread_crash_early_init(string_lit("pthread_attr_destroy() failed\n"));
+    diag_crash_msg("pthread_attr_destroy() failed");
   }
   return (uptr)stackPtr + (uptr)stackSize;
 }

--- a/libs/core/src/thread_pal_win32.c
+++ b/libs/core/src/thread_pal_win32.c
@@ -122,9 +122,6 @@ u16 thread_pal_core_count(void) {
 }
 
 uptr thread_pal_stack_top(void) {
-  /**
-   * NOTE: Called during early startup so cannot allocate memory.
-   */
   ULONG_PTR low, high;
   GetCurrentThreadStackLimits(&low, &high);
   return (uptr)high;


### PR DESCRIPTION
Disabled for now as on Linux we get allot of false positives (or at least leaks we cannot fix from our code) from our leak detection. And on Windows this is not easily supportable AFAIK.