### PR TITLE
rend: Support VK_EXT_calibrated_timestamps

### DIFF
--- a/apps/utilities/vkgen.c
+++ b/apps/utilities/vkgen.c
@@ -90,11 +90,11 @@ static const String g_vkgenLayers[] = {
 };
 
 static const String g_vkgenExtensions[] = {
+    string_static("VK_EXT_calibrated_timestamps"),
     string_static("VK_EXT_debug_utils"),
     string_static("VK_EXT_memory_budget"),
     string_static("VK_EXT_robustness2"),
     string_static("VK_EXT_validation_features"),
-    string_static("VK_KHR_calibrated_timestamps"),
     string_static("VK_KHR_driver_properties"),
     string_static("VK_KHR_maintenance4"),
     string_static("VK_KHR_pipeline_executable_properties"),

--- a/apps/utilities/vkgen.c
+++ b/apps/utilities/vkgen.c
@@ -1468,7 +1468,7 @@ static void vkgen_write_interface_load_def(VkGenContext* ctx, const VkGenInterfa
         fmt_text(varName),
         fmt_text(loadFunc),
         fmt_text(dep),
-        fmt_text(cmd->name));
+        fmt_text(interface->name));
   }
 
   fmt_write(&ctx->out, "  return VK_SUCCESS;\n}\n\n", fmt_text(catName));

--- a/apps/utilities/vkgen.c
+++ b/apps/utilities/vkgen.c
@@ -593,8 +593,7 @@ static void vkgen_collect_enums(VkGenContext* ctx) {
       log_param("entries", fmt_int(ctx->enumEntries.size)));
 }
 
