### PR TITLE
assets: Disable anisotrophic filtering on decals

### DIFF
--- a/assets/graphics/vfx/stamp.graphic
+++ b/assets/graphics/vfx/stamp.graphic
@@ -5,8 +5,8 @@
     { "program": "shaders/vfx/stamp.frag" }
   ],
   "samplers": [
-    { "texture": "textures/vfx/stamp_color.atlas", "anisotropy": "x4", "mipBlending": true },
-    { "texture": "textures/vfx/stamp_normal.atlas", "anisotropy": "x4", "mipBlending": true }
+    { "texture": "textures/vfx/stamp_color.atlas", "anisotropy": "None", "mipBlending": true },
+    { "texture": "textures/vfx/stamp_normal.atlas", "anisotropy": "None", "mipBlending": true }
   ],
   "mesh": "meshes/vfx/stamp_box.procmesh",
   "blend": "AlphaConstant",


### PR DESCRIPTION
On AMD hardware this causes ugly visual artifacts at the edges because our gradients are wrong. The real fix would be to compute proper gradients but this is a workaround for now.

For more details on the problem see: https://bartwronski.com/2015/03/12/fixing-screen-space-deferred-decals/