### PR TITLE
blob2j: Support partial reads

### DIFF
--- a/apps/utilities/blob2j.c
+++ b/apps/utilities/blob2j.c
@@ -57,10 +57,16 @@ static i32 blob2j_run(const Blob2jConfig* cfg, File* inputFile, File* outputFile
         goto Ret;
       }
     }
-  } else if (file_read_to_end_sync(inputFile, &buffer)) {
-    file_write_sync(g_fileStdErr, string_lit("ERROR: Failed to read input.\n"));
-    exitCode = 1;
-    goto Ret;
+  } else {
+    /**
+     * NOTE: Old versions of the blob format did not store the size, to support them we read the
+     * whole file.
+     */
+    if (file_read_to_end_sync(inputFile, &buffer)) {
+      file_write_sync(g_fileStdErr, string_lit("ERROR: Failed to read input.\n"));
+      exitCode = 1;
+      goto Ret;
+    }
   }
 
   const DataMeta dataMeta = {

--- a/libs/asset/src/cache.c
+++ b/libs/asset/src/cache.c
@@ -5,6 +5,7 @@
 #include "core_file.h"
 #include "core_math.h"
 #include "core_path.h"
+#include "core_stringtable.h"
 #include "core_thread.h"
 #include "data_read.h"
 #include "data_utils.h"
@@ -199,7 +200,7 @@ static AssetCacheEntry* cache_reg_add(AssetCache* c, const String id, const Stri
   } else {
     // New entry.
     *res = (AssetCacheEntry){
-        .id     = string_dup(c->alloc, id),
+        .id     = stringtable_intern(g_stringtable, id),
         .idHash = idHash,
     };
   }
@@ -388,7 +389,7 @@ void asset_cache_set(
     for (usize i = 0; i != depCount; ++i) {
       diag_assert(!string_is_empty(deps[i].id));
       cacheDependencies[i] = (AssetCacheDependency){
-          .id         = string_dup(c->alloc, deps[i].id),
+          .id         = stringtable_intern(g_stringtable, deps[i].id),
           .modTime    = deps[i].modTime,
           .loaderHash = deps[i].loaderHash,
       };
@@ -480,7 +481,7 @@ usize asset_cache_deps(
       result = math_min(entry->dependencies.count, asset_repo_cache_deps_max);
       for (usize i = 0; i != result; ++i) {
         out[i] = (AssetRepoDep){
-            .id         = string_dup(g_allocScratch, entry->dependencies.values[i].id),
+            .id         = entry->dependencies.values[i].id,
             .modTime    = entry->dependencies.values[i].modTime,
             .loaderHash = entry->dependencies.values[i].loaderHash,
         };

--- a/libs/asset/src/cache_internal.h
+++ b/libs/asset/src/cache_internal.h
@@ -43,7 +43,6 @@ bool asset_cache_get(AssetCache*, String id, AssetRepoLoaderHasher, AssetCacheRe
 /**
  * Lookup cache dependencies for the given id.
  * Returns the amount of dependencies written to the out pointer.
- * NOTE: Dependency ids are allocated in scratch memory; should not be stored.
  */
 usize asset_cache_deps(
     AssetCache*, String id, AssetRepoDep out[PARAM_ARRAY_SIZE(asset_repo_cache_deps_max)]);


### PR DESCRIPTION
Avoids reading the whole file if the blob only occupies a sub-section (for example assets.blob).