-static void vkgen_collect_enum_extensions(
-    VkGenContext* ctx, const XmlNode node, i64 extNumber, const bool optional) {
+static void vkgen_collect_enum_extensions(VkGenContext* ctx, const XmlNode node, i64 extNumber) {
   xml_for_children(ctx->schemaDoc, node, child) {
     if (xml_name_hash(ctx->schemaDoc, child) != g_hash_require) {
       continue; // Not a require element.
@@ -609,24 +608,11 @@ static void vkgen_collect_enum_extensions(
       if (!enumKey || string_is_empty(name)) {
         continue; // Enum or name missing.
       }
-      const String aliasName = xml_attr_get(ctx->schemaDoc, entry, g_hash_alias);
-      if (!string_is_empty(aliasName)) {
-        VkGenEnumEntries existingEntries = vkgen_enum_entries_find(ctx, enumKey);
-        for (VkGenEnumEntry* itr = existingEntries.begin; itr != existingEntries.end; ++itr) {
-          if (string_eq(itr->name, aliasName)) {
-            itr->optional = false;
-            goto AliasResolved;
-          }
-        }
-        log_w("Unable to resolve enum alias", log_param("name", fmt_text(aliasName)));
-      AliasResolved:
-        continue;
-      }
       const String bitPosStr = xml_attr_get(ctx->schemaDoc, entry, g_hash_bitpos);
       if (!string_is_empty(bitPosStr)) {
         const VkGenEnumEntry entryRes = {
             .key      = enumKey,
-            .optional = optional,
+            .optional = true,
             .name     = name,
             .value    = u64_lit(1) << vkgen_to_int(bitPosStr),
         };
@@ -638,7 +624,7 @@ static void vkgen_collect_enum_extensions(
       if (!string_is_empty(valueStr)) {
         const VkGenEnumEntry entryRes = {
             .key      = enumKey,
-            .optional = optional,
+            .optional = true,
             .name     = name,
             .value    = vkgen_to_int(valueStr) * (invert ? -1 : 1),
         };
@@ -658,13 +644,45 @@ static void vkgen_collect_enum_extensions(
         const i64            value = 1000000000 + (extNumber - 1) * 1000 + vkgen_to_int(offsetStr);
         const VkGenEnumEntry entryRes = {
             .key      = enumKey,
-            .optional = optional,
+            .optional = true,
             .name     = name,
             .value    = value * (invert ? -1 : 1),
         };
         vkgen_enum_entry_push(ctx, entryRes);
         continue;
       }
+    }
+  }
+}
+
+static void vkgen_collect_enum_extensions_required(VkGenContext* ctx, const XmlNode node) {
+  xml_for_children(ctx->schemaDoc, node, child) {
+    if (xml_name_hash(ctx->schemaDoc, child) != g_hash_require) {
+      continue; // Not a require element.
+    }
+    xml_for_children(ctx->schemaDoc, child, entry) {
+      const StringHash entryNameHash = xml_name_hash(ctx->schemaDoc, entry);
+      if (entryNameHash != g_hash_enum) {
+        continue; // Not an enum.
+      }
+      const StringHash enumKey = xml_attr_get_hash(ctx->schemaDoc, entry, g_hash_extends);
+      String           name    = xml_attr_get(ctx->schemaDoc, entry, g_hash_name);
+      if (!enumKey || string_is_empty(name)) {
+        continue; // Enum or name missing.
+      }
+      const String aliasName = xml_attr_get(ctx->schemaDoc, entry, g_hash_alias);
+      if (!string_is_empty(aliasName)) {
+        name = aliasName;
+      }
+      VkGenEnumEntries entries = vkgen_enum_entries_find(ctx, enumKey);
+      for (VkGenEnumEntry* itr = entries.begin; itr != entries.end; ++itr) {
+        if (string_eq(itr->name, name)) {
+          itr->optional = false;
+          goto Resolved;
+        }
+      }
+      log_w("Unable to resolve enum", log_param("name", fmt_text(name)));
+    Resolved:;
     }
   }
 }
@@ -736,13 +754,14 @@ static void vkgen_collect_features(VkGenContext* ctx) {
     if (!vkgen_is_supported_api(ctx, child)) {
       continue; // Not supported.
     }
+    vkgen_collect_enum_extensions(ctx, child, -1);
+
     const StringHash nameHash  = xml_attr_get_hash(ctx->schemaDoc, child, g_hash_name);
     const u32        featIndex = vkgen_feat_find(nameHash);
-    const bool       optional  = sentinel_check(featIndex);
-    if (!optional) {
+    if (!sentinel_check(featIndex)) {
       ctx->featureNodes[featIndex] = child;
+      vkgen_collect_enum_extensions_required(ctx, child);
     }
-    vkgen_collect_enum_extensions(ctx, child, -1, optional);
   }
   log_i("Collected features");
 }
@@ -758,17 +777,18 @@ static void vkgen_collect_extensions(VkGenContext* ctx) {
     if (!vkgen_is_supported(ctx, child)) {
       continue; // Not supported.
     }
-    const StringHash nameHash = xml_attr_get_hash(ctx->schemaDoc, child, g_hash_name);
-    const u32        extIndex = vkgen_ext_find(nameHash);
-    if (sentinel_check(extIndex)) {
-      continue; // Not a required extension.
-    }
     const String numberStr = xml_attr_get(ctx->schemaDoc, child, g_hash_number);
     if (string_is_empty(numberStr)) {
       continue;
     }
-    vkgen_collect_enum_extensions(ctx, child, vkgen_to_int(numberStr), false /* optional */);
-    ctx->extensionNodes[extIndex] = child;
+    vkgen_collect_enum_extensions(ctx, child, vkgen_to_int(numberStr));
+
+    const StringHash nameHash = xml_attr_get_hash(ctx->schemaDoc, child, g_hash_name);
+    const u32        extIndex = vkgen_ext_find(nameHash);
+    if (!sentinel_check(extIndex)) {
+      ctx->extensionNodes[extIndex] = child;
+      vkgen_collect_enum_extensions_required(ctx, child);
+    }
   }
   log_i("Collected extensions");
 }
@@ -1596,7 +1616,7 @@ i32 app_cli_run(const CliApp* app, const CliInvocation* invoc) {
       .constants    = dynarray_create_t(g_allocHeap, VkGenConstant, 64),
       .types        = dynarray_create_t(g_allocHeap, VkGenType, 4096),
       .typesWritten = dynbitset_create(g_allocHeap, 4096),
-      .enumEntries  = dynarray_create_t(g_allocHeap, VkGenEnumEntry, 2048),
+      .enumEntries  = dynarray_create_t(g_allocHeap, VkGenEnumEntry, 4096),
       .commands     = dynarray_create_t(g_allocHeap, VkGenCommand, 1024),
       .interfaces   = dynarray_create_t(g_allocHeap, VkGenInterface, 512),
       .formats      = dynarray_create_t(g_allocHeap, VkGenFormat, 512),

--- a/libs/rend/src/rvk/device.c
+++ b/libs/rend/src/rvk/device.c
@@ -421,9 +421,9 @@ static VkDevice rvk_device_create_internal(RvkLib* lib, RvkDevice* dev) {
     dev->flags |= RvkDeviceFlags_SupportDriverProperties;
     extsToEnable[extsToEnableCount++] = VK_KHR_driver_properties;
   }
-  if (rvk_has_ext(supportedExts, string_lit(VK_KHR_calibrated_timestamps))) {
+  if (rvk_has_ext(supportedExts, string_lit(VK_EXT_calibrated_timestamps))) {
     dev->flags |= RvkDeviceFlags_SupportCalibratedTimestamps;
-    extsToEnable[extsToEnableCount++] = VK_KHR_calibrated_timestamps;
+    extsToEnable[extsToEnableCount++] = VK_EXT_calibrated_timestamps;
   }
 
   const VkDeviceCreateInfo createInfo = {

--- a/libs/rend/src/rvk/stopwatch.c
+++ b/libs/rend/src/rvk/stopwatch.c
@@ -50,7 +50,7 @@ static bool rvk_stopwatch_can_calibrate(RvkStopwatch* sw) {
   u32             supportedDomainCount = array_elems(supportedDomains);
   rvk_call_checked(
       sw->dev->lib,
-      getPhysicalDeviceCalibrateableTimeDomainsKHR,
+      getPhysicalDeviceCalibrateableTimeDomainsEXT,
       sw->dev->vkPhysDev,
       &supportedDomainCount,
       supportedDomains);
@@ -91,7 +91,7 @@ static void rvk_stopwatch_calibrate(RvkStopwatch* sw) {
 Retry:
   rvk_call_checked(
       sw->dev,
-      getCalibratedTimestampsKHR,
+      getCalibratedTimestampsEXT,
       sw->dev->vkDev,
       array_elems(timestamps),
       timestampInfos,

--- a/libs/rend/src/rvk/vulkan_api.c
+++ b/libs/rend/src/rvk/vulkan_api.c
@@ -833,6 +833,7 @@ VkResult vkLoadInstance(VkInstance inst, const VkInterfaceLoader* src, VkInterfa
   out->getPhysicalDeviceExternalBufferProperties = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceExternalBufferProperties");
   out->getPhysicalDeviceExternalFenceProperties = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceExternalFenceProperties");
   out->getPhysicalDeviceExternalSemaphoreProperties = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceExternalSemaphoreProperties");
+  out->getPhysicalDeviceCalibrateableTimeDomainsEXT = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT");
   out->setDebugUtilsObjectNameEXT = (Symbol)src->getInstanceProcAddr(inst, "vkSetDebugUtilsObjectNameEXT");
   out->setDebugUtilsObjectTagEXT = (Symbol)src->getInstanceProcAddr(inst, "vkSetDebugUtilsObjectTagEXT");
   out->queueBeginDebugUtilsLabelEXT = (Symbol)src->getInstanceProcAddr(inst, "vkQueueBeginDebugUtilsLabelEXT");
@@ -844,7 +845,6 @@ VkResult vkLoadInstance(VkInstance inst, const VkInterfaceLoader* src, VkInterfa
   out->createDebugUtilsMessengerEXT = (Symbol)src->getInstanceProcAddr(inst, "vkCreateDebugUtilsMessengerEXT");
   out->destroyDebugUtilsMessengerEXT = (Symbol)src->getInstanceProcAddr(inst, "vkDestroyDebugUtilsMessengerEXT");
   out->submitDebugUtilsMessageEXT = (Symbol)src->getInstanceProcAddr(inst, "vkSubmitDebugUtilsMessageEXT");
-  out->getPhysicalDeviceCalibrateableTimeDomainsEXT = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceCalibrateableTimeDomainsKHR");
   out->destroySurfaceKHR = (Symbol)src->getInstanceProcAddr(inst, "vkDestroySurfaceKHR");
   out->getPhysicalDeviceSurfaceSupportKHR = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceSurfaceSupportKHR");
   out->getPhysicalDeviceSurfaceCapabilitiesKHR = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
@@ -995,10 +995,10 @@ VkResult vkLoadDevice(VkDevice dev, const VkInterfaceInstance* src, VkInterfaceD
   out->destroyDescriptorUpdateTemplate = (Symbol)src->getDeviceProcAddr(dev, "vkDestroyDescriptorUpdateTemplate");
   out->updateDescriptorSetWithTemplate = (Symbol)src->getDeviceProcAddr(dev, "vkUpdateDescriptorSetWithTemplate");
   out->getDescriptorSetLayoutSupport = (Symbol)src->getDeviceProcAddr(dev, "vkGetDescriptorSetLayoutSupport");
-  out->getCalibratedTimestampsEXT = (Symbol)src->getDeviceProcAddr(dev, "vkGetCalibratedTimestampsKHR");
-  out->getDeviceBufferMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceBufferMemoryRequirements");
-  out->getDeviceImageMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageMemoryRequirements");
-  out->getDeviceImageSparseMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageSparseMemoryRequirements");
+  out->getCalibratedTimestampsEXT = (Symbol)src->getDeviceProcAddr(dev, "vkGetCalibratedTimestampsEXT");
+  out->getDeviceBufferMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceBufferMemoryRequirementsKHR");
+  out->getDeviceImageMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageMemoryRequirementsKHR");
+  out->getDeviceImageSparseMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageSparseMemoryRequirementsKHR");
   out->getPipelineExecutablePropertiesKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetPipelineExecutablePropertiesKHR");
   out->getPipelineExecutableStatisticsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetPipelineExecutableStatisticsKHR");
   out->getPipelineExecutableInternalRepresentationsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetPipelineExecutableInternalRepresentationsKHR");

--- a/libs/rend/src/rvk/vulkan_api.c
+++ b/libs/rend/src/rvk/vulkan_api.c
@@ -844,7 +844,7 @@ VkResult vkLoadInstance(VkInstance inst, const VkInterfaceLoader* src, VkInterfa
   out->createDebugUtilsMessengerEXT = (Symbol)src->getInstanceProcAddr(inst, "vkCreateDebugUtilsMessengerEXT");
   out->destroyDebugUtilsMessengerEXT = (Symbol)src->getInstanceProcAddr(inst, "vkDestroyDebugUtilsMessengerEXT");
   out->submitDebugUtilsMessageEXT = (Symbol)src->getInstanceProcAddr(inst, "vkSubmitDebugUtilsMessageEXT");
-  out->getPhysicalDeviceCalibrateableTimeDomainsKHR = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceCalibrateableTimeDomainsKHR");
+  out->getPhysicalDeviceCalibrateableTimeDomainsEXT = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceCalibrateableTimeDomainsKHR");
   out->destroySurfaceKHR = (Symbol)src->getInstanceProcAddr(inst, "vkDestroySurfaceKHR");
   out->getPhysicalDeviceSurfaceSupportKHR = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceSurfaceSupportKHR");
   out->getPhysicalDeviceSurfaceCapabilitiesKHR = (Symbol)src->getInstanceProcAddr(inst, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
@@ -995,7 +995,7 @@ VkResult vkLoadDevice(VkDevice dev, const VkInterfaceInstance* src, VkInterfaceD
   out->destroyDescriptorUpdateTemplate = (Symbol)src->getDeviceProcAddr(dev, "vkDestroyDescriptorUpdateTemplate");
   out->updateDescriptorSetWithTemplate = (Symbol)src->getDeviceProcAddr(dev, "vkUpdateDescriptorSetWithTemplate");
   out->getDescriptorSetLayoutSupport = (Symbol)src->getDeviceProcAddr(dev, "vkGetDescriptorSetLayoutSupport");
-  out->getCalibratedTimestampsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetCalibratedTimestampsKHR");
+  out->getCalibratedTimestampsEXT = (Symbol)src->getDeviceProcAddr(dev, "vkGetCalibratedTimestampsKHR");
   out->getDeviceBufferMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceBufferMemoryRequirements");
   out->getDeviceImageMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageMemoryRequirements");
   out->getDeviceImageSparseMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageSparseMemoryRequirements");

--- a/libs/rend/src/rvk/vulkan_api.c
+++ b/libs/rend/src/rvk/vulkan_api.c
@@ -996,9 +996,9 @@ VkResult vkLoadDevice(VkDevice dev, const VkInterfaceInstance* src, VkInterfaceD
   out->updateDescriptorSetWithTemplate = (Symbol)src->getDeviceProcAddr(dev, "vkUpdateDescriptorSetWithTemplate");
   out->getDescriptorSetLayoutSupport = (Symbol)src->getDeviceProcAddr(dev, "vkGetDescriptorSetLayoutSupport");
   out->getCalibratedTimestampsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetCalibratedTimestampsKHR");
-  out->getDeviceBufferMemoryRequirements = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceBufferMemoryRequirements");
-  out->getDeviceImageMemoryRequirements = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageMemoryRequirements");
-  out->getDeviceImageSparseMemoryRequirements = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageSparseMemoryRequirements");
+  out->getDeviceBufferMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceBufferMemoryRequirements");
+  out->getDeviceImageMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageMemoryRequirements");
+  out->getDeviceImageSparseMemoryRequirementsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetDeviceImageSparseMemoryRequirements");
   out->getPipelineExecutablePropertiesKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetPipelineExecutablePropertiesKHR");
   out->getPipelineExecutableStatisticsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetPipelineExecutableStatisticsKHR");
   out->getPipelineExecutableInternalRepresentationsKHR = (Symbol)src->getDeviceProcAddr(dev, "vkGetPipelineExecutableInternalRepresentationsKHR");

--- a/libs/rend/src/rvk/vulkan_api.h
+++ b/libs/rend/src/rvk/vulkan_api.h
@@ -3604,9 +3604,9 @@ typedef struct VkInterfaceDevice {
   void (SYS_DECL* updateDescriptorSetWithTemplate)(VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData);
   void (SYS_DECL* getDescriptorSetLayoutSupport)(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo, VkDescriptorSetLayoutSupport* pSupport);
   VkResult (SYS_DECL* getCalibratedTimestampsKHR)(VkDevice device, u32 timestampCount, const VkCalibratedTimestampInfoKHR* pTimestampInfos, u64* pTimestamps, u64* pMaxDeviation);
-  void (SYS_DECL* getDeviceBufferMemoryRequirements)(VkDevice device, const VkDeviceBufferMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements);
-  void (SYS_DECL* getDeviceImageMemoryRequirements)(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements);
-  void (SYS_DECL* getDeviceImageSparseMemoryRequirements)(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, u32* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2* pSparseMemoryRequirements);
+  void (SYS_DECL* getDeviceBufferMemoryRequirementsKHR)(VkDevice device, const VkDeviceBufferMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements);
+  void (SYS_DECL* getDeviceImageMemoryRequirementsKHR)(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements);
+  void (SYS_DECL* getDeviceImageSparseMemoryRequirementsKHR)(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, u32* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2* pSparseMemoryRequirements);
   VkResult (SYS_DECL* getPipelineExecutablePropertiesKHR)(VkDevice device, const VkPipelineInfoKHR* pPipelineInfo, u32* pExecutableCount, VkPipelineExecutablePropertiesKHR* pProperties);
   VkResult (SYS_DECL* getPipelineExecutableStatisticsKHR)(VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo, u32* pStatisticCount, VkPipelineExecutableStatisticKHR* pStatistics);
   VkResult (SYS_DECL* getPipelineExecutableInternalRepresentationsKHR)(VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo, u32* pInternalRepresentationCount, VkPipelineExecutableInternalRepresentationKHR* pInternalRepresentations);

--- a/libs/rend/src/rvk/vulkan_api.h
+++ b/libs/rend/src/rvk/vulkan_api.h
@@ -37,11 +37,11 @@
 
 #define VK_LAYER_KHRONOS_validation "VK_LAYER_KHRONOS_validation"
 
+#define VK_EXT_calibrated_timestamps "VK_EXT_calibrated_timestamps"
 #define VK_EXT_debug_utils "VK_EXT_debug_utils"
 #define VK_EXT_memory_budget "VK_EXT_memory_budget"
 #define VK_EXT_robustness2 "VK_EXT_robustness2"
 #define VK_EXT_validation_features "VK_EXT_validation_features"
-#define VK_EXT_calibrated_timestamps "VK_EXT_calibrated_timestamps"
 #define VK_KHR_driver_properties "VK_KHR_driver_properties"
 #define VK_KHR_maintenance4 "VK_KHR_maintenance4"
 #define VK_KHR_pipeline_executable_properties "VK_KHR_pipeline_executable_properties"
@@ -2939,6 +2939,19 @@ typedef struct VkPhysicalDeviceShaderDrawParametersFeatures {
 } VkPhysicalDeviceShaderDrawParametersFeatures;
 
 typedef enum {
+  VK_TIME_DOMAIN_DEVICE_KHR = 0,
+  VK_TIME_DOMAIN_CLOCK_MONOTONIC_KHR = 1,
+  VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_KHR = 2,
+  VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR = 3,
+} VkTimeDomainKHR;
+
+typedef struct VkCalibratedTimestampInfoKHR {
+  VkStructureType sType;
+  const void* pNext;
+  VkTimeDomainKHR timeDomain;
+} VkCalibratedTimestampInfoKHR;
+
+typedef enum {
   VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT = 1,
   VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT = 16,
   VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT = 256,
@@ -3062,19 +3075,6 @@ typedef struct VkValidationFeaturesEXT {
   u32 disabledValidationFeatureCount;
   const VkValidationFeatureDisableEXT* pDisabledValidationFeatures;
 } VkValidationFeaturesEXT;
-
-typedef enum {
-  VK_TIME_DOMAIN_DEVICE_KHR = 0,
-  VK_TIME_DOMAIN_CLOCK_MONOTONIC_KHR = 1,
-  VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_KHR = 2,
-  VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR = 3,
-} VkTimeDomainKHR;
-
-typedef struct VkCalibratedTimestampInfoKHR {
-  VkStructureType sType;
-  const void* pNext;
-  VkTimeDomainKHR timeDomain;
-} VkCalibratedTimestampInfoKHR;
 
 typedef enum {
   VK_DRIVER_ID_AMD_PROPRIETARY = 1,
@@ -3440,6 +3440,7 @@ typedef struct VkInterfaceInstance {
   void (SYS_DECL* getPhysicalDeviceExternalBufferProperties)(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalBufferInfo* pExternalBufferInfo, VkExternalBufferProperties* pExternalBufferProperties);
   void (SYS_DECL* getPhysicalDeviceExternalFenceProperties)(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalFenceInfo* pExternalFenceInfo, VkExternalFenceProperties* pExternalFenceProperties);
   void (SYS_DECL* getPhysicalDeviceExternalSemaphoreProperties)(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo, VkExternalSemaphoreProperties* pExternalSemaphoreProperties);
+  VkResult (SYS_DECL* getPhysicalDeviceCalibrateableTimeDomainsEXT)(VkPhysicalDevice physicalDevice, u32* pTimeDomainCount, VkTimeDomainKHR* pTimeDomains);
   VkResult (SYS_DECL* setDebugUtilsObjectNameEXT)(VkDevice device, const VkDebugUtilsObjectNameInfoEXT* pNameInfo);
   VkResult (SYS_DECL* setDebugUtilsObjectTagEXT)(VkDevice device, const VkDebugUtilsObjectTagInfoEXT* pTagInfo);
   void (SYS_DECL* queueBeginDebugUtilsLabelEXT)(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo);
@@ -3451,7 +3452,6 @@ typedef struct VkInterfaceInstance {
   VkResult (SYS_DECL* createDebugUtilsMessengerEXT)(VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pMessenger);
   void (SYS_DECL* destroyDebugUtilsMessengerEXT)(VkInstance instance, VkDebugUtilsMessengerEXT messenger, const VkAllocationCallbacks* pAllocator);
   void (SYS_DECL* submitDebugUtilsMessageEXT)(VkInstance instance, VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData);
-  VkResult (SYS_DECL* getPhysicalDeviceCalibrateableTimeDomainsEXT)(VkPhysicalDevice physicalDevice, u32* pTimeDomainCount, VkTimeDomainKHR* pTimeDomains);
   void (SYS_DECL* destroySurfaceKHR)(VkInstance instance, VkSurfaceKHR surface, const VkAllocationCallbacks* pAllocator);
   VkResult (SYS_DECL* getPhysicalDeviceSurfaceSupportKHR)(VkPhysicalDevice physicalDevice, u32 queueFamilyIndex, VkSurfaceKHR surface, VkBool32* pSupported);
   VkResult (SYS_DECL* getPhysicalDeviceSurfaceCapabilitiesKHR)(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR* pSurfaceCapabilities);

--- a/libs/rend/src/rvk/vulkan_api.h
+++ b/libs/rend/src/rvk/vulkan_api.h
@@ -41,7 +41,7 @@
 #define VK_EXT_memory_budget "VK_EXT_memory_budget"
 #define VK_EXT_robustness2 "VK_EXT_robustness2"
 #define VK_EXT_validation_features "VK_EXT_validation_features"
-#define VK_KHR_calibrated_timestamps "VK_KHR_calibrated_timestamps"
+#define VK_EXT_calibrated_timestamps "VK_EXT_calibrated_timestamps"
 #define VK_KHR_driver_properties "VK_KHR_driver_properties"
 #define VK_KHR_maintenance4 "VK_KHR_maintenance4"
 #define VK_KHR_pipeline_executable_properties "VK_KHR_pipeline_executable_properties"
@@ -3451,7 +3451,7 @@ typedef struct VkInterfaceInstance {
   VkResult (SYS_DECL* createDebugUtilsMessengerEXT)(VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pMessenger);
   void (SYS_DECL* destroyDebugUtilsMessengerEXT)(VkInstance instance, VkDebugUtilsMessengerEXT messenger, const VkAllocationCallbacks* pAllocator);
   void (SYS_DECL* submitDebugUtilsMessageEXT)(VkInstance instance, VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData);
-  VkResult (SYS_DECL* getPhysicalDeviceCalibrateableTimeDomainsKHR)(VkPhysicalDevice physicalDevice, u32* pTimeDomainCount, VkTimeDomainKHR* pTimeDomains);
+  VkResult (SYS_DECL* getPhysicalDeviceCalibrateableTimeDomainsEXT)(VkPhysicalDevice physicalDevice, u32* pTimeDomainCount, VkTimeDomainKHR* pTimeDomains);
   void (SYS_DECL* destroySurfaceKHR)(VkInstance instance, VkSurfaceKHR surface, const VkAllocationCallbacks* pAllocator);
   VkResult (SYS_DECL* getPhysicalDeviceSurfaceSupportKHR)(VkPhysicalDevice physicalDevice, u32 queueFamilyIndex, VkSurfaceKHR surface, VkBool32* pSupported);
   VkResult (SYS_DECL* getPhysicalDeviceSurfaceCapabilitiesKHR)(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR* pSurfaceCapabilities);
@@ -3603,7 +3603,7 @@ typedef struct VkInterfaceDevice {
   void (SYS_DECL* destroyDescriptorUpdateTemplate)(VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator);
   void (SYS_DECL* updateDescriptorSetWithTemplate)(VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData);
   void (SYS_DECL* getDescriptorSetLayoutSupport)(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo, VkDescriptorSetLayoutSupport* pSupport);
-  VkResult (SYS_DECL* getCalibratedTimestampsKHR)(VkDevice device, u32 timestampCount, const VkCalibratedTimestampInfoKHR* pTimestampInfos, u64* pTimestamps, u64* pMaxDeviation);
+  VkResult (SYS_DECL* getCalibratedTimestampsEXT)(VkDevice device, u32 timestampCount, const VkCalibratedTimestampInfoKHR* pTimestampInfos, u64* pTimestamps, u64* pMaxDeviation);
   void (SYS_DECL* getDeviceBufferMemoryRequirementsKHR)(VkDevice device, const VkDeviceBufferMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements);
   void (SYS_DECL* getDeviceImageMemoryRequirementsKHR)(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements);
   void (SYS_DECL* getDeviceImageSparseMemoryRequirementsKHR)(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, u32* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2* pSparseMemoryRequirements);


### PR DESCRIPTION
Has wider spread support then VK_KHR_calibrated_timestamps.